### PR TITLE
Fix final blockers for v0.1.0 release

### DIFF
--- a/src/XcaNet.Application/Services/DatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/DatabaseSessionService.cs
@@ -907,10 +907,10 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var appVersion = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
-            ?? Assembly.GetEntryAssembly()?.GetName().Version?.ToString()
-            ?? typeof(DatabaseSessionService).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        var appVersion = NormalizeVersion(typeof(DatabaseSessionService).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion)
             ?? typeof(DatabaseSessionService).Assembly.GetName().Version?.ToString()
+            ?? NormalizeVersion(Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion)
+            ?? Assembly.GetEntryAssembly()?.GetName().Version?.ToString()
             ?? "0.0.0";
 
         return Task.FromResult(
@@ -922,6 +922,9 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
                     _state),
                 "Application diagnostics loaded."));
     }
+
+    private static string? NormalizeVersion(string? version)
+        => string.IsNullOrWhiteSpace(version) ? null : version.Split('+', 2)[0];
 
     public async Task<OperationResult<CertificateDetails>> GetCertificateDetailsAsync(Guid certificateId, CancellationToken cancellationToken)
     {

--- a/src/XcaNet.Crypto.DotNet/DotNetCryptoBackend.cs
+++ b/src/XcaNet.Crypto.DotNet/DotNetCryptoBackend.cs
@@ -207,7 +207,7 @@ public sealed class DotNetCryptoBackend : IKeyService, ICertificateService, ICer
                 ParseCertificateRevocationList(request.Data, request.Format),
                 "Certificate revocation list parsed."));
         }
-        catch (CryptographicException)
+        catch (Exception ex) when (ex is CryptographicException or AsnContentException)
         {
             return Task.FromResult(OperationResult<CertificateRevocationListDetails>.Failure(OperationErrorCode.ValidationFailed, "Invalid certificate revocation list data."));
         }


### PR DESCRIPTION
## Summary

This fixes the final two release-blocking integration failures for v0.1.0.

- Diagnostics version reporting now prefers the XcaNet application assembly and normalizes informational versions so runtime diagnostics report 0.1.0 instead of test-host or CI metadata values.
- Managed CRL parsing now converts ASN.1 parsing failures into the existing validation-failure result path, so malformed DER imports fail cleanly with the expected user-facing error.

## Validation

Ran successfully:
- dotnet build XcaNet.sln
- dotnet test XcaNet.sln --no-build
- dotnet build XcaNet.sln -c Release
- dotnet test XcaNet.sln -c Release --no-build

Result:
- zero failing tests in both Debug and Release validation
- build and release test suite fully pass for v0.1.0