### PR TITLE
Add XCA screen parity inventory

### DIFF
--- a/docs/parity/xca-screen-inventory.md
+++ b/docs/parity/xca-screen-inventory.md
@@ -1,0 +1,1391 @@
+# XCA Screen Parity Inventory
+
+**Status**: Active reference document — updated per milestone  
+**Source of truth**: XCA 2.9.0 (https://github.com/chris2511/xca)  
+**Rule**: A screen is not parity-complete until its visible buttons, columns, tabs, dialogs,
+and workflows match XCA or have an explicitly documented intentional deviation recorded here.
+
+---
+
+## How to Use This Document
+
+Each section covers one XCA screen area. For each:
+
+- **XCA reference** — what the real XCA screen contains (exact labels, columns, buttons)
+- **XcaNet current** — what exists today in XcaNet
+- **Gaps** — checklist of missing or wrong items
+- **Intentional deviations** — explicit exceptions approved by the project (if any)
+- **Priority** — milestone where this screen reaches parity
+
+Do not remove a gap item unless the corresponding UI element is implemented and visually
+confirmed to match XCA. Do not mark a screen parity-complete unless all gaps are resolved
+or moved to Intentional Deviations with a written justification.
+
+---
+
+## 1. Main Window Shell
+
+### XCA Reference
+
+**Window layout:**
+- Menu bar (File | Import | Token | Extra | Help)
+- Central area: tab widget with 5 object tabs
+- Status bar (bottom)
+- Default size: 702 × 511 px (resizable)
+
+**Menu bar — File menu:**
+- New DataBase
+- Open DataBase
+- Open Remote DataBase
+- (Recent databases — dynamic list)
+- Set default database
+- Close DataBase
+- Options
+- Language Selection (submenu)
+- Exit
+
+**Menu bar — Import menu:**
+- Keys
+- Requests
+- Certificates
+- PKCS#12
+- PKCS#7
+- Template
+- Revocation list
+- PEM files (also paste from clipboard)
+
+**Menu bar — Token menu:**
+- Manage Security token
+- Init Security token
+- Change PIN
+- Change SO PIN
+- Init PIN
+
+**Menu bar — Extra menu:**
+- Database dump
+- Certificate index export
+- Hierarchy export
+- Password change
+- DH parameter generation
+- OID Resolver
+
+**Menu bar — Help menu:**
+- Documentation
+- About
+
+**Tab bar:**
+- Tab 1: Private Keys
+- Tab 2: Certificate Signing Requests
+- Tab 3: Certificates (default active)
+- Tab 4: Templates
+- Tab 5: Revocation Lists
+
+**Status bar:**
+- Shows operational status messages
+
+**Toolbar:**
+- Not present in base XCA (menu-driven)
+
+### XcaNet Current
+
+File: `src/XcaNet.App/Views/MainWindow.axaml`
+
+- Menu bar present: File | Token | Help
+- Object tab bar present: 5 tabs (Private Keys, Certificate Signing Requests, Certificates,
+  Templates, Revocation Lists)
+- Bottom status bar present with search field
+- Content fills edge-to-edge below tab bar
+- Authoring dialog rendered as overlay on top of main window
+
+### Gaps
+
+**Menus:**
+- [ ] `Import` menu missing entirely (Keys, Requests, Certificates, PKCS#12, PKCS#7,
+      Template, Revocation list, PEM files / clipboard)
+- [ ] `Extra` menu missing (Database dump, Certificate index export, Hierarchy export,
+      Password change, DH parameter generation, OID Resolver)
+- [ ] `File → Open Remote DataBase` missing
+- [ ] `File → Set default database` missing
+- [ ] `File → Close DataBase` missing
+- [ ] `File → Options` missing (links to Options/Preferences dialog)
+- [ ] `File → Language Selection` missing (low priority, intentional deviation candidate)
+- [ ] `Help → Documentation` missing
+- [ ] `Help → About` missing
+- [ ] `Token → Manage Security token` missing
+- [ ] `Token → Init Security token` missing
+- [ ] `Token → Change PIN` missing
+- [ ] `Token → Change SO PIN` missing
+- [ ] `Token → Init PIN` missing
+
+**Shell behavior:**
+- [ ] No "Recent databases" list in File menu
+- [ ] Search field is in the bottom status bar — XCA has per-tab filter bars (acceptable
+      deviation if documented)
+
+### Intentional Deviations
+
+None declared yet.
+
+### Priority
+
+M13.4 (shell menus), M15 (Token menu, remote database, language)
+
+---
+
+## 2. Private Keys Tab
+
+### XCA Reference
+
+**Tab layout:**
+- Left panel: tree view of private keys
+- Right panel: vertical button stack
+- Bottom: 200 × 94 px preview label (key info / icon)
+
+**Right-side buttons (top to bottom):**
+1. New
+2. Export
+3. Import
+4. Show Details
+5. Delete
+
+**Tree view columns (default):**
+- Name (internal database name)
+- Algorithm (RSA, DSA, EC, etc.)
+- Bit length / Curve
+- Use (count of related objects referencing this key)
+- Token (security token indicator)
+
+**Context menu (right-click on key):**
+- Import
+- Export → Clipboard (Ctrl+C) / File (Ctrl+S)
+- Rename
+- Properties (opens ItemProperties dialog)
+- Delete
+- Change password (if common password protection)
+- Reset password (if private password protection)
+- Set own password
+- Reset own password
+- Security token → Change PIN / Init PIN / Change SO PIN / Export to token
+
+**Double-click:** Opens Show Details (KeyDetail dialog)
+
+**New Key dialog (NewKey.ui):**
+- Field: Key Name (default "New Key")
+- Dropdown: Key Type (RSA / DSA / EC)
+- Dropdown: Key Size (conditional on type)
+- Dropdown: Curve Name (conditional on EC type)
+- Checkbox: "Remember as default"
+- Buttons: OK / Cancel
+
+**Key Detail dialog (KeyDetail.ui) — tabs:**
+1. Key — public exponent, key size, private exponent (clickable), modulus
+2. Security Token — label, PKCS#11 ID, model, manufacturer, serial, label
+3. Fingerprint
+4. Comment — plain text editor
+
+### XcaNet Current
+
+File: `src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml`
+
+**Table columns:** DisplayName, Algorithm, SizeOrCurve, CreatedUtc, RelatedObjectSummary
+
+**Right-side buttons:**
+- New Key (→ GenerateKeyCommand)
+- Export (→ ExportSelectedToFileCommand)
+- Import (disabled)
+- Show Details (disabled)
+- Delete (disabled)
+- Create CSR (→ OpenCertificateSigningRequestAuthoringCommand)
+- Create Certificate (→ OpenSelfSignedCaAuthoringCommand)
+- Preview Export (→ ExportSelectedCommand)
+- Refresh (→ RefreshCommand)
+
+**Inspector panel (bottom):**
+- Tabs: Details, New Key, Export
+- Details tab: Name, Algorithm, Fingerprint, Created (label/value rows)
+- New Key tab: inline name + algorithm + curve + Generate button
+- Export tab: format combo, password, PEM preview text box
+
+### Gaps
+
+**Columns:**
+- [ ] `Use` column missing (count of certificates/requests referencing this key)
+- [ ] `Token` column missing (security token indicator)
+- [ ] Column header context menu missing (show/hide, reorder, auto-fit)
+- [ ] `Name` in XCA is the "internal database name" — should match XCA semantics
+
+**Buttons / button order:**
+- [ ] Button labels and order differ from XCA:
+  - XCA: New, Export, Import, Show Details, Delete
+  - XcaNet: New Key, Export, Import (disabled), Show Details (disabled), Delete (disabled),
+    Create CSR, Create Certificate, Preview Export, Refresh
+  - Correct order should match XCA (New, Export, Import, Show Details, Delete) followed by
+    key-specific extra actions
+- [ ] "New Key" should be labeled "New" (matching XCA convention)
+
+**New Key dialog:**
+- [ ] Currently inline in inspector "New Key" tab — XCA launches a separate modal dialog
+- [ ] Missing "Key Type" dropdown (XCA: RSA / DSA / EC)
+- [ ] Missing "Remember as default" checkbox
+
+**Key Detail dialog:**
+- [ ] No standalone Key Detail modal (XCA: KeyDetail.ui with 4 tabs)
+- [ ] "Show Details" button disabled — must open a detail dialog
+- [ ] Missing tabs: Key (modulus, exponent), Security Token, Fingerprint, Comment
+- [ ] `Delete` button disabled — must implement delete with confirmation
+
+**Context menus:**
+- [ ] No right-click context menu on key rows at all
+- [ ] Missing: Rename, Properties, Delete from context menu
+- [ ] Missing: Password operations (Change, Set own, Reset own)
+- [ ] Missing: Security token submenu
+
+**Bottom preview panel:**
+- [ ] XCA has a 200 × 94 px preview/icon area at bottom of button stack
+- [ ] XcaNet has no equivalent — low priority intentional deviation candidate
+
+**Import:**
+- [ ] Import button disabled — must implement key import (PEM/DER/PKCS#12)
+
+### Intentional Deviations
+
+None declared yet.
+
+### Priority
+
+M13.5 (columns, button order, New Key dialog, Show Details, Delete), M15 (context menus,
+password ops, security token)
+
+---
+
+## 3. Certificate Signing Requests Tab
+
+### XCA Reference
+
+**Tab layout:**
+- Left panel: tree view of CSRs
+- Right panel: vertical button stack
+- Bottom: preview label
+
+**Right-side buttons:**
+1. New
+2. Export
+3. Import
+4. Show Details
+5. Delete
+
+**Tree view columns (default):**
+- Name (internal)
+- Subject (DN string)
+- Private key (linked key name)
+- Signed (yes/no indicator)
+- Algorithm
+
+**Context menu (right-click on CSR):**
+- Import / Export → Clipboard / File
+- Rename
+- Properties
+- Delete
+- Sign (→ opens NewX509 dialog in signing mode)
+- Mark signed / Unmark signed
+- Similar Request (→ creates a new CSR based on selected)
+
+**Double-click:** Opens Show Details (CSR detail view via NewX509 in read mode)
+
+**New Request workflow:**
+- "New" button opens NewX509 dialog in request-creation mode
+- Tabs: Source, Subject, Extensions, Key Usage, Netscape, Advanced, Comment
+
+### XcaNet Current
+
+File: `src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml`
+
+**Table columns:** DisplayName, Subject, PrivateKeySummary, CreatedUtc, KeyAlgorithm
+
+**Right-side buttons:**
+- New Request (disabled)
+- Sign (→ OpenIssuanceAuthoringCommand)
+- Export (→ ExportSelectedToFileCommand)
+- Import (disabled)
+- Show Details (disabled)
+- Delete (disabled)
+- Similar Request (→ CreateSimilarRequestCommand)
+- To Template (→ CreateTemplateFromRequestCommand)
+- Open Key (→ OpenSelectedPrivateKeyCommand)
+- Refresh (→ RefreshCommand)
+
+**Inspector panel (bottom):**
+- Tabs: Details, Export
+- Details: Name, Subject, Alternative names, Algorithm
+- Export: format combo, preview text box
+
+### Gaps
+
+**Columns:**
+- [ ] `Signed` column missing (shows whether CSR has been signed into a certificate)
+- [ ] Column header context menu missing
+
+**Buttons:**
+- [ ] "New Request" disabled — must implement CSR creation via NewX509 dialog
+- [ ] "New" label should match XCA ("New" not "New Request")
+- [ ] Import disabled — must implement PKCS#10 import
+- [ ] Show Details disabled — must open detail view (read-only NewX509 tabs or equivalent)
+- [ ] Delete disabled — must implement with confirmation
+
+**Context menus:**
+- [ ] No right-click context menu on rows
+- [ ] Missing: Sign, Mark signed / Unmark signed, Similar Request, Rename, Properties,
+      Delete from context menu
+
+**Sign workflow:**
+- [ ] "Sign" button opens CertificateAuthoringSurfaceView overlay — acceptable, but the
+      NewX509 Source tab must clearly identify the CSR being signed
+
+**Detail view:**
+- [ ] No standalone CSR detail dialog — Show Details disabled
+- [ ] XCA shows CSR content in NewX509 dialog in read mode (or separate view)
+
+### Intentional Deviations
+
+None declared yet.
+
+### Priority
+
+M13.5 (columns, New Request, Show Details, Delete, context menu basics), M14 (Sign
+workflow completeness)
+
+---
+
+## 4. Certificates Tab
+
+### XCA Reference
+
+**Tab layout:**
+- Left panel: hierarchical tree view (chains are grouped)
+- Right panel: vertical button stack
+- Bottom: preview label
+
+**Right-side buttons:**
+1. New
+2. Export
+3. Import
+4. Show Details
+5. Delete
+6. Import PKCS#12
+7. Import PKCS#7
+8. Plain View (toggle — switches between tree/flat view)
+
+**Tree view columns (default, in hierarchy/tree mode):**
+- Name (internal)
+- Common Name
+- Status (trust / expiry / revocation indicator — color coded)
+- Not Before
+- Not After
+- Serial number
+- Fingerprint (MD5 or SHA1)
+
+**Hierarchy display:**
+- Certificates are grouped under their signing CA
+- Root CAs at top level
+- Issued certificates indented under issuer
+- "Plain View" toggle switches to flat list
+
+**Context menu (right-click on certificate):**
+- Import / Export → Clipboard / File
+- Rename
+- Properties
+- Delete
+- Convert to request
+- Export to token
+- Create similar certificate
+- Generate CRL (if CA certificate)
+- Manage revocations (if CA certificate)
+- CA Properties (if CA certificate)
+- Certificate renewal
+- Revoke
+- Unrevoke
+
+**Double-click:** Opens Certificate Detail dialog (CertDetail.ui)
+
+**Certificate Detail dialog (CertDetail.ui) — 6 tabs:**
+1. Status — name, signature algorithm, key reference, serial, MD5/SHA1/SHA256 fingerprints,
+   Not before, Not after
+2. Subject — distinguished name components with OID tooltips
+3. Issuer — distinguished name of issuer
+4. Attributes — certificate attributes
+5. Extensions — v3 extensions (raw text), "Show config" button
+6. Comment — plain text editor
+
+**Certificate Renewal dialog (CertExtend.ui):**
+- Not before / Not after date pickers
+- Duration spinner + Days/Months/Years dropdown + Apply button
+- Checkboxes: Midnight, Local time, No well-defined expiration
+- Checkboxes: Revoke old certificate, Replace old certificate, Keep serial number
+
+### XcaNet Current
+
+File: `src/XcaNet.App/Views/Pages/CertificatesPageView.axaml`
+
+**Table columns:** DisplayName, Subject, Issuer, Serial, NotBefore, NotAfter,
+CertificateKind, RevocationStatus, PrivateKeyStatus
+
+**Filter row:** Name, Subject, Issuer, Serial text boxes + Refresh button (at top of pane)
+
+**Right-side buttons:**
+- New Certificate (disabled)
+- Export (→ ExportSelectedCommand)
+- Import (→ ImportFilesCommand)
+- Show Details (disabled)
+- Delete (disabled)
+- Revoke (→ RevokeSelectedCommand)
+- Generate CRL (→ GenerateCertificateRevocationListCommand)
+- To Template (→ CreateTemplateFromCertificateCommand)
+- Plain View (disabled)
+- Open Issuer (→ OpenIssuerCommand)
+
+**Inspector panel (bottom):**
+- Tabs: General, Details, Extensions, Relationships, Raw / PEM
+- General: DisplayName, Subject, Issuer, Validity, Private key
+- Details: Serial, SHA-1, SHA-256, Key algorithm
+- Extensions: Subject Alternative Names list, Key Usage list, EKU list
+- Relationships: Type, Issuer display name, Children combobox, Open Child button
+- Raw/PEM: export target/format combos, password field, text box for PEM output
+
+### Gaps
+
+**Columns:**
+- [ ] `Common Name` column missing (separate from full Subject)
+- [ ] `Status` column missing (trust/expiry/revocation with color coding)
+- [ ] `Fingerprint` column missing (MD5 or SHA1 for quick identification)
+- [ ] Column header context menu missing
+
+**Hierarchy / tree view:**
+- [ ] Flat list only — no certificate hierarchy tree grouping CAs with their issued certs
+- [ ] No "Plain View" toggle to switch between tree and flat list (button present but disabled)
+- [ ] XCA color-codes expired certificates in the list — XcaNet has no color coding
+
+**Buttons:**
+- [ ] "New Certificate" disabled — must implement (opens NewX509 dialog in cert-creation mode)
+- [ ] "Show Details" disabled — must open CertDetail dialog (6 tabs)
+- [ ] "Delete" disabled — must implement with confirmation
+
+**Certificate Detail dialog:**
+- [ ] No standalone Certificate Detail dialog (CertDetail.ui equivalent)
+- [ ] Current inspector tabs partially cover this but are not the same as a detail modal
+- [ ] Missing: MD5 fingerprint display
+- [ ] Missing: Issuer DN tab (separate from issuer name reference)
+- [ ] Missing: Attributes tab
+- [ ] Missing: Comment tab on certificate
+- [ ] Missing: "Show config" button in Extensions view
+
+**Certificate Renewal dialog:**
+- [ ] No renewal dialog (CertExtend.ui equivalent)
+- [ ] Context menu "Certificate renewal" missing
+
+**Revocation:**
+- [ ] Revoke button calls RevokeSelectedCommand — XCA opens a Revoke dialog with serial,
+      date, and reason inputs — XcaNet must show equivalent before committing
+- [ ] "Unrevoke" not available from button or context menu
+
+**Context menus:**
+- [ ] No right-click context menu on rows
+- [ ] Missing: Convert to request, Export to token, Create similar certificate,
+      Generate CRL, Manage revocations, CA Properties, Certificate renewal, Revoke,
+      Unrevoke, Rename, Properties, Delete
+
+**Import:**
+- [ ] Import button present but covers only file import
+- [ ] Missing: explicit PKCS#12 import button
+- [ ] Missing: PKCS#7 import button
+
+### Intentional Deviations
+
+None declared yet.
+
+### Priority
+
+M13.6 (hierarchy tree, Show Details, New Certificate, color coding, column fixes),
+M14 (renewal dialog, revoke dialog, CA context menus, CA Properties)
+
+---
+
+## 5. Templates Tab
+
+### XCA Reference
+
+**Tab layout:**
+- Left panel: tree view of templates
+- Right panel: vertical button stack
+- Bottom: preview label
+
+**Right-side buttons:**
+1. New
+2. Export
+3. Import
+4. Show Details
+5. Delete
+
+**Tree view columns:**
+- Name (template identifier)
+- (Templates have minimal column data — they are named configurations)
+
+**Context menu (right-click on template):**
+- Import / Export → Clipboard / File
+- Rename
+- Properties
+- Delete
+- Duplicate (creates copy with " copy" appended to name)
+- Create certificate (opens NewX509 with template pre-applied)
+- Create request (opens NewX509 with template pre-applied in request mode)
+
+**Template Edit dialog:**
+- Accessed via Show Details / double-click
+- Integrated into NewX509 dialog (same tab structure) — template editing uses the shared
+  certificate/request input surface
+- Additional: Name, insertion date, comment fields
+
+### XcaNet Current
+
+File: `src/XcaNet.App/Views/Pages/TemplatesPageView.axaml`
+
+**Table columns:** Name, Usage, Enabled, Favorite, SubjectPreset, ExtensionPreset
+
+**Filter row:** Usage filter combo, Status filter combo, Refresh button
+
+**Right-side buttons:**
+- New Template (→ CreateNewCommand)
+- Edit (→ EditTemplateCommand)
+- Clone (→ CloneTemplateCommand)
+- Delete (→ DeleteTemplateCommand)
+- Enable/Disable (→ ToggleEnabledCommand)
+- Favorite (→ ToggleFavoriteCommand)
+- Export/Import (disabled)
+
+**Inspector panel (bottom):**
+- Tabs: General, Details, Validation
+- General: Name, Usage, State, Summary (label/value rows)
+- Details: SubjectPreset + ExtensionPreset text boxes
+- Validation: validation summary text box
+
+### Gaps
+
+**Columns:**
+- [ ] XCA has a single "Name" column — XcaNet extensions (Usage, Enabled, Favorite) are
+      acceptable additions but not present in XCA; document as intentional extension
+- [ ] Column header context menu missing
+
+**Buttons:**
+- [ ] Button order / labels differ from XCA (New, Export, Import, Show Details, Delete)
+- [ ] "Edit" should map to "Show Details" in XCA semantics
+- [ ] Export / Import disabled — must implement template export/import
+
+**Template editing surface:**
+- [ ] XCA edits templates using the full NewX509 dialog tabs (Source, Subject, Extensions,
+      Key Usage, Netscape, Advanced, Comment) — XcaNet's TemplateAuthoringDialogView
+      provides the shared CertificateAuthoringSurfaceView but displayed differently
+- [ ] Verify that XcaNet's template editing surface covers all NewX509 tabs
+
+**Context menus:**
+- [ ] No right-click context menu on rows
+- [ ] Missing: Duplicate (XcaNet has Clone — same intent, label differs)
+- [ ] Missing: Create certificate from template
+- [ ] Missing: Create request from template
+- [ ] Missing: Rename, Properties, Delete from context menu
+
+**Template Detail / Properties:**
+- [ ] No equivalent to ItemProperties.ui modal (Name, Source, Insertion date, Comment)
+- [ ] Comment field not present on templates in XcaNet
+
+### Intentional Deviations
+
+- **Usage, Enabled, Favorite columns**: XcaNet-specific extensions not present in XCA.
+  Retained as they improve template management UX. Must be documented as additions, not
+  replacements for XCA columns.
+- **Clone vs Duplicate**: Same intent. Label "Clone" is acceptable.
+
+### Priority
+
+M13.7 (button order, export/import, context menus, Comment field), M14 (template
+application from context menu — Create cert/request from template)
+
+---
+
+## 6. Revocation Lists Tab
+
+### XCA Reference
+
+**Tab layout:**
+- Left panel: tree view of CRLs
+- Right panel: vertical button stack
+- Bottom: preview label
+
+**Right-side buttons:**
+1. New
+2. Export
+3. Import
+4. Show Details
+5. Delete
+
+**Tree view columns:**
+- Name (internal)
+- Issuer (CA name)
+- Last update
+- Next update
+- Revoked (count of revoked entries)
+
+**New CRL workflow:**
+- If no CA certificates: informational message
+- If one CA: auto-selects it
+- If multiple CAs: itemComboCert dialog for selection
+- Then opens NewCrl.ui dialog
+
+**NewCrl dialog fields:**
+- Last update (date/time picker)
+- Next update (date/time picker)
+- Duration spinner + Days/Months/Years + Apply
+- Checkboxes: Midnight, Local time
+- Hash algorithm dropdown
+- Checkboxes: Subject alternative name, Authority key identifier, CRL number (+ text field),
+  Revocation reasons
+
+**CRL Detail dialog (CrlDetail.ui) — 5 tabs:**
+1. Status — name, signed by, signature algorithm, version, last update, next update
+2. Issuer — DN widget
+3. Extensions — v3 extensions raw text
+4. Revocation list — tree widget of revoked entries
+5. Comment — plain text editor
+
+**Context menu:**
+- Show Details
+- Export → Clipboard / File
+- Import
+- Delete
+
+### XcaNet Current
+
+File: `src/XcaNet.App/Views/Pages/CertificateRevocationListsPageView.axaml`
+
+**Table columns:** DisplayName, CrlNumber, IssuerDisplayName, ThisUpdate, NextUpdateUtc,
+RevokedEntryCount
+
+**Right-side buttons:**
+- Generate CRL (disabled)
+- Export (→ ExportSelectedCommand)
+- Import (disabled)
+- Show Details (disabled)
+- Delete (disabled)
+- Open Issuer (→ OpenIssuerCommand)
+- Refresh (→ RefreshCommand)
+
+**Inspector panel (bottom):**
+- Tabs: Details, Revoked entries
+- Details: Issuer, CRL number, This update, Next update
+- Revoked entries: list of revoked entries (DisplayName, SerialNumber, Reason, RevokedAt)
+
+### Gaps
+
+**Columns:**
+- [ ] `CRL number` is present in XcaNet but not a default XCA column — acceptable addition
+- [ ] Column header context menu missing
+
+**Buttons:**
+- [ ] "Generate CRL" disabled — must implement (selects CA, opens NewCrl dialog)
+- [ ] Import disabled — must implement CRL import
+- [ ] Show Details disabled — must open CrlDetail dialog (5 tabs)
+- [ ] Delete disabled — must implement with confirmation
+- [ ] "Generate CRL" in XcaNet is on this tab — in XCA it is accessed from the
+      Certificates tab context menu on a CA certificate AND the CRL tab New button
+
+**New CRL dialog:**
+- [ ] No NewCrl dialog (NewCrl.ui equivalent)
+- [ ] Missing: CA selection when multiple CAs present
+- [ ] Missing: Last/Next update date pickers
+- [ ] Missing: Hash algorithm selection
+- [ ] Missing: Extension checkboxes (SAN, AKI, CRL number, Revocation reasons)
+
+**CRL Detail dialog:**
+- [ ] No standalone CRL Detail modal (CrlDetail.ui equivalent)
+- [ ] Inspector covers partial content but is not modal and lacks Issuer DN tab,
+      Extensions tab, Comment tab
+
+**Context menus:**
+- [ ] No right-click context menu on rows
+
+### Intentional Deviations
+
+None declared yet.
+
+### Priority
+
+M14 (Generate CRL dialog, Show Details, Delete, Import, context menus)
+
+---
+
+## 7. Certificate / Request Input Dialog (NewX509 Equivalent)
+
+### XCA Reference
+
+This is the single most important dialog in XCA. It is used for:
+- Creating a new certificate (self-signed or CA-signed)
+- Creating a new certificate signing request
+- Editing/viewing a template
+- Signing a CSR into a certificate
+
+**Dialog tabs (some conditional):**
+
+1. **Source** — always present
+   - Certificate signing mode: Self-signed / Sign with CA / Use existing request
+   - CSR selection with extension copy options
+   - Signature algorithm dropdown
+   - Template selector (with application mode: Replace / Merge / Don't apply)
+   - Validity section (Not before, Not after, duration)
+
+2. **Subject** — shown unless using a CSR without modification
+   - Internal name field
+   - Distinguished Name widget (multi-field: CN, O, OU, C, ST, L, email, etc.)
+   - Custom attribute support
+   - Private key dropdown (itemComboKey — selects existing key)
+   - Option to generate new key
+
+3. **Extensions** — always present
+   - Basic Constraints: CA checkbox, Path length spinner
+   - Subject key identifier checkbox
+   - Authority key identifier checkbox
+   - Validity (Not before / Not after — alternative to Source tab placement)
+   - Subject Alternative Names (SAN)
+   - CRL Distribution Points
+   - Authority Information Access
+   - OCSP stapling checkbox
+
+4. **Key Usage** — always present
+   - Key Usage flags (checkboxes): Digital signature, Key encipherment, Data encipherment,
+     Key agreement, Key cert sign, CRL sign, Encipher only, Decipher only
+   - Critical flag for Key Usage
+   - Extended Key Usage selections (multi-select list)
+   - Critical flag for EKU
+
+5. **Netscape** — conditional (hidden if `disable_netscape` setting active)
+   - Netscape certificate types selector
+   - URL: revocation
+   - URL: renewal
+   - CA policy references
+   - SSL server name field
+
+6. **Advanced** — always present
+   - Direct OpenSSL config syntax editor
+   - Validate button
+
+7. **Comment** — always present
+   - Plain text editor for user notes
+
+**Dialog buttons:**
+- OK
+- Cancel
+
+### XcaNet Current
+
+File: `src/XcaNet.App/Views/Shared/CertificateAuthoringSurfaceView.axaml`
+
+**Tabs:**
+1. Source — Operation summary, Source summary, Template selector (with application mode),
+   Validity days
+2. Subject — Name, Subject DN (single text box), Alternative names (text box)
+3. Extensions — CA checkbox, Path length (Constrained checkbox + spinner), Signature
+   algorithm (conditional), Key algorithm section (type + RSA size + EC curve)
+4. Key usage — Key usage (text box, multi-line), Extended key usage (text box, multi-line)
+5. Advanced — Raw key usage (text box), Raw extended usage (text box)
+6. Signing / Issuer — Issuer certificate combo, Issuer key combo (conditional on mode)
+
+**Bottom action bar:**
+- Title text block, Cancel button, Primary action button
+
+### Gaps
+
+**Source tab:**
+- [ ] No explicit mode radio buttons (Self-signed / Sign with CA / Use existing request) —
+      XcaNet infers mode from authoring kind but does not present this choice visually
+- [ ] Signature algorithm dropdown missing
+- [ ] Validity should show Not before + Not after date pickers, not just "Validity days"
+      (XCA uses date pickers with duration shortcut)
+- [ ] Template application mode dropdown present (good) — labels should match XCA:
+      Replace / Merge / Don't apply
+
+**Subject tab:**
+- [ ] Subject DN is a single free-form text box — XCA uses a structured DN widget with
+      individual fields per OID component (CN, O, OU, C, ST, L, emailAddress)
+- [ ] Private key selector missing — XCA has a key dropdown on Subject tab
+- [ ] "Generate new key" option missing (generates key inline during cert/request creation)
+
+**Extensions tab:**
+- [ ] Extensions tab mixes key algorithm (key generation) with certificate extensions
+- [ ] SAN editor is on the Subject tab (text box) — XCA has SAN on Extensions tab with
+      structured multi-value editor
+- [ ] CRL Distribution Points field missing
+- [ ] Authority Information Access field missing
+- [ ] OCSP stapling checkbox missing
+- [ ] Subject key identifier checkbox missing
+- [ ] Authority key identifier checkbox missing
+
+**Key Usage tab:**
+- [ ] Key Usage is a free-form text box — XCA uses individual checkboxes per flag
+- [ ] EKU is a free-form text box — XCA uses a multi-select list
+- [ ] Critical flag checkboxes missing for both Key Usage and EKU
+
+**Netscape tab:**
+- [ ] Entire Netscape tab missing (intentional deviation candidate — legacy)
+
+**Comment tab:**
+- [ ] Comment tab missing entirely — no user notes field on certificates/requests
+
+**Key algorithm in dialog:**
+- [ ] Key algorithm section on Extensions tab is misplaced — should be on Subject tab
+      or Source tab near the private key selector
+
+**Validity:**
+- [ ] Only "Validity days" NumericUpDown — must add Not before + Not after date pickers
+
+### Intentional Deviations
+
+- **Netscape tab**: Netscape extensions are deprecated. XcaNet may omit by default,
+  matching XCA's `disable_netscape` option. **Must be documented as an explicit omission.**
+
+### Priority
+
+M13.7 (structured DN widget, private key selector, validity date pickers, Key Usage
+checkboxes, EKU multi-select, Critical flags, Comment tab), M14 (SAN editor, CDP, AIA,
+key identifier checkboxes)
+
+---
+
+## 8. Template Input / Edit Dialog
+
+### XCA Reference
+
+Template editing in XCA reuses the NewX509 dialog with the same 7 tabs (Source, Subject,
+Extensions, Key Usage, Netscape, Advanced, Comment). The template captures the certificate
+configuration that will be applied when creating certificates or requests from it.
+
+Additional template-level fields (shown in ItemProperties.ui and the properties header):
+- Name (editable)
+- Source (read-only: how template was created)
+- Insertion date (read-only)
+- Comment (plain text)
+
+### XcaNet Current
+
+File: `src/XcaNet.App/Views/Shared/TemplateAuthoringDialogView.axaml`
+
+- Top row: Name text box, IntendedUsage combo, Enabled checkbox, Favorite checkbox
+- Main area: CertificateAuthoringSurfaceView (left) + Summary/Validation tabs (right)
+- Bottom row: Description text box, Clone, Delete, Save Template buttons
+
+### Gaps
+
+- [ ] All gaps from §7 (NewX509 tabs) apply here too
+- [ ] "Source" (creation origin) read-only field missing
+- [ ] "Insertion date" read-only field missing
+- [ ] Comment tab in CertificateAuthoringSurfaceView missing (also listed in §7)
+- [ ] Usage / Enabled / Favorite are XcaNet additions — acceptable but document as such
+- [ ] Bottom action bar: XCA uses OK/Cancel — XcaNet uses Save/Clone/Delete with
+      Description field; acceptable deviation for the inline editing model
+
+### Intentional Deviations
+
+- **Enabled, Favorite, IntendedUsage**: XcaNet additions not in XCA. Retained.
+- **Inline editing model**: XcaNet shows template editing in a panel alongside a preview
+  rather than as a modal. Acceptable if the fields match.
+
+### Priority
+
+M13.7 (align with NewX509 tab fixes), M14 (Source, Insertion date, Comment)
+
+---
+
+## 9. CA Properties Dialog
+
+### XCA Reference
+
+**CaProperties.ui — single dialog with 2 fields:**
+- Days until next CRL issuing (spinner)
+- Default template (itemComboTemp dropdown — selects a template)
+
+Accessed via: Certificates tab → right-click CA certificate → CA Properties
+
+### XcaNet Current
+
+No CA Properties dialog exists. No equivalent accessible from the UI.
+
+### Gaps
+
+- [ ] CA Properties dialog missing entirely
+- [ ] No access point: right-click context menu on CA certificate missing
+- [ ] Days until next CRL issuing setting missing
+- [ ] Default template assignment per CA missing
+
+### Intentional Deviations
+
+None declared yet.
+
+### Priority
+
+M14 (CA Properties dialog, CA context menu)
+
+---
+
+## 10. Certificate Revocation Dialog
+
+### XCA Reference
+
+**Revoke.ui — single dialog:**
+- Title: "Certificate revocation" (Arial 14pt)
+- Serial field (read-only, shows certificate serial number)
+- Invalid Since (date/time picker)
+- Local Time checkbox
+- Revocation Reason dropdown (unspecified, keyCompromise, CACompromise, affiliationChanged,
+  superseded, cessationOfOperation, certificateHold, removeFromCRL, privilegeWithdrawn,
+  AACompromise)
+
+**Manage Revocations dialog (RevocationList.ui):**
+- Tree widget of revoked certificates (multi-select)
+- Right-side buttons: Add, Delete, Edit
+- OK / Cancel
+
+Accessed via: Certificates tab → right-click CA certificate → Manage revocations
+
+### XcaNet Current
+
+- `RevokeSelectedCommand` exists on Certificates page but directly revokes without a
+  confirmation/reason dialog
+- No Manage Revocations dialog
+
+### Gaps
+
+- [ ] Revoke dialog missing — must show serial, date picker, reason dropdown before committing
+- [ ] Revocation reason dropdown missing (must use RFC 5280 reasons)
+- [ ] Manage Revocations dialog missing (add/delete/edit revocation entries for a CA)
+- [ ] Unrevoke action missing entirely
+
+### Intentional Deviations
+
+None declared yet.
+
+### Priority
+
+M14 (Revoke dialog with reason, Manage Revocations, Unrevoke)
+
+---
+
+## 11. Database Open / Create / Change Password Flows
+
+### XCA Reference
+
+**New Database:**
+- File → New DataBase → file save dialog → creates new .xdb file
+- Password set via PwDialog (two fields: new password, confirm)
+- Hex checkbox option for binary passwords
+
+**Open Local Database:**
+- File → Open DataBase → file open dialog → selects .xdb
+- If password-protected: PwDialog appears (one field: enter password)
+
+**Open Remote Database (OpenDb.ui):**
+- File → Open Remote DataBase
+- Fields: database type, hostname, username, password, database name, table prefix
+- Types: SQLite, MySQL/MariaDB, PostgreSQL, Microsoft SQL Server
+
+**Change Password:**
+- Extra → Password change → PwDialog (two fields: new password, confirm)
+
+**PwDialog fields:**
+- Password field A (masked)
+- Confirmation field B (masked)
+- Hex checkbox (interpret as hexadecimal)
+
+### XcaNet Current
+
+- File → Create Database (→ CreateDatabaseCommand)
+- File → Open Database (→ OpenDatabaseCommand)
+- File → Unlock (→ UnlockDatabaseCommand)
+- File → Lock (→ LockDatabaseCommand)
+
+### Gaps
+
+- [ ] Password dialog UI not visible / inspectable — unclear if it shows the XCA-style
+      two-field confirmation on creation vs one-field on open
+- [ ] Hex password checkbox missing
+- [ ] Open Remote Database missing
+- [ ] Change Password missing (Extra menu missing entirely)
+- [ ] "Set default database" missing
+- [ ] Recent databases list missing
+- [ ] Close Database missing
+
+### Intentional Deviations
+
+- **Remote database**: Out of scope until M15. XcaNet uses a local SQLite model.
+
+### Priority
+
+M13.4 (Close Database, proper PwDialog on create), M15 (remote database, Change Password)
+
+---
+
+## 12. Import / Export Dialogs
+
+### XCA Reference
+
+**Import Multi dialog (ImportMulti.ui):**
+- Left: list of importable items
+- Right buttons: Import All, Import (selected), Done, Remove from list, Details,
+  Delete from token, Rename on token
+- Bottom: slot information display
+- Used for bulk import from file or token
+
+**Export dialog (ExportDialog.ui):**
+- Name field (read-only — internal DB name)
+- Filename field + browse ("...") button
+- Format dropdown
+- Checkbox: "Export comment into PEM file"
+- Info text area
+
+**Import menu triggers (per type):**
+- Keys → PEM/DER key import
+- Requests → PKCS#10 import
+- Certificates → PEM/DER/PKCS#12/PKCS#7 import
+- PKCS#12 → combined key+cert bundle
+- PKCS#7 → certificate chain
+- Template → template file
+- Revocation list → CRL file
+- PEM files → auto-detect type, includes clipboard paste
+
+### XcaNet Current
+
+- Import button on Certificates page calls ImportFilesCommand (file dialog, minimal UI)
+- Export on various pages calls export commands
+- No ImportMulti dialog
+- No ExportDialog modal with format selection and comment option
+- Import menu entirely missing from menu bar
+
+### Gaps
+
+- [ ] Import menu missing from menu bar (see §1 — Shell)
+- [ ] No ImportMulti dialog
+- [ ] No ExportDialog modal (format + filename + comment option)
+- [ ] Clipboard import/paste missing
+- [ ] Per-type import commands missing from Import menu
+- [ ] "Export comment into PEM file" option missing
+- [ ] Import from security token missing
+
+### Intentional Deviations
+
+- **Security token import**: Out of scope until hardware token support added (M15).
+
+### Priority
+
+M13.5 (per-type import from menu, Export dialog modal), M14 (Import All / ImportMulti
+for bulk), M15 (token import/export)
+
+---
+
+## 13. Options / Preferences Dialog
+
+### XCA Reference
+
+**Options.ui — 3 tabs:**
+
+**Tab 1: Settings**
+- Hash algorithm dropdown (default: SHA-256)
+- String types configuration
+- Suppress success messages checkbox
+- Disable legacy Netscape extensions checkbox
+- Translate X.509 terminology checkbox
+- Restrict token hash support checkbox
+- Disable colorization of expired certificates checkbox
+- Certificate expiry warning threshold (spinner, days)
+- Calendar reminder threshold (spinner, days)
+- Serial number length (8–256 bits, default 64)
+
+**Tab 2: Distinguished Name**
+- Mandatory Subject Entries list
+- Explicit Subject Entries list (drag-and-drop reorder, Add/Remove buttons)
+- "Dynamically arrange explicit entries" checkbox
+
+**Tab 3: PKCS#11 Provider**
+- Draggable list of PKCS#11 provider libraries
+- Add, Remove, Search buttons
+
+Accessed via: File → Options
+
+### XcaNet Current
+
+- No Options/Preferences dialog
+- `SettingsSecurityCommand` in ShellViewModel — unclear if it covers any of the above
+
+### Gaps
+
+- [ ] Options dialog missing entirely
+- [ ] Hash algorithm preference missing
+- [ ] Expiry warning thresholds missing
+- [ ] Serial number length preference missing
+- [ ] DN configuration missing (mandatory / explicit subject entries)
+- [ ] Suppress success messages missing
+- [ ] Netscape disable setting missing
+- [ ] PKCS#11 provider management missing (low priority)
+- [ ] File → Options menu item missing (see §1)
+
+### Intentional Deviations
+
+- **PKCS#11 Provider tab**: Out of scope until hardware token support (M15).
+
+### Priority
+
+M14 (hash algorithm, expiry warnings, serial preferences, basic settings tab),
+M15 (DN configuration, PKCS#11 tab)
+
+---
+
+## 14. OID Resolver Dialog
+
+### XCA Reference
+
+**OidResolver.ui — modeless dialog:**
+- Search field (text input — real-time lookup as user types)
+- Results: OID (copyable), Short name / sn (copyable), Long name / ln (copyable), Nid (copyable)
+- Instruction text: "Enter the OID, the Nid, or one of the textual representations"
+
+Accessed via: Extra → OID Resolver
+
+### XcaNet Current
+
+No OID Resolver dialog or equivalent.
+
+### Gaps
+
+- [ ] OID Resolver dialog missing
+- [ ] Extra menu missing (see §1)
+
+### Intentional Deviations
+
+None declared. Low priority but should be present for parity.
+
+### Priority
+
+M15
+
+---
+
+## 15. Certificate Renewal Dialog
+
+### XCA Reference
+
+**CertExtend.ui:**
+- Not before date picker
+- Not after date picker
+- Duration spinner + Days/Months/Years dropdown + Apply button
+- Checkboxes: Midnight, Local time, No well-defined expiration
+- Checkboxes: Revoke old certificate, Replace old certificate, Keep serial number
+
+Accessed via: Certificates tab → right-click → Certificate renewal
+
+### XcaNet Current
+
+No certificate renewal dialog or workflow.
+
+### Gaps
+
+- [ ] Certificate renewal dialog missing entirely
+- [ ] Context menu access point missing
+- [ ] Not before / Not after date picker missing
+- [ ] Duration quick-entry missing (Days/Months/Years)
+- [ ] Revoke old / Replace old / Keep serial options missing
+
+### Intentional Deviations
+
+None declared yet.
+
+### Priority
+
+M14
+
+---
+
+## Implementation Roadmap
+
+### M13.4 — Main Shell and Object Tabs Exact Parity
+
+**Scope:**
+- Add Import menu to menu bar with all import items (wired to stubs if backend not ready)
+- Add Extra menu with: Password change, OID Resolver placeholder
+- Add File → Options (stub), Close Database, Recent databases list
+- Add Help → Documentation, About
+- Fix object tab labels to match XCA exactly
+- Ensure status bar shows meaningful operational status
+- Confirm selected tab is visually obvious (accent border on active tab)
+
+**Acceptance:**
+- [ ] Menu bar matches XCA: File | Import | Token | Extra | Help with all top-level items
+- [ ] All 5 object tabs visible and labeled as in XCA
+- [ ] Status bar visible at bottom
+- [ ] Active tab clearly indicated
+
+---
+
+### M13.5 — Private Keys and Requests Tab Parity
+
+**Scope:**
+
+*Private Keys:*
+- Add `Use` column (related object count)
+- Add `Token` column (security token indicator)
+- Change button order/labels to: New, Export, Import, Show Details, Delete (+ key extras)
+- Implement New Key modal dialog (separate from inspector inline tab)
+- Implement Show Details — Key Detail modal (Key, Fingerprint, Comment tabs minimum)
+- Implement Delete with confirmation dialog
+- Implement Import (PEM/DER)
+
+*Certificate Requests:*
+- Add `Signed` column
+- Change button order/labels to: New, Export, Import, Show Details, Delete (+ Sign etc.)
+- Implement New Request (opens NewX509 dialog in request mode)
+- Implement Show Details — CSR detail view
+- Implement Delete with confirmation dialog
+- Implement Import (PKCS#10)
+- Implement per-type Import from Import menu (Keys, Requests)
+
+**Acceptance:**
+- [ ] Private Keys: columns match XCA, New opens modal, Show Details opens modal,
+      Delete works, Import works
+- [ ] CSR: columns match XCA, New opens modal (NewX509 request mode), Sign works,
+      Show Details works, Delete works
+
+---
+
+### M13.6 — Certificates Tab and Chain Tree Parity
+
+**Scope:**
+- Add `Common Name` column
+- Add `Status` column with expiry/revocation color coding
+- Add `Fingerprint` column
+- Implement hierarchical tree view grouping CAs with issued certificates
+- Implement Plain View toggle (tree ↔ flat list)
+- Implement New Certificate (opens NewX509 in certificate creation mode)
+- Implement Show Details — CertDetail modal (Status, Subject, Issuer, Attributes,
+  Extensions, Comment tabs)
+- Implement Delete with confirmation
+- Implement Import PKCS#12 and PKCS#7 buttons
+- Implement Certificate Renewal dialog
+
+**Acceptance:**
+- [ ] Certificates: columns match XCA, tree hierarchy displays, Plain View toggles,
+      New opens NewX509, Show Details opens CertDetail modal, Delete works
+
+---
+
+### M13.7 — Certificate / Request / Template Input Dialog Parity
+
+**Scope:**
+
+*NewX509 equivalent (CertificateAuthoringSurfaceView + TemplateAuthoringDialogView):*
+- Source tab: Add mode radio buttons, signature algorithm dropdown, Not before/Not after
+  date pickers (replace Validity days only)
+- Subject tab: Replace free-form Subject text box with structured DN widget (CN, O, OU, C,
+  ST, L, emailAddress minimum); Add private key selector; Add "Generate new key" option
+- Extensions tab: Restructure — remove key algorithm from here; add SAN structured editor,
+  subject/authority key identifier checkboxes
+- Key Usage tab: Replace text boxes with individual checkboxes per flag; add Critical
+  checkbox; add EKU multi-select list with Critical checkbox
+- Comment tab: Add new tab with plain text editor
+- Advanced tab: Verify OpenSSL config syntax editor works
+
+*Template Dialog:*
+- Apply all NewX509 tab improvements above
+- Add Comment tab to template editing surface
+- Add Source (read-only) and Insertion date (read-only) fields
+
+**Acceptance:**
+- [ ] Source tab shows mode selection and date pickers
+- [ ] Subject tab has structured DN widget and key selector
+- [ ] Key Usage tab uses checkboxes per flag
+- [ ] Comment tab exists
+- [ ] Template editing covers same tabs as certificate/request editing
+
+---
+
+### M14 — CA, CRL, Validation, Import/Export Behavior Parity
+
+**Scope:**
+- CA Properties dialog (CRL interval, default template)
+- Revoke dialog (serial, date, reason dropdown)
+- Manage Revocations dialog (tree + Add/Delete/Edit)
+- Unrevoke action
+- Generate CRL dialog (NewCrl equivalent) — CA selection, date pickers, extension checkboxes
+- CRL Show Details modal (CrlDetail — 5 tabs)
+- Context menus on all object list rows (right-click)
+- Certificate Renewal dialog (CertExtend)
+- Export dialog modal (format + filename + comment option)
+- ImportMulti dialog for bulk import
+- Options dialog (Settings tab: hash algorithm, expiry warnings, serial length)
+
+**Acceptance:**
+- [ ] CA-centric actions (CA Properties, Manage Revocations, Generate CRL) accessible
+      from Certificates context menu on CA certs
+- [ ] Revoke opens dialog with reason before committing
+- [ ] CRL tab New opens NewCrl dialog
+- [ ] All Show Details on all tabs open detail modals
+- [ ] Right-click context menus present on all object list rows
+
+---
+
+### Remaining Gaps After M14 (M15 scope)
+
+- Token menu operations (hardware token / PKCS#11)
+- Open Remote Database
+- Options → DN configuration tab
+- Options → PKCS#11 Provider tab
+- Password change dialog (Extra menu)
+- OID Resolver dialog
+- DH parameter generation
+- Language selection
+- Database dump / Certificate index export / Hierarchy export
+- SSH public key import
+- Security token key import/export/rename/delete
+
+---
+
+## Screen Parity Status Summary
+
+| Screen | M13.4 | M13.5 | M13.6 | M13.7 | M14 | M15 |
+|---|---|---|---|---|---|---|
+| Main shell / menus | target | | | | | |
+| Private Keys tab | | target | | | | |
+| CSR tab | | target | | | | |
+| Certificates tab | | | target | | | |
+| Templates tab | | | | target | | |
+| CRL tab | | | | | target | |
+| NewX509 / input dialog | | | | target | | |
+| CA Properties | | | | | target | |
+| Revoke / Manage Revocations | | | | | target | |
+| New CRL dialog | | | | | target | |
+| Certificate Renewal | | | | | target | |
+| Export dialog modal | | | | | target | |
+| ImportMulti | | | | | target | |
+| Options / Preferences | | | | | target | partial |
+| OID Resolver | | | | | | target |
+| Token operations | | | | | | target |
+| Remote database | | | | | | target |
+
+---
+
+## Parity Completion Rule
+
+A screen is **parity-complete** when all of the following are true:
+
+1. Every visible button, column, tab, and dialog in the XCA reference for this screen
+   is either implemented in XcaNet or listed under **Intentional Deviations** in this
+   document with a written justification.
+2. The workflow to reach and operate the screen matches the XCA mental model
+   (object-centric, table-first, action-from-selection).
+3. A person familiar with XCA can locate and operate the screen without guidance.
+4. Any visual differences are minor (color scheme, font) and do not change where things
+   are or what they are called.
+
+Do not claim parity-complete based on "similar enough." Claim it based on this checklist.

--- a/src/XcaNet.App/Styles/ThemeResources.axaml
+++ b/src/XcaNet.App/Styles/ThemeResources.axaml
@@ -95,6 +95,32 @@
     <Setter Property="CornerRadius" Value="10" />
   </Style>
 
+  <Style Selector="Border.workspace-shell">
+    <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="14" />
+  </Style>
+
+  <Style Selector="Border.workspace-toolbar">
+    <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+    <Setter Property="BorderThickness" Value="0,0,0,1" />
+  </Style>
+
+  <Style Selector="Border.table-header">
+    <Setter Property="Background" Value="{DynamicResource SurfaceRaisedBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+    <Setter Property="BorderThickness" Value="0,0,0,1" />
+  </Style>
+
+  <Style Selector="Border.workspace-pane">
+    <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="12" />
+  </Style>
+
   <Style Selector="Border.authoring-dialog-shell">
     <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource BorderStrongBrush}" />
@@ -197,6 +223,55 @@
   <Style Selector="TextBox.readonly-surface">
     <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+  </Style>
+
+  <Style Selector="Button.workspace-tab">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="10" />
+    <Setter Property="Padding" Value="16,10" />
+  </Style>
+
+  <Style Selector="Button.workspace-tab:pointerover">
+    <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource SelectedBorderBrush}" />
+  </Style>
+
+  <Style Selector="Button.workspace-tab.is-selected">
+    <Setter Property="Background" Value="{DynamicResource SelectedSurfaceBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource SelectedBorderBrush}" />
+  </Style>
+
+  <Style Selector="Button.utility-tab">
+    <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="10" />
+    <Setter Property="Padding" Value="12,8" />
+  </Style>
+
+  <Style Selector="Button.toolbar-action">
+    <Setter Property="Padding" Value="12,8" />
+    <Setter Property="CornerRadius" Value="8" />
+  </Style>
+
+  <Style Selector="TextBlock.table-header-text">
+    <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="FontSize" Value="12" />
+  </Style>
+
+  <Style Selector="TabControl.workspace-inspector-tabs">
+    <Setter Property="Background" Value="Transparent" />
+  </Style>
+
+  <Style Selector="TabControl.workspace-inspector-tabs TabStrip">
+    <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
+  </Style>
+
+  <Style Selector="TabControl.workspace-inspector-tabs TabItem">
+    <Setter Property="Padding" Value="12,8" />
   </Style>
 
   <Style Selector="TabControl.authoring-tabs">

--- a/src/XcaNet.App/Styles/ThemeResources.axaml
+++ b/src/XcaNet.App/Styles/ThemeResources.axaml
@@ -4,22 +4,22 @@
     <ResourceDictionary>
       <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Light">
-          <SolidColorBrush x:Key="AppBackgroundBrush" Color="#F3F7FB" />
-          <SolidColorBrush x:Key="ShellSidebarBrush" Color="#163047" />
-          <SolidColorBrush x:Key="ShellSidebarTextBrush" Color="#F8FAFC" />
-          <SolidColorBrush x:Key="ShellSidebarMutedTextBrush" Color="#C9D6E3" />
-          <SolidColorBrush x:Key="SurfaceBrush" Color="#FFFFFF" />
-          <SolidColorBrush x:Key="SurfaceAltBrush" Color="#F8FAFC" />
-          <SolidColorBrush x:Key="SurfaceRaisedBrush" Color="#EEF4FA" />
-          <SolidColorBrush x:Key="BorderSubtleBrush" Color="#D7E0EA" />
-          <SolidColorBrush x:Key="BorderStrongBrush" Color="#B7C5D6" />
-          <SolidColorBrush x:Key="TextPrimaryBrush" Color="#102132" />
-          <SolidColorBrush x:Key="TextSecondaryBrush" Color="#405769" />
-          <SolidColorBrush x:Key="TextMutedBrush" Color="#61788C" />
-          <SolidColorBrush x:Key="AccentBrush" Color="#0F6CBD" />
-          <SolidColorBrush x:Key="AccentMutedBrush" Color="#DCEBFA" />
-          <SolidColorBrush x:Key="SelectedSurfaceBrush" Color="#DCEBFA" />
-          <SolidColorBrush x:Key="SelectedBorderBrush" Color="#6EA9DE" />
+          <SolidColorBrush x:Key="AppBackgroundBrush" Color="#E9E9E9" />
+          <SolidColorBrush x:Key="ShellSidebarBrush" Color="#E9E9E9" />
+          <SolidColorBrush x:Key="ShellSidebarTextBrush" Color="#1D1D1D" />
+          <SolidColorBrush x:Key="ShellSidebarMutedTextBrush" Color="#666666" />
+          <SolidColorBrush x:Key="SurfaceBrush" Color="#F6F6F6" />
+          <SolidColorBrush x:Key="SurfaceAltBrush" Color="#EFEFEF" />
+          <SolidColorBrush x:Key="SurfaceRaisedBrush" Color="#E2E2E2" />
+          <SolidColorBrush x:Key="BorderSubtleBrush" Color="#A8A8A8" />
+          <SolidColorBrush x:Key="BorderStrongBrush" Color="#7E7E7E" />
+          <SolidColorBrush x:Key="TextPrimaryBrush" Color="#1E1E1E" />
+          <SolidColorBrush x:Key="TextSecondaryBrush" Color="#4F4F4F" />
+          <SolidColorBrush x:Key="TextMutedBrush" Color="#707070" />
+          <SolidColorBrush x:Key="AccentBrush" Color="#2B579A" />
+          <SolidColorBrush x:Key="AccentMutedBrush" Color="#D8E1F0" />
+          <SolidColorBrush x:Key="SelectedSurfaceBrush" Color="#D7DCE4" />
+          <SolidColorBrush x:Key="SelectedBorderBrush" Color="#6E7E96" />
           <SolidColorBrush x:Key="DisabledSurfaceBrush" Color="#EDF2F7" />
           <SolidColorBrush x:Key="DisabledTextBrush" Color="#7B8795" />
           <SolidColorBrush x:Key="SuccessBrush" Color="#1F7A4D" />
@@ -35,15 +35,15 @@
           <SolidColorBrush x:Key="DialogOverlayBrush" Color="#88081824" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="Dark">
-          <SolidColorBrush x:Key="AppBackgroundBrush" Color="#111827" />
-          <SolidColorBrush x:Key="ShellSidebarBrush" Color="#081624" />
+          <SolidColorBrush x:Key="AppBackgroundBrush" Color="#1E1E1E" />
+          <SolidColorBrush x:Key="ShellSidebarBrush" Color="#1E1E1E" />
           <SolidColorBrush x:Key="ShellSidebarTextBrush" Color="#F8FAFC" />
           <SolidColorBrush x:Key="ShellSidebarMutedTextBrush" Color="#A9BCD0" />
-          <SolidColorBrush x:Key="SurfaceBrush" Color="#162130" />
-          <SolidColorBrush x:Key="SurfaceAltBrush" Color="#101A27" />
-          <SolidColorBrush x:Key="SurfaceRaisedBrush" Color="#1D2A39" />
-          <SolidColorBrush x:Key="BorderSubtleBrush" Color="#314355" />
-          <SolidColorBrush x:Key="BorderStrongBrush" Color="#486078" />
+          <SolidColorBrush x:Key="SurfaceBrush" Color="#2B2B2B" />
+          <SolidColorBrush x:Key="SurfaceAltBrush" Color="#242424" />
+          <SolidColorBrush x:Key="SurfaceRaisedBrush" Color="#333333" />
+          <SolidColorBrush x:Key="BorderSubtleBrush" Color="#666666" />
+          <SolidColorBrush x:Key="BorderStrongBrush" Color="#8D8D8D" />
           <SolidColorBrush x:Key="TextPrimaryBrush" Color="#E5EDF5" />
           <SolidColorBrush x:Key="TextSecondaryBrush" Color="#B8C7D6" />
           <SolidColorBrush x:Key="TextMutedBrush" Color="#90A4B8" />
@@ -78,28 +78,28 @@
     <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="CornerRadius" Value="12" />
+    <Setter Property="CornerRadius" Value="0" />
   </Style>
 
   <Style Selector="Border.surface-subtle">
     <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="CornerRadius" Value="10" />
+    <Setter Property="CornerRadius" Value="0" />
   </Style>
 
   <Style Selector="Border.status-pill">
     <Setter Property="Background" Value="{DynamicResource SurfaceRaisedBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="CornerRadius" Value="10" />
+    <Setter Property="CornerRadius" Value="0" />
   </Style>
 
   <Style Selector="Border.workspace-shell">
     <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="CornerRadius" Value="14" />
+    <Setter Property="CornerRadius" Value="0" />
   </Style>
 
   <Style Selector="Border.workspace-toolbar">
@@ -118,36 +118,35 @@
     <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="CornerRadius" Value="12" />
+    <Setter Property="CornerRadius" Value="0" />
   </Style>
 
   <Style Selector="Border.authoring-dialog-shell">
     <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource BorderStrongBrush}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="CornerRadius" Value="16" />
-    <Setter Property="BoxShadow" Value="0 20 48 0 #40000000" />
+    <Setter Property="CornerRadius" Value="0" />
   </Style>
 
   <Style Selector="Border.empty-state">
     <Setter Property="Background" Value="{DynamicResource EmptyStateBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="CornerRadius" Value="10" />
+    <Setter Property="CornerRadius" Value="0" />
   </Style>
 
   <Style Selector="Border.info-panel">
     <Setter Property="Background" Value="{DynamicResource InfoMutedBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="CornerRadius" Value="10" />
+    <Setter Property="CornerRadius" Value="0" />
   </Style>
 
   <Style Selector="Border.validation-panel">
     <Setter Property="Background" Value="{DynamicResource ValidationBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource WarningBrush}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="CornerRadius" Value="10" />
+    <Setter Property="CornerRadius" Value="0" />
   </Style>
 
   <Style Selector="Border.notification-chip">
@@ -181,7 +180,7 @@
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="CornerRadius" Value="10" />
+    <Setter Property="CornerRadius" Value="0" />
     <Setter Property="Foreground" Value="{DynamicResource ShellSidebarTextBrush}" />
   </Style>
 
@@ -225,12 +224,30 @@
     <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
   </Style>
 
+  <Style Selector="Button">
+    <Setter Property="CornerRadius" Value="0" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Padding" Value="8,4" />
+    <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+  </Style>
+
+  <Style Selector="Menu">
+    <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+    <Setter Property="BorderThickness" Value="0,0,0,1" />
+  </Style>
+
+  <Style Selector="MenuItem">
+    <Setter Property="Padding" Value="10,4" />
+  </Style>
+
   <Style Selector="Button.workspace-tab">
-    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="CornerRadius" Value="10" />
-    <Setter Property="Padding" Value="16,10" />
+    <Setter Property="CornerRadius" Value="0" />
+    <Setter Property="Padding" Value="10,5" />
   </Style>
 
   <Style Selector="Button.workspace-tab:pointerover">
@@ -247,13 +264,34 @@
     <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="CornerRadius" Value="10" />
-    <Setter Property="Padding" Value="12,8" />
+    <Setter Property="CornerRadius" Value="0" />
+    <Setter Property="Padding" Value="8,4" />
   </Style>
 
   <Style Selector="Button.toolbar-action">
-    <Setter Property="Padding" Value="12,8" />
-    <Setter Property="CornerRadius" Value="8" />
+    <Setter Property="Padding" Value="8,4" />
+    <Setter Property="CornerRadius" Value="0" />
+  </Style>
+
+  <Style Selector="Button.side-action">
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="Margin" Value="0,0,0,6" />
+    <Setter Property="MinWidth" Value="132" />
+  </Style>
+
+  <Style Selector="Border.classic-side-panel">
+    <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="0" />
+  </Style>
+
+  <Style Selector="Border.classic-status-bar">
+    <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+    <Setter Property="BorderThickness" Value="1,1,1,0" />
+    <Setter Property="CornerRadius" Value="0" />
   </Style>
 
   <Style Selector="TextBlock.table-header-text">
@@ -271,7 +309,7 @@
   </Style>
 
   <Style Selector="TabControl.workspace-inspector-tabs TabItem">
-    <Setter Property="Padding" Value="12,8" />
+    <Setter Property="Padding" Value="8,4" />
   </Style>
 
   <Style Selector="TabControl.authoring-tabs">
@@ -283,6 +321,6 @@
   </Style>
 
   <Style Selector="TabControl.authoring-tabs TabItem">
-    <Setter Property="Padding" Value="14,10" />
+    <Setter Property="Padding" Value="8,4" />
   </Style>
 </Styles>

--- a/src/XcaNet.App/Styles/ThemeResources.axaml
+++ b/src/XcaNet.App/Styles/ThemeResources.axaml
@@ -32,6 +32,7 @@
           <SolidColorBrush x:Key="InfoMutedBrush" Color="#DCEBFA" />
           <SolidColorBrush x:Key="EmptyStateBrush" Color="#F7FAFD" />
           <SolidColorBrush x:Key="ValidationBrush" Color="#FFF4E5" />
+          <SolidColorBrush x:Key="DialogOverlayBrush" Color="#88081824" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="Dark">
           <SolidColorBrush x:Key="AppBackgroundBrush" Color="#111827" />
@@ -62,6 +63,7 @@
           <SolidColorBrush x:Key="InfoMutedBrush" Color="#17304A" />
           <SolidColorBrush x:Key="EmptyStateBrush" Color="#101A27" />
           <SolidColorBrush x:Key="ValidationBrush" Color="#3D2A10" />
+          <SolidColorBrush x:Key="DialogOverlayBrush" Color="#AA040B14" />
         </ResourceDictionary>
       </ResourceDictionary.ThemeDictionaries>
     </ResourceDictionary>
@@ -91,6 +93,14 @@
     <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
     <Setter Property="BorderThickness" Value="1" />
     <Setter Property="CornerRadius" Value="10" />
+  </Style>
+
+  <Style Selector="Border.authoring-dialog-shell">
+    <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource BorderStrongBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="16" />
+    <Setter Property="BoxShadow" Value="0 20 48 0 #40000000" />
   </Style>
 
   <Style Selector="Border.empty-state">
@@ -187,5 +197,17 @@
   <Style Selector="TextBox.readonly-surface">
     <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource BorderSubtleBrush}" />
+  </Style>
+
+  <Style Selector="TabControl.authoring-tabs">
+    <Setter Property="Background" Value="Transparent" />
+  </Style>
+
+  <Style Selector="TabControl.authoring-tabs TabStrip">
+    <Setter Property="Background" Value="{DynamicResource SurfaceAltBrush}" />
+  </Style>
+
+  <Style Selector="TabControl.authoring-tabs TabItem">
+    <Setter Property="Padding" Value="14,10" />
   </Style>
 </Styles>

--- a/src/XcaNet.App/ViewModels/AuthoringDialogKind.cs
+++ b/src/XcaNet.App/ViewModels/AuthoringDialogKind.cs
@@ -1,0 +1,8 @@
+namespace XcaNet.App.ViewModels;
+
+public enum AuthoringDialogKind
+{
+    None = 0,
+    Certificate = 1,
+    Template = 2
+}

--- a/src/XcaNet.App/ViewModels/Pages/CertificateAuthoringViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateAuthoringViewModel.cs
@@ -1,0 +1,409 @@
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using XcaNet.Contracts.Browser;
+using XcaNet.Contracts.Crypto;
+
+namespace XcaNet.App.ViewModels.Pages;
+
+public sealed class CertificateAuthoringViewModel : ViewModelBase
+{
+    private string _title;
+    private string _operationModeSummary;
+    private string _sourceSummary;
+    private string _displayName;
+    private string _subjectName;
+    private string _subjectAlternativeNames;
+    private KeyAlgorithmKind _keyAlgorithm;
+    private int _rsaKeySize;
+    private EllipticCurveKind _curve;
+    private string _signatureAlgorithm;
+    private int _validityDays;
+    private bool _isCertificateAuthority;
+    private bool _hasPathLengthConstraint;
+    private int _pathLengthConstraint;
+    private string _keyUsages;
+    private string _enhancedKeyUsages;
+    private bool _showTemplateApplication;
+    private bool _showKeySection;
+    private bool _showSigningSection;
+    private bool _showValiditySection;
+    private bool _showSignatureAlgorithm;
+    private string _primaryActionLabel;
+    private TemplateListItem? _selectedTemplate;
+    private TemplateApplicationModeView _selectedTemplateApplicationMode;
+    private CertificateListItem? _selectedIssuerCertificate;
+    private PrivateKeyListItem? _selectedIssuerPrivateKey;
+    private ICommand? _applyTemplateCommand;
+    private ICommand? _primaryActionCommand;
+
+    public CertificateAuthoringViewModel(
+        string title,
+        string operationModeSummary,
+        string sourceSummary,
+        string displayName,
+        string subjectName,
+        int validityDays,
+        bool isCertificateAuthority,
+        string keyUsages,
+        string enhancedKeyUsages,
+        bool showTemplateApplication,
+        bool showKeySection,
+        bool showSigningSection,
+        bool showValiditySection,
+        bool showSignatureAlgorithm,
+        string primaryActionLabel)
+    {
+        _title = title;
+        _operationModeSummary = operationModeSummary;
+        _sourceSummary = sourceSummary;
+        _displayName = displayName;
+        _subjectName = subjectName;
+        _validityDays = validityDays;
+        _isCertificateAuthority = isCertificateAuthority;
+        _keyUsages = keyUsages;
+        _enhancedKeyUsages = enhancedKeyUsages;
+        _showTemplateApplication = showTemplateApplication;
+        _showKeySection = showKeySection;
+        _showSigningSection = showSigningSection;
+        _showValiditySection = showValiditySection;
+        _showSignatureAlgorithm = showSignatureAlgorithm;
+        _primaryActionLabel = primaryActionLabel;
+        _subjectAlternativeNames = string.Empty;
+        _keyAlgorithm = KeyAlgorithmKind.Rsa;
+        _rsaKeySize = 3072;
+        _curve = EllipticCurveKind.P256;
+        _signatureAlgorithm = "SHA-256";
+        _selectedTemplateApplicationMode = TemplateApplicationModeView.Full;
+    }
+
+    public IReadOnlyList<KeyAlgorithmKind> KeyAlgorithms { get; } = [KeyAlgorithmKind.Rsa, KeyAlgorithmKind.Ecdsa];
+
+    public IReadOnlyList<EllipticCurveKind> Curves { get; } = [EllipticCurveKind.P256, EllipticCurveKind.P384];
+
+    public IReadOnlyList<TemplateApplicationModeView> TemplateApplicationModes { get; } =
+        [TemplateApplicationModeView.Full, TemplateApplicationModeView.SubjectOnly, TemplateApplicationModeView.ExtensionsOnly];
+
+    public ObservableCollection<TemplateListItem> Templates { get; } = [];
+
+    public ObservableCollection<CertificateListItem> IssuerCertificates { get; } = [];
+
+    public ObservableCollection<PrivateKeyListItem> IssuerPrivateKeys { get; } = [];
+
+    public string Title
+    {
+        get => _title;
+        set => SetProperty(ref _title, value);
+    }
+
+    public string OperationModeSummary
+    {
+        get => _operationModeSummary;
+        set => SetProperty(ref _operationModeSummary, value);
+    }
+
+    public string SourceSummary
+    {
+        get => _sourceSummary;
+        set => SetProperty(ref _sourceSummary, value);
+    }
+
+    public string DisplayName
+    {
+        get => _displayName;
+        set => SetProperty(ref _displayName, value);
+    }
+
+    public string SubjectName
+    {
+        get => _subjectName;
+        set => SetProperty(ref _subjectName, value);
+    }
+
+    public string SubjectAlternativeNames
+    {
+        get => _subjectAlternativeNames;
+        set => SetProperty(ref _subjectAlternativeNames, value);
+    }
+
+    public KeyAlgorithmKind KeyAlgorithm
+    {
+        get => _keyAlgorithm;
+        set
+        {
+            if (SetProperty(ref _keyAlgorithm, value))
+            {
+                OnPropertyChanged(nameof(IsRsa));
+                OnPropertyChanged(nameof(IsEcdsa));
+            }
+        }
+    }
+
+    public bool IsRsa => KeyAlgorithm == KeyAlgorithmKind.Rsa;
+
+    public bool IsEcdsa => KeyAlgorithm == KeyAlgorithmKind.Ecdsa;
+
+    public int RsaKeySize
+    {
+        get => _rsaKeySize;
+        set => SetProperty(ref _rsaKeySize, value);
+    }
+
+    public EllipticCurveKind Curve
+    {
+        get => _curve;
+        set => SetProperty(ref _curve, value);
+    }
+
+    public string SignatureAlgorithm
+    {
+        get => _signatureAlgorithm;
+        set => SetProperty(ref _signatureAlgorithm, value);
+    }
+
+    public int ValidityDays
+    {
+        get => _validityDays;
+        set => SetProperty(ref _validityDays, value);
+    }
+
+    public bool IsCertificateAuthority
+    {
+        get => _isCertificateAuthority;
+        set => SetProperty(ref _isCertificateAuthority, value);
+    }
+
+    public bool HasPathLengthConstraint
+    {
+        get => _hasPathLengthConstraint;
+        set => SetProperty(ref _hasPathLengthConstraint, value);
+    }
+
+    public int PathLengthConstraint
+    {
+        get => _pathLengthConstraint;
+        set => SetProperty(ref _pathLengthConstraint, value);
+    }
+
+    public string KeyUsages
+    {
+        get => _keyUsages;
+        set => SetProperty(ref _keyUsages, value);
+    }
+
+    public string EnhancedKeyUsages
+    {
+        get => _enhancedKeyUsages;
+        set => SetProperty(ref _enhancedKeyUsages, value);
+    }
+
+    public bool ShowTemplateApplication
+    {
+        get => _showTemplateApplication;
+        set => SetProperty(ref _showTemplateApplication, value);
+    }
+
+    public bool ShowKeySection
+    {
+        get => _showKeySection;
+        set => SetProperty(ref _showKeySection, value);
+    }
+
+    public bool ShowSigningSection
+    {
+        get => _showSigningSection;
+        set => SetProperty(ref _showSigningSection, value);
+    }
+
+    public bool ShowValiditySection
+    {
+        get => _showValiditySection;
+        set => SetProperty(ref _showValiditySection, value);
+    }
+
+    public bool ShowSignatureAlgorithm
+    {
+        get => _showSignatureAlgorithm;
+        set => SetProperty(ref _showSignatureAlgorithm, value);
+    }
+
+    public string PrimaryActionLabel
+    {
+        get => _primaryActionLabel;
+        set => SetProperty(ref _primaryActionLabel, value);
+    }
+
+    public TemplateListItem? SelectedTemplate
+    {
+        get => _selectedTemplate;
+        set => SetProperty(ref _selectedTemplate, value);
+    }
+
+    public TemplateApplicationModeView SelectedTemplateApplicationMode
+    {
+        get => _selectedTemplateApplicationMode;
+        set => SetProperty(ref _selectedTemplateApplicationMode, value);
+    }
+
+    public CertificateListItem? SelectedIssuerCertificate
+    {
+        get => _selectedIssuerCertificate;
+        set => SetProperty(ref _selectedIssuerCertificate, value);
+    }
+
+    public PrivateKeyListItem? SelectedIssuerPrivateKey
+    {
+        get => _selectedIssuerPrivateKey;
+        set => SetProperty(ref _selectedIssuerPrivateKey, value);
+    }
+
+    public ICommand? ApplyTemplateCommand
+    {
+        get => _applyTemplateCommand;
+        set => SetProperty(ref _applyTemplateCommand, value);
+    }
+
+    public ICommand? PrimaryActionCommand
+    {
+        get => _primaryActionCommand;
+        set => SetProperty(ref _primaryActionCommand, value);
+    }
+
+    public void SetTemplates(IEnumerable<TemplateListItem> templates)
+    {
+        Templates.Clear();
+        foreach (var template in templates)
+        {
+            Templates.Add(template);
+        }
+
+        SelectedTemplate = Templates.FirstOrDefault(x => SelectedTemplate is not null && x.TemplateId == SelectedTemplate.TemplateId)
+            ?? Templates.FirstOrDefault();
+    }
+
+    public void SetIssuers(IEnumerable<CertificateListItem> certificates, IEnumerable<PrivateKeyListItem> privateKeys)
+    {
+        IssuerCertificates.Clear();
+        foreach (var certificate in certificates.Where(x => x.IsCertificateAuthority))
+        {
+            IssuerCertificates.Add(certificate);
+        }
+
+        IssuerPrivateKeys.Clear();
+        foreach (var privateKey in privateKeys)
+        {
+            IssuerPrivateKeys.Add(privateKey);
+        }
+
+        SelectedIssuerCertificate = IssuerCertificates.FirstOrDefault(x => SelectedIssuerCertificate is not null && x.CertificateId == SelectedIssuerCertificate.CertificateId)
+            ?? IssuerCertificates.FirstOrDefault();
+        SelectedIssuerPrivateKey = IssuerPrivateKeys.FirstOrDefault(x => SelectedIssuerPrivateKey is not null && x.PrivateKeyId == SelectedIssuerPrivateKey.PrivateKeyId)
+            ?? IssuerPrivateKeys.FirstOrDefault();
+    }
+
+    public void ApplyTemplateDefaults(AppliedTemplateDefaults defaults)
+    {
+        switch (SelectedTemplateApplicationMode)
+        {
+            case TemplateApplicationModeView.Full:
+                DisplayName = defaults.DisplayNameDefault;
+                SubjectName = defaults.SubjectDefault ?? SubjectName;
+                SubjectAlternativeNames = string.Join(", ", defaults.SubjectAlternativeNames);
+                KeyAlgorithm = defaults.KeyAlgorithm;
+                RsaKeySize = defaults.RsaKeySize ?? RsaKeySize;
+                Curve = defaults.Curve ?? Curve;
+                SignatureAlgorithm = defaults.SignatureAlgorithm;
+                ValidityDays = Math.Max(1, defaults.ValidityDays);
+                IsCertificateAuthority = defaults.IsCertificateAuthority;
+                HasPathLengthConstraint = defaults.PathLengthConstraint.HasValue;
+                PathLengthConstraint = defaults.PathLengthConstraint ?? 0;
+                KeyUsages = string.Join(", ", defaults.KeyUsages);
+                EnhancedKeyUsages = string.Join(", ", defaults.EnhancedKeyUsages);
+                break;
+            case TemplateApplicationModeView.SubjectOnly:
+                SubjectName = defaults.SubjectDefault ?? SubjectName;
+                SubjectAlternativeNames = string.Join(", ", defaults.SubjectAlternativeNames);
+                break;
+            case TemplateApplicationModeView.ExtensionsOnly:
+                IsCertificateAuthority = defaults.IsCertificateAuthority;
+                HasPathLengthConstraint = defaults.PathLengthConstraint.HasValue;
+                PathLengthConstraint = defaults.PathLengthConstraint ?? 0;
+                KeyUsages = string.Join(", ", defaults.KeyUsages);
+                EnhancedKeyUsages = string.Join(", ", defaults.EnhancedKeyUsages);
+                break;
+        }
+    }
+
+    public void LoadFromTemplate(TemplateDetails template)
+    {
+        SubjectName = template.SubjectDefault ?? string.Empty;
+        SubjectAlternativeNames = string.Join(", ", template.SubjectAlternativeNames);
+        KeyAlgorithm = template.KeyAlgorithm;
+        RsaKeySize = template.RsaKeySize ?? 3072;
+        Curve = template.Curve ?? EllipticCurveKind.P256;
+        SignatureAlgorithm = template.SignatureAlgorithm;
+        ValidityDays = template.ValidityDays;
+        IsCertificateAuthority = template.IsCertificateAuthority;
+        HasPathLengthConstraint = template.PathLengthConstraint.HasValue;
+        PathLengthConstraint = template.PathLengthConstraint ?? 0;
+        KeyUsages = string.Join(", ", template.KeyUsages);
+        EnhancedKeyUsages = string.Join(", ", template.EnhancedKeyUsages);
+    }
+
+    public void LoadFromCertificate(CertificateListItem certificate, CertificateInspectorData? inspector)
+    {
+        DisplayName = $"{certificate.DisplayName} Template";
+        SubjectName = inspector?.Raw.Subject ?? certificate.Subject;
+        SubjectAlternativeNames = string.Join(", ", inspector?.Extensions.SubjectAlternativeNames ?? []);
+        KeyAlgorithm = ParseKeyAlgorithm(certificate.KeyAlgorithm);
+        SignatureAlgorithm = "SHA-256";
+        ValidityDays = BuildValidityDays(certificate.NotBefore, certificate.NotAfter, ValidityDays);
+        IsCertificateAuthority = certificate.IsCertificateAuthority;
+        HasPathLengthConstraint = false;
+        PathLengthConstraint = 0;
+        KeyUsages = string.Join(", ", inspector?.Extensions.KeyUsages ?? []);
+        EnhancedKeyUsages = string.Join(", ", inspector?.Extensions.EnhancedKeyUsages ?? []);
+        SourceSummary = $"Source: certificate {certificate.DisplayName}";
+    }
+
+    public void LoadFromCertificateRequest(CertificateRequestListItem request)
+    {
+        DisplayName = $"{request.DisplayName} Template";
+        SubjectName = request.Subject;
+        SubjectAlternativeNames = request.SubjectAlternativeNames;
+        KeyAlgorithm = ParseKeyAlgorithm(request.KeyAlgorithm);
+        SourceSummary = $"Source: request {request.DisplayName}";
+    }
+
+    public void ResetForNewTemplateSource(string sourceSummary)
+    {
+        SourceSummary = sourceSummary;
+        DisplayName = "Template";
+        SubjectName = string.Empty;
+        SubjectAlternativeNames = string.Empty;
+        KeyAlgorithm = KeyAlgorithmKind.Rsa;
+        RsaKeySize = 3072;
+        Curve = EllipticCurveKind.P256;
+        SignatureAlgorithm = "SHA-256";
+        ValidityDays = 365;
+        IsCertificateAuthority = false;
+        HasPathLengthConstraint = false;
+        PathLengthConstraint = 0;
+        KeyUsages = "DigitalSignature, KeyEncipherment";
+        EnhancedKeyUsages = "Server Authentication";
+    }
+
+    private static int BuildValidityDays(DateTimeOffset? notBefore, DateTimeOffset? notAfter, int fallback)
+    {
+        if (notBefore is null || notAfter is null)
+        {
+            return fallback;
+        }
+
+        return Math.Max(1, (int)Math.Round((notAfter.Value - notBefore.Value).TotalDays, MidpointRounding.AwayFromZero));
+    }
+
+    private static KeyAlgorithmKind ParseKeyAlgorithm(string keyAlgorithm)
+        => keyAlgorithm.Contains("ECDSA", StringComparison.OrdinalIgnoreCase)
+            ? KeyAlgorithmKind.Ecdsa
+            : KeyAlgorithmKind.Rsa;
+}

--- a/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
@@ -52,6 +52,8 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
 
     public ICommand? SignSelectedCommand { get; set; }
 
+    public ICommand? OpenIssuanceAuthoringCommand { get; set; }
+
     public ICommand? ExportSelectedCommand { get; set; }
 
     public ICommand? ExportSelectedToFileCommand { get; set; }

--- a/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using System.Windows.Input;
 using XcaNet.Contracts.Browser;
 
@@ -6,11 +5,6 @@ namespace XcaNet.App.ViewModels.Pages;
 
 public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewModelBase<CertificateRequestListItem, Guid>
 {
-    private CertificateListItem? _selectedIssuerCertificate;
-    private PrivateKeyListItem? _selectedIssuerPrivateKey;
-    private string _issuedCertificateDisplayName = "Issued Certificate";
-    private int _validityDays = 365;
-    private TemplateListItem? _selectedIssuanceTemplate;
     private CryptoFormatView _selectedExportFormat = CryptoFormatView.Pem;
     private string _exportPreview = string.Empty;
 
@@ -21,43 +15,28 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
         EmptyStateMessage = "Create a CSR from the Private Keys page or import request files to review and sign them.";
     }
 
-    public ObservableCollection<CertificateListItem> IssuerCertificates { get; } = [];
+    public CertificateAuthoringViewModel IssuanceAuthoring { get; } = new(
+        "Certificate Input",
+        "Operation: sign selected request into a certificate",
+        "Source: selected certificate request",
+        "Issued Certificate",
+        "CN=issued.example.test",
+        365,
+        false,
+        "DigitalSignature, KeyEncipherment",
+        "Server Authentication",
+        true,
+        false,
+        true,
+        true,
+        true,
+        "Sign CSR");
 
-    public ObservableCollection<PrivateKeyListItem> IssuerPrivateKeys { get; } = [];
+    public IReadOnlyList<CertificateListItem> IssuerCertificates => IssuanceAuthoring.IssuerCertificates;
 
-    public ObservableCollection<TemplateListItem> IssuanceTemplates { get; } = [];
+    public IReadOnlyList<PrivateKeyListItem> IssuerPrivateKeys => IssuanceAuthoring.IssuerPrivateKeys;
 
     public IReadOnlyList<CryptoFormatView> ExportFormats { get; } = [CryptoFormatView.Pem, CryptoFormatView.Der, CryptoFormatView.Pkcs10];
-
-    public CertificateListItem? SelectedIssuerCertificate
-    {
-        get => _selectedIssuerCertificate;
-        set => SetProperty(ref _selectedIssuerCertificate, value);
-    }
-
-    public PrivateKeyListItem? SelectedIssuerPrivateKey
-    {
-        get => _selectedIssuerPrivateKey;
-        set => SetProperty(ref _selectedIssuerPrivateKey, value);
-    }
-
-    public string IssuedCertificateDisplayName
-    {
-        get => _issuedCertificateDisplayName;
-        set => SetProperty(ref _issuedCertificateDisplayName, value);
-    }
-
-    public int ValidityDays
-    {
-        get => _validityDays;
-        set => SetProperty(ref _validityDays, value);
-    }
-
-    public TemplateListItem? SelectedIssuanceTemplate
-    {
-        get => _selectedIssuanceTemplate;
-        set => SetProperty(ref _selectedIssuanceTemplate, value);
-    }
 
     public CryptoFormatView SelectedExportFormat
     {
@@ -81,35 +60,20 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
 
     public ICommand? ApplyIssuanceTemplateCommand { get; set; }
 
+    public ICommand? CreateTemplateFromRequestCommand { get; set; }
+
+    public ICommand? CreateSimilarRequestCommand { get; set; }
+
     public void SetIssuers(IEnumerable<CertificateListItem> certificates, IEnumerable<PrivateKeyListItem> privateKeys)
     {
-        IssuerCertificates.Clear();
-        foreach (var certificate in certificates.Where(x => x.IsCertificateAuthority))
-        {
-            IssuerCertificates.Add(certificate);
-        }
-
-        IssuerPrivateKeys.Clear();
-        foreach (var privateKey in privateKeys)
-        {
-            IssuerPrivateKeys.Add(privateKey);
-        }
-
-        SelectedIssuerCertificate ??= IssuerCertificates.FirstOrDefault();
-        SelectedIssuerPrivateKey ??= IssuerPrivateKeys.FirstOrDefault();
+        IssuanceAuthoring.SetIssuers(certificates, privateKeys);
     }
 
     public void SetTemplates(IEnumerable<TemplateListItem> templates)
     {
-        IssuanceTemplates.Clear();
-        foreach (var template in templates.Where(x => x.IsEnabled && (
-                     x.IntendedUsage == TemplateIntendedUsage.IntermediateCa
-                     || x.IntendedUsage == TemplateIntendedUsage.EndEntityCertificate)))
-        {
-            IssuanceTemplates.Add(template);
-        }
-
-        SelectedIssuanceTemplate ??= IssuanceTemplates.FirstOrDefault();
+        IssuanceAuthoring.SetTemplates(templates.Where(x => x.IsEnabled && (
+            x.IntendedUsage == TemplateIntendedUsage.IntermediateCa
+            || x.IntendedUsage == TemplateIntendedUsage.EndEntityCertificate)));
     }
 
     protected override Guid GetItemId(CertificateRequestListItem item) => item.CertificateSigningRequestId;

--- a/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
@@ -9,7 +9,7 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
     private string _exportPreview = string.Empty;
 
     public CertificateRequestsPageViewModel()
-        : base("CSRs")
+        : base("Certificate signing requests")
     {
         EmptyStateTitle = "No certificate signing requests";
         EmptyStateMessage = "Create a CSR from the Private Keys page or import request files to review and sign them.";

--- a/src/XcaNet.App/ViewModels/Pages/CertificateRevocationListsPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateRevocationListsPageViewModel.cs
@@ -9,7 +9,7 @@ public sealed class CertificateRevocationListsPageViewModel : SelectableItemsPag
     private CertificateRevocationListInspectorData? _inspector;
 
     public CertificateRevocationListsPageViewModel()
-        : base("CRLs")
+        : base("Revocation lists")
     {
         EmptyStateTitle = "No CRLs available";
         EmptyStateMessage = "Generate a CRL from a CA certificate after revoking one or more issued certificates.";

--- a/src/XcaNet.App/ViewModels/Pages/CertificatesPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificatesPageViewModel.cs
@@ -165,5 +165,7 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
 
     public ICommand? OpenChildCertificateCommand { get; set; }
 
+    public ICommand? CreateTemplateFromCertificateCommand { get; set; }
+
     protected override Guid GetItemId(CertificateListItem item) => item.CertificateId;
 }

--- a/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
@@ -9,14 +9,6 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
     private string _newKeyDisplayName = "Managed Key";
     private KeyAlgorithmView _selectedAlgorithm = KeyAlgorithmView.Rsa;
     private EllipticCurveView _selectedCurve = EllipticCurveView.P256;
-    private string _selfSignedCaDisplayName = "Self-Signed CA";
-    private string _selfSignedCaSubjectName = "CN=XcaNet Root CA";
-    private int _selfSignedCaValidityDays = 3650;
-    private TemplateListItem? _selectedSelfSignedCaTemplate;
-    private string _certificateSigningRequestDisplayName = "Certificate Signing Request";
-    private string _certificateSigningRequestSubjectName = "CN=service.example.test";
-    private string _certificateSigningRequestSubjectAlternativeNames = "service.example.test";
-    private TemplateListItem? _selectedCertificateSigningRequestTemplate;
     private CryptoFormatView _selectedExportFormat = CryptoFormatView.Pem;
     private string _selectedExportPassword = string.Empty;
     private string _exportPreview = string.Empty;
@@ -34,9 +26,39 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
 
     public IReadOnlyList<CryptoFormatView> ExportFormats { get; } = [CryptoFormatView.Pem, CryptoFormatView.Der, CryptoFormatView.Pkcs8];
 
-    public ObservableCollection<TemplateListItem> SelfSignedCaTemplates { get; } = [];
+    public CertificateAuthoringViewModel SelfSignedCaAuthoring { get; } = new(
+        "Certificate Input",
+        "Operation: create self-signed CA certificate",
+        "Source: selected private key",
+        "Self-Signed CA",
+        "CN=XcaNet Root CA",
+        3650,
+        true,
+        "KeyCertSign, CrlSign, DigitalSignature",
+        string.Empty,
+        true,
+        false,
+        false,
+        true,
+        true,
+        "Create CA");
 
-    public ObservableCollection<TemplateListItem> CertificateSigningRequestTemplates { get; } = [];
+    public CertificateAuthoringViewModel CertificateSigningRequestAuthoring { get; } = new(
+        "Certificate Input",
+        "Operation: create certificate signing request",
+        "Source: selected private key",
+        "Certificate Signing Request",
+        "CN=service.example.test",
+        365,
+        false,
+        "DigitalSignature, KeyEncipherment",
+        "Server Authentication",
+        true,
+        true,
+        false,
+        false,
+        true,
+        "Create CSR");
 
     public string NewKeyDisplayName
     {
@@ -54,54 +76,6 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
     {
         get => _selectedCurve;
         set => SetProperty(ref _selectedCurve, value);
-    }
-
-    public string SelfSignedCaDisplayName
-    {
-        get => _selfSignedCaDisplayName;
-        set => SetProperty(ref _selfSignedCaDisplayName, value);
-    }
-
-    public string SelfSignedCaSubjectName
-    {
-        get => _selfSignedCaSubjectName;
-        set => SetProperty(ref _selfSignedCaSubjectName, value);
-    }
-
-    public int SelfSignedCaValidityDays
-    {
-        get => _selfSignedCaValidityDays;
-        set => SetProperty(ref _selfSignedCaValidityDays, value);
-    }
-
-    public TemplateListItem? SelectedSelfSignedCaTemplate
-    {
-        get => _selectedSelfSignedCaTemplate;
-        set => SetProperty(ref _selectedSelfSignedCaTemplate, value);
-    }
-
-    public string CertificateSigningRequestDisplayName
-    {
-        get => _certificateSigningRequestDisplayName;
-        set => SetProperty(ref _certificateSigningRequestDisplayName, value);
-    }
-
-    public string CertificateSigningRequestSubjectName
-    {
-        get => _certificateSigningRequestSubjectName;
-        set => SetProperty(ref _certificateSigningRequestSubjectName, value);
-    }
-
-    public string CertificateSigningRequestSubjectAlternativeNames
-    {
-        get => _certificateSigningRequestSubjectAlternativeNames;
-        set => SetProperty(ref _certificateSigningRequestSubjectAlternativeNames, value);
-    }
-
-    public TemplateListItem? SelectedCertificateSigningRequestTemplate
-    {
-        get => _selectedCertificateSigningRequestTemplate;
-        set => SetProperty(ref _selectedCertificateSigningRequestTemplate, value);
     }
 
     public CryptoFormatView SelectedExportFormat
@@ -138,16 +112,20 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
 
     public void SetTemplates(IEnumerable<TemplateListItem> templates)
     {
-        ResetTemplateCollection(SelfSignedCaTemplates, templates.Where(x => x.IntendedUsage == TemplateIntendedUsage.SelfSignedCa && x.IsEnabled));
+        ResetTemplateCollection(SelfSignedCaAuthoring.Templates, templates.Where(x => x.IntendedUsage == TemplateIntendedUsage.SelfSignedCa && x.IsEnabled));
         ResetTemplateCollection(
-            CertificateSigningRequestTemplates,
+            CertificateSigningRequestAuthoring.Templates,
             templates.Where(x => x.IsEnabled && (
                 x.IntendedUsage == TemplateIntendedUsage.IntermediateCa
                 || x.IntendedUsage == TemplateIntendedUsage.EndEntityCertificate
                 || x.IntendedUsage == TemplateIntendedUsage.CertificateSigningRequest)));
+    }
 
-        SelectedSelfSignedCaTemplate ??= SelfSignedCaTemplates.FirstOrDefault();
-        SelectedCertificateSigningRequestTemplate ??= CertificateSigningRequestTemplates.FirstOrDefault();
+    public void LoadCertificateSigningRequestAuthoringFromRequest(CertificateRequestListItem request)
+    {
+        CertificateSigningRequestAuthoring.LoadFromCertificateRequest(request);
+        CertificateSigningRequestAuthoring.DisplayName = $"{request.DisplayName} Copy";
+        CertificateSigningRequestAuthoring.SourceSummary = $"Source: similar request {request.DisplayName}";
     }
 
     private static void ResetTemplateCollection(ObservableCollection<TemplateListItem> target, IEnumerable<TemplateListItem> templates)

--- a/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
@@ -102,6 +102,10 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
 
     public ICommand? CreateCertificateSigningRequestCommand { get; set; }
 
+    public ICommand? OpenSelfSignedCaAuthoringCommand { get; set; }
+
+    public ICommand? OpenCertificateSigningRequestAuthoringCommand { get; set; }
+
     public ICommand? ApplySelfSignedCaTemplateCommand { get; set; }
 
     public ICommand? ApplyCertificateSigningRequestTemplateCommand { get; set; }

--- a/src/XcaNet.App/ViewModels/Pages/TemplateApplicationModeView.cs
+++ b/src/XcaNet.App/ViewModels/Pages/TemplateApplicationModeView.cs
@@ -1,0 +1,8 @@
+namespace XcaNet.App.ViewModels.Pages;
+
+public enum TemplateApplicationModeView
+{
+    Full = 0,
+    SubjectOnly = 1,
+    ExtensionsOnly = 2
+}

--- a/src/XcaNet.App/ViewModels/Pages/TemplatesPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/TemplatesPageViewModel.cs
@@ -15,18 +15,6 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
     private bool _isFavorite;
     private bool _isEnabled = true;
     private TemplateIntendedUsage _intendedUsage = TemplateIntendedUsage.EndEntityCertificate;
-    private string _subjectDefault = string.Empty;
-    private string _subjectAlternativeNames = string.Empty;
-    private KeyAlgorithmKind _keyAlgorithm = KeyAlgorithmKind.Rsa;
-    private int _rsaKeySize = 3072;
-    private EllipticCurveKind _curve = EllipticCurveKind.P256;
-    private string _signatureAlgorithm = "SHA-256";
-    private int _validityDays = 365;
-    private bool _isCertificateAuthority;
-    private int _pathLengthConstraint = 0;
-    private bool _hasPathLengthConstraint;
-    private string _keyUsages = "DigitalSignature";
-    private string _enhancedKeyUsages = "Server Authentication";
     private string _validationSummary = string.Empty;
     private string _previewSummary = "Template preview will appear here.";
 
@@ -35,9 +23,27 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
     {
         EmptyStateTitle = "No templates saved";
         EmptyStateMessage = "Create a template to speed up CA, CSR, and issuance workflows.";
+        Authoring.PropertyChanged += (_, _) => UpdatePreview();
         UpdateUsageDefaults();
         UpdatePreview();
     }
+
+    public CertificateAuthoringViewModel Authoring { get; } = new(
+        "Certificate Input",
+        "Operation: edit or derive template defaults",
+        "Source: template editor",
+        "Template",
+        string.Empty,
+        365,
+        false,
+        "DigitalSignature, KeyEncipherment",
+        "Server Authentication",
+        false,
+        true,
+        false,
+        true,
+        true,
+        "Save Template");
 
     public IReadOnlyList<TemplateIntendedUsage> IntendedUsages { get; } =
     [
@@ -46,10 +52,6 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
         TemplateIntendedUsage.EndEntityCertificate,
         TemplateIntendedUsage.CertificateSigningRequest
     ];
-
-    public IReadOnlyList<KeyAlgorithmKind> KeyAlgorithms { get; } = [KeyAlgorithmKind.Rsa, KeyAlgorithmKind.Ecdsa];
-
-    public IReadOnlyList<EllipticCurveKind> Curves { get; } = [EllipticCurveKind.P256, EllipticCurveKind.P384];
 
     public IReadOnlyList<TemplateStatusFilterView> StatusFilters { get; } = [TemplateStatusFilterView.EnabledOnly, TemplateStatusFilterView.DisabledOnly, TemplateStatusFilterView.All];
 
@@ -141,132 +143,6 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
         }
     }
 
-    public string SubjectDefault
-    {
-        get => _subjectDefault;
-        set
-        {
-            if (SetProperty(ref _subjectDefault, value))
-            {
-                UpdatePreview();
-            }
-        }
-    }
-
-    public string SubjectAlternativeNames
-    {
-        get => _subjectAlternativeNames;
-        set
-        {
-            if (SetProperty(ref _subjectAlternativeNames, value))
-            {
-                UpdatePreview();
-            }
-        }
-    }
-
-    public KeyAlgorithmKind KeyAlgorithm
-    {
-        get => _keyAlgorithm;
-        set
-        {
-            if (SetProperty(ref _keyAlgorithm, value))
-            {
-                UpdatePreview();
-            }
-        }
-    }
-
-    public int RsaKeySize
-    {
-        get => _rsaKeySize;
-        set
-        {
-            if (SetProperty(ref _rsaKeySize, value))
-            {
-                UpdatePreview();
-            }
-        }
-    }
-
-    public EllipticCurveKind Curve
-    {
-        get => _curve;
-        set
-        {
-            if (SetProperty(ref _curve, value))
-            {
-                UpdatePreview();
-            }
-        }
-    }
-
-    public string SignatureAlgorithm
-    {
-        get => _signatureAlgorithm;
-        set => SetProperty(ref _signatureAlgorithm, value);
-    }
-
-    public int ValidityDays
-    {
-        get => _validityDays;
-        set
-        {
-            if (SetProperty(ref _validityDays, value))
-            {
-                UpdatePreview();
-            }
-        }
-    }
-
-    public bool IsCertificateAuthority
-    {
-        get => _isCertificateAuthority;
-        set
-        {
-            if (SetProperty(ref _isCertificateAuthority, value))
-            {
-                UpdatePreview();
-            }
-        }
-    }
-
-    public int PathLengthConstraint
-    {
-        get => _pathLengthConstraint;
-        set => SetProperty(ref _pathLengthConstraint, value);
-    }
-
-    public bool HasPathLengthConstraint
-    {
-        get => _hasPathLengthConstraint;
-        set => SetProperty(ref _hasPathLengthConstraint, value);
-    }
-
-    public string KeyUsages
-    {
-        get => _keyUsages;
-        set
-        {
-            if (SetProperty(ref _keyUsages, value))
-            {
-                UpdatePreview();
-            }
-        }
-    }
-
-    public string EnhancedKeyUsages
-    {
-        get => _enhancedKeyUsages;
-        set
-        {
-            if (SetProperty(ref _enhancedKeyUsages, value))
-            {
-                UpdatePreview();
-            }
-        }
-    }
-
     public string ValidationSummary
     {
         get => _validationSummary;
@@ -309,18 +185,8 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
         IsFavorite = template.IsFavorite;
         IsEnabled = template.IsEnabled;
         IntendedUsage = template.IntendedUsage;
-        SubjectDefault = template.SubjectDefault ?? string.Empty;
-        SubjectAlternativeNames = string.Join(", ", template.SubjectAlternativeNames);
-        KeyAlgorithm = template.KeyAlgorithm;
-        RsaKeySize = template.RsaKeySize ?? 3072;
-        Curve = template.Curve ?? EllipticCurveKind.P256;
-        SignatureAlgorithm = template.SignatureAlgorithm;
-        ValidityDays = template.ValidityDays;
-        IsCertificateAuthority = template.IsCertificateAuthority;
-        HasPathLengthConstraint = template.PathLengthConstraint.HasValue;
-        PathLengthConstraint = template.PathLengthConstraint ?? 0;
-        KeyUsages = string.Join(", ", template.KeyUsages);
-        EnhancedKeyUsages = string.Join(", ", template.EnhancedKeyUsages);
+        Authoring.LoadFromTemplate(template);
+        Authoring.SourceSummary = $"Source: saved template {template.Name}";
         ValidationSummary = BuildValidationSummary(template.Validation);
         PreviewSummary = string.Join(Environment.NewLine,
         [
@@ -343,19 +209,31 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
         IsFavorite = false;
         IsEnabled = true;
         IntendedUsage = TemplateIntendedUsage.EndEntityCertificate;
-        SubjectDefault = string.Empty;
-        SubjectAlternativeNames = string.Empty;
-        KeyAlgorithm = KeyAlgorithmKind.Rsa;
-        RsaKeySize = 3072;
-        Curve = EllipticCurveKind.P256;
-        SignatureAlgorithm = "SHA-256";
-        ValidityDays = 365;
-        HasPathLengthConstraint = false;
-        PathLengthConstraint = 0;
         ValidationSummary = string.Empty;
+        Authoring.ResetForNewTemplateSource("Source: new template definition");
         UpdateUsageDefaults();
         UpdatePreview();
         OnPropertyChanged(nameof(IsEditingExisting));
+    }
+
+    public void PrepareTemplateFromCertificate(CertificateListItem certificate, CertificateInspectorData? inspector)
+    {
+        PrepareNewTemplate();
+        Name = $"{certificate.DisplayName} derived template";
+        IntendedUsage = DetermineTemplateUsage(certificate, inspector);
+        Authoring.LoadFromCertificate(certificate, inspector);
+        UpdateUsageDefaults();
+        UpdatePreview();
+    }
+
+    public void PrepareTemplateFromCertificateRequest(CertificateRequestListItem request)
+    {
+        PrepareNewTemplate();
+        Name = $"{request.DisplayName} derived template";
+        IntendedUsage = TemplateIntendedUsage.CertificateSigningRequest;
+        Authoring.LoadFromCertificateRequest(request);
+        UpdateUsageDefaults();
+        UpdatePreview();
     }
 
     public SaveTemplateRequest BuildSaveRequest()
@@ -367,17 +245,17 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
             IsFavorite,
             IsEnabled,
             IntendedUsage,
-            SubjectDefault,
-            SplitValues(SubjectAlternativeNames),
-            KeyAlgorithm,
-            KeyAlgorithm == KeyAlgorithmKind.Rsa ? RsaKeySize : null,
-            KeyAlgorithm == KeyAlgorithmKind.Ecdsa ? Curve : null,
-            SignatureAlgorithm,
-            ValidityDays,
-            IsCertificateAuthority,
-            HasPathLengthConstraint ? PathLengthConstraint : null,
-            SplitValues(KeyUsages),
-            SplitValues(EnhancedKeyUsages));
+            Authoring.SubjectName,
+            SplitValues(Authoring.SubjectAlternativeNames),
+            Authoring.KeyAlgorithm,
+            Authoring.KeyAlgorithm == KeyAlgorithmKind.Rsa ? Authoring.RsaKeySize : null,
+            Authoring.KeyAlgorithm == KeyAlgorithmKind.Ecdsa ? Authoring.Curve : null,
+            Authoring.SignatureAlgorithm,
+            Authoring.ValidityDays,
+            Authoring.IsCertificateAuthority,
+            Authoring.HasPathLengthConstraint ? Authoring.PathLengthConstraint : null,
+            SplitValues(Authoring.KeyUsages),
+            SplitValues(Authoring.EnhancedKeyUsages));
     }
 
     protected override void OnItemsChanged()
@@ -411,36 +289,48 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
     {
         if (IntendedUsage is TemplateIntendedUsage.SelfSignedCa or TemplateIntendedUsage.IntermediateCa)
         {
-            IsCertificateAuthority = true;
-            KeyUsages = "KeyCertSign, CrlSign, DigitalSignature";
-            EnhancedKeyUsages = string.Empty;
-            ValidityDays = Math.Max(ValidityDays, 3650);
+            Authoring.IsCertificateAuthority = true;
+            Authoring.KeyUsages = "KeyCertSign, CrlSign, DigitalSignature";
+            Authoring.EnhancedKeyUsages = string.Empty;
+            Authoring.ValidityDays = Math.Max(Authoring.ValidityDays, 3650);
         }
         else
         {
-            IsCertificateAuthority = false;
-            KeyUsages = string.IsNullOrWhiteSpace(KeyUsages) || KeyUsages.Contains("KeyCertSign", StringComparison.OrdinalIgnoreCase)
+            Authoring.IsCertificateAuthority = false;
+            Authoring.KeyUsages = string.IsNullOrWhiteSpace(Authoring.KeyUsages) || Authoring.KeyUsages.Contains("KeyCertSign", StringComparison.OrdinalIgnoreCase)
                 ? "DigitalSignature, KeyEncipherment"
-                : KeyUsages;
-            EnhancedKeyUsages = string.IsNullOrWhiteSpace(EnhancedKeyUsages) ? "Server Authentication" : EnhancedKeyUsages;
-            ValidityDays = Math.Max(ValidityDays, 365);
+                : Authoring.KeyUsages;
+            Authoring.EnhancedKeyUsages = string.IsNullOrWhiteSpace(Authoring.EnhancedKeyUsages) ? "Server Authentication" : Authoring.EnhancedKeyUsages;
+            Authoring.ValidityDays = Math.Max(Authoring.ValidityDays, 365);
         }
     }
 
     private void UpdatePreview()
     {
-        var keySummary = KeyAlgorithm == KeyAlgorithmKind.Rsa ? $"RSA {RsaKeySize}" : $"ECDSA {Curve}";
+        var keySummary = Authoring.KeyAlgorithm == KeyAlgorithmKind.Rsa ? $"RSA {Authoring.RsaKeySize}" : $"ECDSA {Authoring.Curve}";
         PreviewSummary = string.Join(
             Environment.NewLine,
             [
                 $"Usage: {IntendedUsage}",
-                $"Subject: {(string.IsNullOrWhiteSpace(SubjectDefault) ? "not preset" : SubjectDefault)}",
-                $"SAN: {(string.IsNullOrWhiteSpace(SubjectAlternativeNames) ? "none" : SubjectAlternativeNames)}",
+                $"Subject: {(string.IsNullOrWhiteSpace(Authoring.SubjectName) ? "not preset" : Authoring.SubjectName)}",
+                $"SAN: {(string.IsNullOrWhiteSpace(Authoring.SubjectAlternativeNames) ? "none" : Authoring.SubjectAlternativeNames)}",
                 $"Key: {keySummary}",
-                $"Validity: {ValidityDays} day(s)",
-                $"Extensions: {(IsCertificateAuthority ? "CA" : "Leaf")} | KU: {KeyUsages}",
+                $"Validity: {Authoring.ValidityDays} day(s)",
+                $"Extensions: {(Authoring.IsCertificateAuthority ? "CA" : "Leaf")} | KU: {Authoring.KeyUsages}",
                 $"State: {(IsEnabled ? "Enabled" : "Disabled")} | {(IsFavorite ? "Favorite" : "Standard")}"
             ]);
+    }
+
+    private static TemplateIntendedUsage DetermineTemplateUsage(CertificateListItem certificate, CertificateInspectorData? inspector)
+    {
+        if (certificate.IsCertificateAuthority)
+        {
+            return inspector is not null && string.Equals(inspector.Raw.Subject, inspector.Raw.Issuer, StringComparison.OrdinalIgnoreCase)
+                ? TemplateIntendedUsage.SelfSignedCa
+                : TemplateIntendedUsage.IntermediateCa;
+        }
+
+        return TemplateIntendedUsage.EndEntityCertificate;
     }
 
     private static string BuildValidationSummary(TemplateValidationSummary validation)

--- a/src/XcaNet.App/ViewModels/Pages/TemplatesPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/TemplatesPageViewModel.cs
@@ -155,6 +155,12 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
         private set => SetProperty(ref _previewSummary, value);
     }
 
+    public string PreviewSubjectSummary => GetPreviewLine(1, "Subject: not preset");
+
+    public string PreviewExtensionSummary => GetPreviewLine(5, "Extensions: not preset");
+
+    public string PreviewStateSummary => GetPreviewLine(6, "State: standard");
+
     public bool IsEditingExisting => SelectedItem is not null;
 
     public ICommand? CreateNewCommand { get; set; }
@@ -200,6 +206,7 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
             template.Preview.ExtensionSummary,
             template.Preview.StateSummary
         ]);
+        RaisePreviewPropertiesChanged();
         OnPropertyChanged(nameof(IsEditingExisting));
     }
 
@@ -321,6 +328,7 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
                 $"Extensions: {(Authoring.IsCertificateAuthority ? "CA" : "Leaf")} | KU: {Authoring.KeyUsages}",
                 $"State: {(IsEnabled ? "Enabled" : "Disabled")} | {(IsFavorite ? "Favorite" : "Standard")}"
             ]);
+        RaisePreviewPropertiesChanged();
     }
 
     private static TemplateIntendedUsage DetermineTemplateUsage(CertificateListItem certificate, CertificateInspectorData? inspector)
@@ -352,4 +360,17 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
         => string.IsNullOrWhiteSpace(value)
             ? []
             : value.Split([',', ';', '\n'], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+    private string GetPreviewLine(int index, string fallback)
+    {
+        var lines = PreviewSummary.Split(Environment.NewLine, StringSplitOptions.None);
+        return index < lines.Length ? lines[index] : fallback;
+    }
+
+    private void RaisePreviewPropertiesChanged()
+    {
+        OnPropertyChanged(nameof(PreviewSubjectSummary));
+        OnPropertyChanged(nameof(PreviewExtensionSummary));
+        OnPropertyChanged(nameof(PreviewStateSummary));
+    }
 }

--- a/src/XcaNet.App/ViewModels/Pages/TemplatesPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/TemplatesPageViewModel.cs
@@ -159,6 +159,8 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
 
     public ICommand? CreateNewCommand { get; set; }
 
+    public ICommand? EditTemplateCommand { get; set; }
+
     public ICommand? SaveTemplateCommand { get; set; }
 
     public ICommand? CloneTemplateCommand { get; set; }

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -62,6 +62,9 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly AsyncCommand _applySelfSignedCaTemplateCommand;
     private readonly AsyncCommand _applyCertificateSigningRequestTemplateCommand;
     private readonly AsyncCommand _applyIssuanceTemplateCommand;
+    private readonly DelegateCommand _createTemplateFromCertificateCommand;
+    private readonly DelegateCommand _createTemplateFromRequestCommand;
+    private readonly DelegateCommand _createSimilarRequestCommand;
 
     private PageViewModelBase _currentPage;
     private string _subtitle = "Core UI workflows";
@@ -106,7 +109,7 @@ public sealed class ShellViewModel : ViewModelBase
         _exportPrivateKeyCommand = new AsyncCommand(ExportSelectedPrivateKeyAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
         _exportPrivateKeyToFileCommand = new AsyncCommand(ExportSelectedPrivateKeyToFileAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
         _refreshCertificateRequestsCommand = new AsyncCommand(LoadCertificateRequestsAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed);
-        _signCertificateSigningRequestCommand = new AsyncCommand(SignCertificateSigningRequestAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificateRequestsPage.HasSelection && CertificateRequestsPage.SelectedIssuerCertificate is not null && CertificateRequestsPage.SelectedIssuerPrivateKey is not null);
+        _signCertificateSigningRequestCommand = new AsyncCommand(SignCertificateSigningRequestAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificateRequestsPage.HasSelection && CertificateRequestsPage.IssuanceAuthoring.SelectedIssuerCertificate is not null && CertificateRequestsPage.IssuanceAuthoring.SelectedIssuerPrivateKey is not null);
         _exportCertificateSigningRequestCommand = new AsyncCommand(ExportSelectedCertificateSigningRequestAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificateRequestsPage.HasSelection);
         _exportCertificateSigningRequestToFileCommand = new AsyncCommand(ExportSelectedCertificateSigningRequestToFileAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificateRequestsPage.HasSelection);
         _navigateRequestPrivateKeyCommand = new DelegateCommand(() => NavigateTo(CertificateRequestsPage.SelectedItem?.PrivateKeyTarget), () => CertificateRequestsPage.SelectedItem?.PrivateKeyTarget is not null);
@@ -120,9 +123,12 @@ public sealed class ShellViewModel : ViewModelBase
         _toggleTemplateFavoriteCommand = new AsyncCommand(ToggleTemplateFavoriteAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
         _toggleTemplateEnabledCommand = new AsyncCommand(ToggleTemplateEnabledAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
         _deleteTemplateCommand = new AsyncCommand(DeleteTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
-        _applySelfSignedCaTemplateCommand = new AsyncCommand(ApplySelfSignedCaTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && PrivateKeysPage.SelectedSelfSignedCaTemplate is not null);
-        _applyCertificateSigningRequestTemplateCommand = new AsyncCommand(ApplyCertificateSigningRequestTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && PrivateKeysPage.SelectedCertificateSigningRequestTemplate is not null);
-        _applyIssuanceTemplateCommand = new AsyncCommand(ApplyIssuanceTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && CertificateRequestsPage.SelectedIssuanceTemplate is not null);
+        _applySelfSignedCaTemplateCommand = new AsyncCommand(ApplySelfSignedCaTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && PrivateKeysPage.SelfSignedCaAuthoring.SelectedTemplate is not null);
+        _applyCertificateSigningRequestTemplateCommand = new AsyncCommand(ApplyCertificateSigningRequestTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && PrivateKeysPage.CertificateSigningRequestAuthoring.SelectedTemplate is not null);
+        _applyIssuanceTemplateCommand = new AsyncCommand(ApplyIssuanceTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && CertificateRequestsPage.IssuanceAuthoring.SelectedTemplate is not null);
+        _createTemplateFromCertificateCommand = new DelegateCommand(CreateTemplateFromCertificate, () => CertificatesPage.SelectedItem is not null);
+        _createTemplateFromRequestCommand = new DelegateCommand(CreateTemplateFromRequest, () => CertificateRequestsPage.SelectedItem is not null);
+        _createSimilarRequestCommand = new DelegateCommand(CreateSimilarRequest, () => CertificateRequestsPage.SelectedItem is not null);
 
         SettingsSecurityPage.CreateDatabaseCommand = _createDatabaseCommand;
         SettingsSecurityPage.OpenDatabaseCommand = _openDatabaseCommand;
@@ -138,6 +144,7 @@ public sealed class ShellViewModel : ViewModelBase
         CertificatesPage.OpenIssuerCommand = _navigateIssuerCommand;
         CertificatesPage.OpenPrivateKeyCommand = _navigatePrivateKeyCommand;
         CertificatesPage.OpenChildCertificateCommand = _navigateChildCertificateCommand;
+        CertificatesPage.CreateTemplateFromCertificateCommand = _createTemplateFromCertificateCommand;
 
         PrivateKeysPage.RefreshCommand = _refreshPrivateKeysCommand;
         PrivateKeysPage.GenerateKeyCommand = _generateKeyCommand;
@@ -147,6 +154,10 @@ public sealed class ShellViewModel : ViewModelBase
         PrivateKeysPage.ApplyCertificateSigningRequestTemplateCommand = _applyCertificateSigningRequestTemplateCommand;
         PrivateKeysPage.ExportSelectedCommand = _exportPrivateKeyCommand;
         PrivateKeysPage.ExportSelectedToFileCommand = _exportPrivateKeyToFileCommand;
+        PrivateKeysPage.SelfSignedCaAuthoring.ApplyTemplateCommand = _applySelfSignedCaTemplateCommand;
+        PrivateKeysPage.SelfSignedCaAuthoring.PrimaryActionCommand = _createSelfSignedCaCommand;
+        PrivateKeysPage.CertificateSigningRequestAuthoring.ApplyTemplateCommand = _applyCertificateSigningRequestTemplateCommand;
+        PrivateKeysPage.CertificateSigningRequestAuthoring.PrimaryActionCommand = _createCertificateSigningRequestCommand;
 
         CertificateRequestsPage.RefreshCommand = _refreshCertificateRequestsCommand;
         CertificateRequestsPage.SignSelectedCommand = _signCertificateSigningRequestCommand;
@@ -154,6 +165,10 @@ public sealed class ShellViewModel : ViewModelBase
         CertificateRequestsPage.ExportSelectedCommand = _exportCertificateSigningRequestCommand;
         CertificateRequestsPage.ExportSelectedToFileCommand = _exportCertificateSigningRequestToFileCommand;
         CertificateRequestsPage.OpenSelectedPrivateKeyCommand = _navigateRequestPrivateKeyCommand;
+        CertificateRequestsPage.CreateTemplateFromRequestCommand = _createTemplateFromRequestCommand;
+        CertificateRequestsPage.CreateSimilarRequestCommand = _createSimilarRequestCommand;
+        CertificateRequestsPage.IssuanceAuthoring.ApplyTemplateCommand = _applyIssuanceTemplateCommand;
+        CertificateRequestsPage.IssuanceAuthoring.PrimaryActionCommand = _signCertificateSigningRequestCommand;
 
         CertificateRevocationListsPage.RefreshCommand = _refreshCertificateRevocationListsCommand;
         CertificateRevocationListsPage.ExportSelectedCommand = _exportCertificateRevocationListToFileCommand;
@@ -165,6 +180,7 @@ public sealed class ShellViewModel : ViewModelBase
         TemplatesPage.ToggleFavoriteCommand = _toggleTemplateFavoriteCommand;
         TemplatesPage.ToggleEnabledCommand = _toggleTemplateEnabledCommand;
         TemplatesPage.DeleteTemplateCommand = _deleteTemplateCommand;
+        TemplatesPage.Authoring.PrimaryActionCommand = _saveTemplateCommand;
 
         NavigationItems =
         [
@@ -184,6 +200,10 @@ public sealed class ShellViewModel : ViewModelBase
         CertificateRequestsPage.PropertyChanged += OnPageSelectionChanged;
         CertificateRevocationListsPage.PropertyChanged += OnPageSelectionChanged;
         TemplatesPage.PropertyChanged += OnPageSelectionChanged;
+        PrivateKeysPage.SelfSignedCaAuthoring.PropertyChanged += OnAuthoringPropertyChanged;
+        PrivateKeysPage.CertificateSigningRequestAuthoring.PropertyChanged += OnAuthoringPropertyChanged;
+        CertificateRequestsPage.IssuanceAuthoring.PropertyChanged += OnAuthoringPropertyChanged;
+        TemplatesPage.Authoring.PropertyChanged += OnAuthoringPropertyChanged;
 
         SelectPage(DashboardPage);
         ApplySnapshot(Snapshot);
@@ -305,10 +325,10 @@ public sealed class ShellViewModel : ViewModelBase
         var result = await _databaseSessionService.CreateSelfSignedCaAsync(
             new CreateSelfSignedCaWorkflowRequest(
                 PrivateKeysPage.SelectedItem.PrivateKeyId,
-                PrivateKeysPage.SelfSignedCaDisplayName,
-                PrivateKeysPage.SelfSignedCaSubjectName,
-                Math.Max(1, PrivateKeysPage.SelfSignedCaValidityDays),
-                PrivateKeysPage.SelectedSelfSignedCaTemplate?.TemplateId),
+                PrivateKeysPage.SelfSignedCaAuthoring.DisplayName,
+                PrivateKeysPage.SelfSignedCaAuthoring.SubjectName,
+                Math.Max(1, PrivateKeysPage.SelfSignedCaAuthoring.ValidityDays),
+                PrivateKeysPage.SelfSignedCaAuthoring.SelectedTemplate?.TemplateId),
             CancellationToken.None);
 
         if (!result.IsSuccess || result.Value is null)
@@ -334,14 +354,14 @@ public sealed class ShellViewModel : ViewModelBase
         var result = await _databaseSessionService.CreateCertificateSigningRequestAsync(
             new CreateCertificateSigningRequestWorkflowRequest(
                 PrivateKeysPage.SelectedItem.PrivateKeyId,
-                PrivateKeysPage.CertificateSigningRequestDisplayName,
-                PrivateKeysPage.CertificateSigningRequestSubjectName,
-                ParseSubjectAlternativeNames(PrivateKeysPage.CertificateSigningRequestSubjectAlternativeNames),
-                PrivateKeysPage.SelectedCertificateSigningRequestTemplate?.IntendedUsage == TemplateIntendedUsage.IntermediateCa,
-                PrivateKeysPage.SelectedCertificateSigningRequestTemplate?.IntendedUsage == TemplateIntendedUsage.IntermediateCa ? 0 : null,
-                [],
-                [],
-                PrivateKeysPage.SelectedCertificateSigningRequestTemplate?.TemplateId),
+                PrivateKeysPage.CertificateSigningRequestAuthoring.DisplayName,
+                PrivateKeysPage.CertificateSigningRequestAuthoring.SubjectName,
+                ParseSubjectAlternativeNames(PrivateKeysPage.CertificateSigningRequestAuthoring.SubjectAlternativeNames),
+                PrivateKeysPage.CertificateSigningRequestAuthoring.IsCertificateAuthority,
+                PrivateKeysPage.CertificateSigningRequestAuthoring.HasPathLengthConstraint ? PrivateKeysPage.CertificateSigningRequestAuthoring.PathLengthConstraint : null,
+                SplitValues(PrivateKeysPage.CertificateSigningRequestAuthoring.KeyUsages),
+                SplitValues(PrivateKeysPage.CertificateSigningRequestAuthoring.EnhancedKeyUsages),
+                PrivateKeysPage.CertificateSigningRequestAuthoring.SelectedTemplate?.TemplateId),
             CancellationToken.None);
 
         if (!result.IsSuccess || result.Value is null)
@@ -358,8 +378,8 @@ public sealed class ShellViewModel : ViewModelBase
     private async Task SignCertificateSigningRequestAsync()
     {
         if (CertificateRequestsPage.SelectedItem is null
-            || CertificateRequestsPage.SelectedIssuerCertificate is null
-            || CertificateRequestsPage.SelectedIssuerPrivateKey is null)
+            || CertificateRequestsPage.IssuanceAuthoring.SelectedIssuerCertificate is null
+            || CertificateRequestsPage.IssuanceAuthoring.SelectedIssuerPrivateKey is null)
         {
             NotifyFailure("Select a CSR, issuer certificate, and issuer private key.");
             return;
@@ -369,11 +389,11 @@ public sealed class ShellViewModel : ViewModelBase
         var result = await _databaseSessionService.SignCertificateSigningRequestAsync(
             new SignStoredCertificateSigningRequestRequest(
                 CertificateRequestsPage.SelectedItem.CertificateSigningRequestId,
-                CertificateRequestsPage.SelectedIssuerCertificate.CertificateId,
-                CertificateRequestsPage.SelectedIssuerPrivateKey.PrivateKeyId,
-                CertificateRequestsPage.IssuedCertificateDisplayName,
-                Math.Max(1, CertificateRequestsPage.ValidityDays),
-                CertificateRequestsPage.SelectedIssuanceTemplate?.TemplateId),
+                CertificateRequestsPage.IssuanceAuthoring.SelectedIssuerCertificate.CertificateId,
+                CertificateRequestsPage.IssuanceAuthoring.SelectedIssuerPrivateKey.PrivateKeyId,
+                CertificateRequestsPage.IssuanceAuthoring.DisplayName,
+                Math.Max(1, CertificateRequestsPage.IssuanceAuthoring.ValidityDays),
+                CertificateRequestsPage.IssuanceAuthoring.SelectedTemplate?.TemplateId),
             CancellationToken.None);
 
         if (!result.IsSuccess || result.Value is null)
@@ -1008,7 +1028,7 @@ public sealed class ShellViewModel : ViewModelBase
 
     private async Task ApplySelfSignedCaTemplateAsync()
     {
-        if (PrivateKeysPage.SelectedSelfSignedCaTemplate is null)
+        if (PrivateKeysPage.SelfSignedCaAuthoring.SelectedTemplate is null)
         {
             NotifyFailure("Select a template first.");
             return;
@@ -1016,7 +1036,7 @@ public sealed class ShellViewModel : ViewModelBase
 
         using var scope = BeginBusy("Applying template defaults");
         var result = await _databaseSessionService.ApplyTemplateAsync(
-            new ApplyTemplateRequest(PrivateKeysPage.SelectedSelfSignedCaTemplate.TemplateId, TemplateWorkflowKind.SelfSignedCa),
+            new ApplyTemplateRequest(PrivateKeysPage.SelfSignedCaAuthoring.SelectedTemplate.TemplateId, TemplateWorkflowKind.SelfSignedCa),
             CancellationToken.None);
         if (!result.IsSuccess || result.Value is null)
         {
@@ -1024,15 +1044,13 @@ public sealed class ShellViewModel : ViewModelBase
             return;
         }
 
-        PrivateKeysPage.SelfSignedCaDisplayName = result.Value.DisplayNameDefault;
-        PrivateKeysPage.SelfSignedCaSubjectName = result.Value.SubjectDefault ?? PrivateKeysPage.SelfSignedCaSubjectName;
-        PrivateKeysPage.SelfSignedCaValidityDays = Math.Max(1, result.Value.ValidityDays);
+        PrivateKeysPage.SelfSignedCaAuthoring.ApplyTemplateDefaults(result.Value);
         NotifySuccess("Self-signed CA template applied.");
     }
 
     private async Task ApplyCertificateSigningRequestTemplateAsync()
     {
-        if (PrivateKeysPage.SelectedCertificateSigningRequestTemplate is null)
+        if (PrivateKeysPage.CertificateSigningRequestAuthoring.SelectedTemplate is null)
         {
             NotifyFailure("Select a template first.");
             return;
@@ -1040,7 +1058,7 @@ public sealed class ShellViewModel : ViewModelBase
 
         using var scope = BeginBusy("Applying template defaults");
         var result = await _databaseSessionService.ApplyTemplateAsync(
-            new ApplyTemplateRequest(PrivateKeysPage.SelectedCertificateSigningRequestTemplate.TemplateId, TemplateWorkflowKind.CertificateSigningRequest),
+            new ApplyTemplateRequest(PrivateKeysPage.CertificateSigningRequestAuthoring.SelectedTemplate.TemplateId, TemplateWorkflowKind.CertificateSigningRequest),
             CancellationToken.None);
         if (!result.IsSuccess || result.Value is null)
         {
@@ -1051,15 +1069,13 @@ public sealed class ShellViewModel : ViewModelBase
         PrivateKeysPage.NewKeyDisplayName = result.Value.DisplayNameDefault;
         PrivateKeysPage.SelectedAlgorithm = result.Value.KeyAlgorithm == KeyAlgorithmKind.Rsa ? KeyAlgorithmView.Rsa : KeyAlgorithmView.Ecdsa;
         PrivateKeysPage.SelectedCurve = result.Value.Curve == EllipticCurveKind.P384 ? EllipticCurveView.P384 : EllipticCurveView.P256;
-        PrivateKeysPage.CertificateSigningRequestDisplayName = result.Value.DisplayNameDefault;
-        PrivateKeysPage.CertificateSigningRequestSubjectName = result.Value.SubjectDefault ?? PrivateKeysPage.CertificateSigningRequestSubjectName;
-        PrivateKeysPage.CertificateSigningRequestSubjectAlternativeNames = string.Join(", ", result.Value.SubjectAlternativeNames);
+        PrivateKeysPage.CertificateSigningRequestAuthoring.ApplyTemplateDefaults(result.Value);
         NotifySuccess("CSR template applied.");
     }
 
     private async Task ApplyIssuanceTemplateAsync()
     {
-        if (CertificateRequestsPage.SelectedIssuanceTemplate is null)
+        if (CertificateRequestsPage.IssuanceAuthoring.SelectedTemplate is null)
         {
             NotifyFailure("Select a template first.");
             return;
@@ -1067,7 +1083,7 @@ public sealed class ShellViewModel : ViewModelBase
 
         using var scope = BeginBusy("Applying template defaults");
         var result = await _databaseSessionService.ApplyTemplateAsync(
-            new ApplyTemplateRequest(CertificateRequestsPage.SelectedIssuanceTemplate.TemplateId, TemplateWorkflowKind.SignCertificateSigningRequest),
+            new ApplyTemplateRequest(CertificateRequestsPage.IssuanceAuthoring.SelectedTemplate.TemplateId, TemplateWorkflowKind.SignCertificateSigningRequest),
             CancellationToken.None);
         if (!result.IsSuccess || result.Value is null)
         {
@@ -1075,9 +1091,52 @@ public sealed class ShellViewModel : ViewModelBase
             return;
         }
 
-        CertificateRequestsPage.IssuedCertificateDisplayName = result.Value.DisplayNameDefault;
-        CertificateRequestsPage.ValidityDays = Math.Max(1, result.Value.ValidityDays);
+        CertificateRequestsPage.IssuanceAuthoring.ApplyTemplateDefaults(result.Value);
         NotifySuccess("Issuance template applied.");
+    }
+
+    private void CreateTemplateFromCertificate()
+    {
+        if (CertificatesPage.SelectedItem is null)
+        {
+            NotifyFailure("Select a certificate first.");
+            return;
+        }
+
+        TemplatesPage.PrepareTemplateFromCertificate(CertificatesPage.SelectedItem, CertificatesPage.Inspector);
+        SelectPage(TemplatesPage);
+        NotifySuccess("Selected certificate copied into the template editor.");
+    }
+
+    private void CreateTemplateFromRequest()
+    {
+        if (CertificateRequestsPage.SelectedItem is null)
+        {
+            NotifyFailure("Select a CSR first.");
+            return;
+        }
+
+        TemplatesPage.PrepareTemplateFromCertificateRequest(CertificateRequestsPage.SelectedItem);
+        SelectPage(TemplatesPage);
+        NotifySuccess("Selected CSR copied into the template editor.");
+    }
+
+    private void CreateSimilarRequest()
+    {
+        if (CertificateRequestsPage.SelectedItem is null)
+        {
+            NotifyFailure("Select a CSR first.");
+            return;
+        }
+
+        PrivateKeysPage.LoadCertificateSigningRequestAuthoringFromRequest(CertificateRequestsPage.SelectedItem);
+        if (CertificateRequestsPage.SelectedItem.PrivateKeyId is Guid privateKeyId)
+        {
+            PrivateKeysPage.SelectedItem = PrivateKeysPage.Items.FirstOrDefault(x => x.PrivateKeyId == privateKeyId) ?? PrivateKeysPage.SelectedItem;
+        }
+
+        SelectPage(PrivateKeysPage);
+        NotifySuccess("CSR values copied into the request authoring surface.");
     }
 
     private async Task LoadDiagnosticsAsync()
@@ -1196,15 +1255,23 @@ public sealed class ShellViewModel : ViewModelBase
     private void OnPageSelectionChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName is nameof(PrivateKeysPageViewModel.SelectedItem)
-            or nameof(PrivateKeysPageViewModel.SelectedSelfSignedCaTemplate)
-            or nameof(PrivateKeysPageViewModel.SelectedCertificateSigningRequestTemplate)
             or nameof(CertificateRequestsPageViewModel.SelectedItem)
-            or nameof(CertificateRequestsPageViewModel.SelectedIssuerCertificate)
-            or nameof(CertificateRequestsPageViewModel.SelectedIssuerPrivateKey)
-            or nameof(CertificateRequestsPageViewModel.SelectedIssuanceTemplate)
             or nameof(TemplatesPageViewModel.SelectedItem)
             or nameof(CertificateRevocationListsPageViewModel.SelectedItem))
         {
+            if (sender == PrivateKeysPage && e.PropertyName == nameof(PrivateKeysPageViewModel.SelectedItem))
+            {
+                var keyLabel = PrivateKeysPage.SelectedItem is null ? "selected private key" : $"private key {PrivateKeysPage.SelectedItem.DisplayName}";
+                PrivateKeysPage.SelfSignedCaAuthoring.SourceSummary = $"Source: {keyLabel}";
+                PrivateKeysPage.CertificateSigningRequestAuthoring.SourceSummary = $"Source: {keyLabel}";
+            }
+
+            if (sender == CertificateRequestsPage && e.PropertyName == nameof(CertificateRequestsPageViewModel.SelectedItem))
+            {
+                var requestLabel = CertificateRequestsPage.SelectedItem is null ? "selected certificate request" : $"request {CertificateRequestsPage.SelectedItem.DisplayName}";
+                CertificateRequestsPage.IssuanceAuthoring.SourceSummary = $"Source: {requestLabel}";
+            }
+
             if (sender == CertificateRevocationListsPage && e.PropertyName == nameof(CertificateRevocationListsPageViewModel.SelectedItem))
             {
                 _ = LoadSelectedCertificateRevocationListInspectorAsync();
@@ -1215,6 +1282,16 @@ public sealed class ShellViewModel : ViewModelBase
                 _ = LoadSelectedTemplateAsync();
             }
 
+            RefreshCommandStates();
+        }
+    }
+
+    private void OnAuthoringPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(CertificateAuthoringViewModel.SelectedTemplate)
+            or nameof(CertificateAuthoringViewModel.SelectedIssuerCertificate)
+            or nameof(CertificateAuthoringViewModel.SelectedIssuerPrivateKey))
+        {
             RefreshCommandStates();
         }
     }
@@ -1358,6 +1435,9 @@ public sealed class ShellViewModel : ViewModelBase
         _exportCertificateSigningRequestCommand.RaiseCanExecuteChanged();
         _exportCertificateSigningRequestToFileCommand.RaiseCanExecuteChanged();
         _navigateRequestPrivateKeyCommand.RaiseCanExecuteChanged();
+        _createTemplateFromCertificateCommand.RaiseCanExecuteChanged();
+        _createTemplateFromRequestCommand.RaiseCanExecuteChanged();
+        _createSimilarRequestCommand.RaiseCanExecuteChanged();
         _refreshCertificateRevocationListsCommand.RaiseCanExecuteChanged();
         _exportCertificateRevocationListToFileCommand.RaiseCanExecuteChanged();
         _navigateCrlIssuerCommand.RaiseCanExecuteChanged();
@@ -1378,6 +1458,13 @@ public sealed class ShellViewModel : ViewModelBase
         return value
             .Split([',', ';', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Select(x => new SanEntry(x))
+            .ToList();
+    }
+
+    private static IReadOnlyList<string> SplitValues(string value)
+    {
+        return value
+            .Split([',', ';', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .ToList();
     }
 

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -201,18 +201,22 @@ public sealed class ShellViewModel : ViewModelBase
         TemplatesPage.DeleteTemplateCommand = _deleteTemplateCommand;
         TemplatesPage.Authoring.PrimaryActionCommand = _saveTemplateCommand;
 
-        NavigationItems =
+        WorkspaceNavigationItems =
+        [
+            new NavigationItemViewModel("Private Keys", "Keys", new DelegateCommand(() => SelectPage(PrivateKeysPage))),
+            new NavigationItemViewModel("CSRs", "Requests", new DelegateCommand(() => SelectPage(CertificateRequestsPage))),
+            new NavigationItemViewModel("Certificates", "Certificates", new DelegateCommand(() => SelectPage(CertificatesPage))),
+            new NavigationItemViewModel("Templates", "Templates", new DelegateCommand(() => SelectPage(TemplatesPage))),
+            new NavigationItemViewModel("CRLs", "Revocation", new DelegateCommand(() => SelectPage(CertificateRevocationListsPage)))
+        ];
+        UtilityNavigationItems =
         [
             new NavigationItemViewModel("Dashboard", "Overview", new DelegateCommand(() => SelectPage(DashboardPage))),
-            new NavigationItemViewModel("Certificates", "Browse", new DelegateCommand(() => SelectPage(CertificatesPage))),
-            new NavigationItemViewModel("Private Keys", "Secure", new DelegateCommand(() => SelectPage(PrivateKeysPage))),
-            new NavigationItemViewModel("CSRs", "Requests", new DelegateCommand(() => SelectPage(CertificateRequestsPage))),
-            new NavigationItemViewModel("CRLs", "Revocation", new DelegateCommand(() => SelectPage(CertificateRevocationListsPage))),
-            new NavigationItemViewModel("Templates", "Presets", new DelegateCommand(() => SelectPage(TemplatesPage))),
             new NavigationItemViewModel("Settings / Security", "Database", new DelegateCommand(() => SelectPage(SettingsSecurityPage)))
         ];
+        NavigationItems = [.. WorkspaceNavigationItems, .. UtilityNavigationItems];
 
-        _currentPage = DashboardPage;
+        _currentPage = CertificatesPage;
 
         CertificatesPage.PropertyChanged += OnCertificatesPagePropertyChanged;
         PrivateKeysPage.PropertyChanged += OnPageSelectionChanged;
@@ -224,7 +228,7 @@ public sealed class ShellViewModel : ViewModelBase
         CertificateRequestsPage.IssuanceAuthoring.PropertyChanged += OnAuthoringPropertyChanged;
         TemplatesPage.Authoring.PropertyChanged += OnAuthoringPropertyChanged;
 
-        SelectPage(DashboardPage);
+        SelectPage(CertificatesPage);
         ApplySnapshot(Snapshot);
         _ = RefreshAllAsync();
     }
@@ -312,6 +316,10 @@ public sealed class ShellViewModel : ViewModelBase
 
     public ObservableCollection<NavigationItemViewModel> NavigationItems { get; }
 
+    public ObservableCollection<NavigationItemViewModel> WorkspaceNavigationItems { get; }
+
+    public ObservableCollection<NavigationItemViewModel> UtilityNavigationItems { get; }
+
     public ObservableCollection<NotificationItemViewModel> Notifications { get; } = [];
 
     public PageViewModelBase CurrentPage
@@ -321,6 +329,16 @@ public sealed class ShellViewModel : ViewModelBase
     }
 
     public DatabaseSessionSnapshot Snapshot => _databaseSessionService.GetSnapshot();
+
+    public ICommand CreateDatabaseCommand => _createDatabaseCommand;
+
+    public ICommand OpenDatabaseCommand => _openDatabaseCommand;
+
+    public ICommand UnlockDatabaseCommand => _unlockDatabaseCommand;
+
+    public ICommand LockDatabaseCommand => _lockDatabaseCommand;
+
+    public ICommand RefreshWorkspaceCommand => _refreshWorkspaceCommand;
 
     private async Task CreateDatabaseAsync()
     {

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Text;
+using System.Windows.Input;
 using Microsoft.Extensions.Logging;
 using XcaNet.App.Commands;
 using XcaNet.App.Services;
@@ -40,11 +41,14 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly DelegateCommand _navigateChildCertificateCommand;
     private readonly AsyncCommand _refreshPrivateKeysCommand;
     private readonly AsyncCommand _generateKeyCommand;
+    private readonly DelegateCommand _openSelfSignedCaAuthoringCommand;
+    private readonly DelegateCommand _openCertificateSigningRequestAuthoringCommand;
     private readonly AsyncCommand _createSelfSignedCaCommand;
     private readonly AsyncCommand _createCertificateSigningRequestCommand;
     private readonly AsyncCommand _exportPrivateKeyCommand;
     private readonly AsyncCommand _exportPrivateKeyToFileCommand;
     private readonly AsyncCommand _refreshCertificateRequestsCommand;
+    private readonly DelegateCommand _openIssuanceAuthoringCommand;
     private readonly AsyncCommand _signCertificateSigningRequestCommand;
     private readonly AsyncCommand _exportCertificateSigningRequestCommand;
     private readonly AsyncCommand _exportCertificateSigningRequestToFileCommand;
@@ -54,6 +58,7 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly DelegateCommand _navigateCrlIssuerCommand;
     private readonly AsyncCommand _refreshTemplatesCommand;
     private readonly AsyncCommand _createTemplateCommand;
+    private readonly DelegateCommand _editTemplateCommand;
     private readonly AsyncCommand _saveTemplateCommand;
     private readonly AsyncCommand _cloneTemplateCommand;
     private readonly AsyncCommand _toggleTemplateFavoriteCommand;
@@ -65,11 +70,16 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly DelegateCommand _createTemplateFromCertificateCommand;
     private readonly DelegateCommand _createTemplateFromRequestCommand;
     private readonly DelegateCommand _createSimilarRequestCommand;
+    private readonly DelegateCommand _closeAuthoringDialogCommand;
 
     private PageViewModelBase _currentPage;
     private string _subtitle = "Core UI workflows";
     private bool _isBusy;
     private string _busyMessage = string.Empty;
+    private AuthoringDialogKind _authoringDialogKind;
+    private CertificateAuthoringViewModel? _activeCertificateAuthoring;
+    private string _authoringDialogTitle = string.Empty;
+    private string _authoringDialogSubtitle = string.Empty;
 
     public ShellViewModel(IDatabaseSessionService databaseSessionService, IDesktopFileDialogService fileDialogService, ILogger<ShellViewModel> logger)
     {
@@ -104,11 +114,14 @@ public sealed class ShellViewModel : ViewModelBase
         _navigateChildCertificateCommand = new DelegateCommand(() => NavigateTo(CertificatesPage.SelectedChildNavigationItem?.Target), () => CertificatesPage.SelectedChildNavigationItem is not null);
         _refreshPrivateKeysCommand = new AsyncCommand(LoadPrivateKeysAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed);
         _generateKeyCommand = new AsyncCommand(GenerateKeyAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked);
+        _openSelfSignedCaAuthoringCommand = new DelegateCommand(OpenSelfSignedCaAuthoring, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
+        _openCertificateSigningRequestAuthoringCommand = new DelegateCommand(OpenCertificateSigningRequestAuthoring, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
         _createSelfSignedCaCommand = new AsyncCommand(CreateSelfSignedCaAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
         _createCertificateSigningRequestCommand = new AsyncCommand(CreateCertificateSigningRequestAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
         _exportPrivateKeyCommand = new AsyncCommand(ExportSelectedPrivateKeyAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
         _exportPrivateKeyToFileCommand = new AsyncCommand(ExportSelectedPrivateKeyToFileAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
         _refreshCertificateRequestsCommand = new AsyncCommand(LoadCertificateRequestsAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed);
+        _openIssuanceAuthoringCommand = new DelegateCommand(OpenIssuanceAuthoring, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificateRequestsPage.HasSelection);
         _signCertificateSigningRequestCommand = new AsyncCommand(SignCertificateSigningRequestAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificateRequestsPage.HasSelection && CertificateRequestsPage.IssuanceAuthoring.SelectedIssuerCertificate is not null && CertificateRequestsPage.IssuanceAuthoring.SelectedIssuerPrivateKey is not null);
         _exportCertificateSigningRequestCommand = new AsyncCommand(ExportSelectedCertificateSigningRequestAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificateRequestsPage.HasSelection);
         _exportCertificateSigningRequestToFileCommand = new AsyncCommand(ExportSelectedCertificateSigningRequestToFileAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificateRequestsPage.HasSelection);
@@ -118,6 +131,7 @@ public sealed class ShellViewModel : ViewModelBase
         _navigateCrlIssuerCommand = new DelegateCommand(() => NavigateTo(CertificateRevocationListsPage.Inspector?.IssuerTarget), () => CertificateRevocationListsPage.Inspector?.IssuerTarget is not null);
         _refreshTemplatesCommand = new AsyncCommand(LoadTemplatesAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed);
         _createTemplateCommand = new AsyncCommand(CreateNewTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed);
+        _editTemplateCommand = new DelegateCommand(OpenTemplateAuthoringFromSelection, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
         _saveTemplateCommand = new AsyncCommand(SaveTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed);
         _cloneTemplateCommand = new AsyncCommand(CloneTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
         _toggleTemplateFavoriteCommand = new AsyncCommand(ToggleTemplateFavoriteAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
@@ -129,6 +143,7 @@ public sealed class ShellViewModel : ViewModelBase
         _createTemplateFromCertificateCommand = new DelegateCommand(CreateTemplateFromCertificate, () => CertificatesPage.SelectedItem is not null);
         _createTemplateFromRequestCommand = new DelegateCommand(CreateTemplateFromRequest, () => CertificateRequestsPage.SelectedItem is not null);
         _createSimilarRequestCommand = new DelegateCommand(CreateSimilarRequest, () => CertificateRequestsPage.SelectedItem is not null);
+        _closeAuthoringDialogCommand = new DelegateCommand(CloseAuthoringDialog, () => IsAuthoringDialogOpen && !IsBusy);
 
         SettingsSecurityPage.CreateDatabaseCommand = _createDatabaseCommand;
         SettingsSecurityPage.OpenDatabaseCommand = _openDatabaseCommand;
@@ -148,6 +163,8 @@ public sealed class ShellViewModel : ViewModelBase
 
         PrivateKeysPage.RefreshCommand = _refreshPrivateKeysCommand;
         PrivateKeysPage.GenerateKeyCommand = _generateKeyCommand;
+        PrivateKeysPage.OpenSelfSignedCaAuthoringCommand = _openSelfSignedCaAuthoringCommand;
+        PrivateKeysPage.OpenCertificateSigningRequestAuthoringCommand = _openCertificateSigningRequestAuthoringCommand;
         PrivateKeysPage.CreateSelfSignedCaCommand = _createSelfSignedCaCommand;
         PrivateKeysPage.CreateCertificateSigningRequestCommand = _createCertificateSigningRequestCommand;
         PrivateKeysPage.ApplySelfSignedCaTemplateCommand = _applySelfSignedCaTemplateCommand;
@@ -160,6 +177,7 @@ public sealed class ShellViewModel : ViewModelBase
         PrivateKeysPage.CertificateSigningRequestAuthoring.PrimaryActionCommand = _createCertificateSigningRequestCommand;
 
         CertificateRequestsPage.RefreshCommand = _refreshCertificateRequestsCommand;
+        CertificateRequestsPage.OpenIssuanceAuthoringCommand = _openIssuanceAuthoringCommand;
         CertificateRequestsPage.SignSelectedCommand = _signCertificateSigningRequestCommand;
         CertificateRequestsPage.ApplyIssuanceTemplateCommand = _applyIssuanceTemplateCommand;
         CertificateRequestsPage.ExportSelectedCommand = _exportCertificateSigningRequestCommand;
@@ -175,6 +193,7 @@ public sealed class ShellViewModel : ViewModelBase
         CertificateRevocationListsPage.OpenIssuerCommand = _navigateCrlIssuerCommand;
         TemplatesPage.RefreshCommand = _refreshTemplatesCommand;
         TemplatesPage.CreateNewCommand = _createTemplateCommand;
+        TemplatesPage.EditTemplateCommand = _editTemplateCommand;
         TemplatesPage.SaveTemplateCommand = _saveTemplateCommand;
         TemplatesPage.CloneTemplateCommand = _cloneTemplateCommand;
         TemplatesPage.ToggleFavoriteCommand = _toggleTemplateFavoriteCommand;
@@ -235,6 +254,47 @@ public sealed class ShellViewModel : ViewModelBase
         get => _busyMessage;
         private set => SetProperty(ref _busyMessage, value);
     }
+
+    public bool IsAuthoringDialogOpen => AuthoringDialogKind != AuthoringDialogKind.None;
+
+    public AuthoringDialogKind AuthoringDialogKind
+    {
+        get => _authoringDialogKind;
+        private set
+        {
+            if (SetProperty(ref _authoringDialogKind, value))
+            {
+                OnPropertyChanged(nameof(IsAuthoringDialogOpen));
+                OnPropertyChanged(nameof(IsCertificateAuthoringDialogOpen));
+                OnPropertyChanged(nameof(IsTemplateAuthoringDialogOpen));
+                RefreshCommandStates();
+            }
+        }
+    }
+
+    public bool IsCertificateAuthoringDialogOpen => AuthoringDialogKind == AuthoringDialogKind.Certificate;
+
+    public bool IsTemplateAuthoringDialogOpen => AuthoringDialogKind == AuthoringDialogKind.Template;
+
+    public CertificateAuthoringViewModel? ActiveCertificateAuthoring
+    {
+        get => _activeCertificateAuthoring;
+        private set => SetProperty(ref _activeCertificateAuthoring, value);
+    }
+
+    public string AuthoringDialogTitle
+    {
+        get => _authoringDialogTitle;
+        private set => SetProperty(ref _authoringDialogTitle, value);
+    }
+
+    public string AuthoringDialogSubtitle
+    {
+        get => _authoringDialogSubtitle;
+        private set => SetProperty(ref _authoringDialogSubtitle, value);
+    }
+
+    public ICommand CloseAuthoringDialogCommand => _closeAuthoringDialogCommand;
 
     public DashboardPageViewModel DashboardPage { get; }
 
@@ -313,6 +373,51 @@ public sealed class ShellViewModel : ViewModelBase
         NotifySuccess($"Generated {result.Value.Algorithm} key.");
     }
 
+    private void OpenSelfSignedCaAuthoring()
+    {
+        if (!PrivateKeysPage.HasSelection || PrivateKeysPage.SelectedItem is null)
+        {
+            NotifyFailure("Select a private key first.");
+            return;
+        }
+
+        PrivateKeysPage.SelfSignedCaAuthoring.SourceSummary = $"Source: private key {PrivateKeysPage.SelectedItem.DisplayName}";
+        OpenCertificateAuthoringDialog(
+            PrivateKeysPage.SelfSignedCaAuthoring,
+            "Certificate Input",
+            "Self-signed CA authoring");
+    }
+
+    private void OpenCertificateSigningRequestAuthoring()
+    {
+        if (!PrivateKeysPage.HasSelection || PrivateKeysPage.SelectedItem is null)
+        {
+            NotifyFailure("Select a private key first.");
+            return;
+        }
+
+        PrivateKeysPage.CertificateSigningRequestAuthoring.SourceSummary = $"Source: private key {PrivateKeysPage.SelectedItem.DisplayName}";
+        OpenCertificateAuthoringDialog(
+            PrivateKeysPage.CertificateSigningRequestAuthoring,
+            "Certificate Input",
+            "Certificate request authoring");
+    }
+
+    private void OpenIssuanceAuthoring()
+    {
+        if (!CertificateRequestsPage.HasSelection || CertificateRequestsPage.SelectedItem is null)
+        {
+            NotifyFailure("Select a CSR first.");
+            return;
+        }
+
+        CertificateRequestsPage.IssuanceAuthoring.SourceSummary = $"Source: request {CertificateRequestsPage.SelectedItem.DisplayName}";
+        OpenCertificateAuthoringDialog(
+            CertificateRequestsPage.IssuanceAuthoring,
+            "Certificate Input",
+            "Issue certificate from selected request");
+    }
+
     private async Task CreateSelfSignedCaAsync()
     {
         if (PrivateKeysPage.SelectedItem is null)
@@ -337,6 +442,7 @@ public sealed class ShellViewModel : ViewModelBase
             return;
         }
 
+        CloseAuthoringDialog();
         await RefreshAllAsync();
         NavigateTo(new NavigationTarget(BrowserEntityType.Certificate, result.Value.CertificateId, NavigationFocusSection.Inspector));
         NotifySuccess("Self-signed CA certificate created.");
@@ -370,6 +476,7 @@ public sealed class ShellViewModel : ViewModelBase
             return;
         }
 
+        CloseAuthoringDialog();
         await RefreshAllAsync();
         NavigateTo(new NavigationTarget(BrowserEntityType.CertificateSigningRequest, result.Value.CertificateSigningRequestId, NavigationFocusSection.Overview));
         NotifySuccess("Certificate signing request created.");
@@ -402,6 +509,7 @@ public sealed class ShellViewModel : ViewModelBase
             return;
         }
 
+        CloseAuthoringDialog();
         await RefreshAllAsync();
         NavigateTo(new NavigationTarget(BrowserEntityType.Certificate, result.Value.CertificateId, NavigationFocusSection.Inspector));
         NotifySuccess("CSR signed into a certificate.");
@@ -915,7 +1023,19 @@ public sealed class ShellViewModel : ViewModelBase
     private async Task CreateNewTemplateAsync()
     {
         TemplatesPage.PrepareNewTemplate();
+        OpenTemplateAuthoringDialog("Template Input", "Create template defaults");
         await Task.CompletedTask;
+    }
+
+    private void OpenTemplateAuthoringFromSelection()
+    {
+        if (!TemplatesPage.HasSelection || TemplatesPage.SelectedItem is null)
+        {
+            NotifyFailure("Select a template first.");
+            return;
+        }
+
+        OpenTemplateAuthoringDialog("Template Input", $"Edit template {TemplatesPage.SelectedItem.Name}");
     }
 
     private async Task SaveTemplateAsync()
@@ -932,6 +1052,8 @@ public sealed class ShellViewModel : ViewModelBase
         await LoadTemplatesAsync();
         TemplatesPage.SelectedItem = TemplatesPage.Items.FirstOrDefault(x => x.TemplateId == result.Value.TemplateId);
         TemplatesPage.LoadTemplate(result.Value);
+        CloseAuthoringDialog();
+        SelectPage(TemplatesPage);
         NotifySuccess(result.Message);
     }
 
@@ -954,6 +1076,7 @@ public sealed class ShellViewModel : ViewModelBase
         await LoadTemplatesAsync();
         TemplatesPage.SelectedItem = TemplatesPage.Items.FirstOrDefault(x => x.TemplateId == result.Value.TemplateId);
         TemplatesPage.LoadTemplate(result.Value);
+        OpenTemplateAuthoringDialog("Template Input", $"Edit cloned template {result.Value.Name}");
         NotifySuccess("Template cloned.");
     }
 
@@ -1023,6 +1146,7 @@ public sealed class ShellViewModel : ViewModelBase
 
         TemplatesPage.PrepareNewTemplate();
         await LoadTemplatesAsync();
+        CloseAuthoringDialog();
         NotifySuccess("Template deleted.");
     }
 
@@ -1104,7 +1228,7 @@ public sealed class ShellViewModel : ViewModelBase
         }
 
         TemplatesPage.PrepareTemplateFromCertificate(CertificatesPage.SelectedItem, CertificatesPage.Inspector);
-        SelectPage(TemplatesPage);
+        OpenTemplateAuthoringDialog("Template Input", $"Derived from certificate {CertificatesPage.SelectedItem.DisplayName}");
         NotifySuccess("Selected certificate copied into the template editor.");
     }
 
@@ -1117,7 +1241,7 @@ public sealed class ShellViewModel : ViewModelBase
         }
 
         TemplatesPage.PrepareTemplateFromCertificateRequest(CertificateRequestsPage.SelectedItem);
-        SelectPage(TemplatesPage);
+        OpenTemplateAuthoringDialog("Template Input", $"Derived from request {CertificateRequestsPage.SelectedItem.DisplayName}");
         NotifySuccess("Selected CSR copied into the template editor.");
     }
 
@@ -1136,7 +1260,35 @@ public sealed class ShellViewModel : ViewModelBase
         }
 
         SelectPage(PrivateKeysPage);
+        OpenCertificateAuthoringDialog(
+            PrivateKeysPage.CertificateSigningRequestAuthoring,
+            "Certificate Input",
+            "Create similar request");
         NotifySuccess("CSR values copied into the request authoring surface.");
+    }
+
+    private void OpenCertificateAuthoringDialog(CertificateAuthoringViewModel authoring, string title, string subtitle)
+    {
+        ActiveCertificateAuthoring = authoring;
+        AuthoringDialogTitle = title;
+        AuthoringDialogSubtitle = subtitle;
+        AuthoringDialogKind = AuthoringDialogKind.Certificate;
+    }
+
+    private void OpenTemplateAuthoringDialog(string title, string subtitle)
+    {
+        AuthoringDialogTitle = title;
+        AuthoringDialogSubtitle = subtitle;
+        ActiveCertificateAuthoring = null;
+        AuthoringDialogKind = AuthoringDialogKind.Template;
+    }
+
+    private void CloseAuthoringDialog()
+    {
+        ActiveCertificateAuthoring = null;
+        AuthoringDialogTitle = string.Empty;
+        AuthoringDialogSubtitle = string.Empty;
+        AuthoringDialogKind = AuthoringDialogKind.None;
     }
 
     private async Task LoadDiagnosticsAsync()
@@ -1333,6 +1485,7 @@ public sealed class ShellViewModel : ViewModelBase
 
     private void ClearBrowseState()
     {
+        CloseAuthoringDialog();
         DashboardPage.CertificateCount = 0;
         DashboardPage.PrivateKeyCount = 0;
         DashboardPage.CertificateRequestCount = 0;
@@ -1426,11 +1579,14 @@ public sealed class ShellViewModel : ViewModelBase
         _navigateChildCertificateCommand.RaiseCanExecuteChanged();
         _refreshPrivateKeysCommand.RaiseCanExecuteChanged();
         _generateKeyCommand.RaiseCanExecuteChanged();
+        _openSelfSignedCaAuthoringCommand.RaiseCanExecuteChanged();
+        _openCertificateSigningRequestAuthoringCommand.RaiseCanExecuteChanged();
         _createSelfSignedCaCommand.RaiseCanExecuteChanged();
         _createCertificateSigningRequestCommand.RaiseCanExecuteChanged();
         _exportPrivateKeyCommand.RaiseCanExecuteChanged();
         _exportPrivateKeyToFileCommand.RaiseCanExecuteChanged();
         _refreshCertificateRequestsCommand.RaiseCanExecuteChanged();
+        _openIssuanceAuthoringCommand.RaiseCanExecuteChanged();
         _signCertificateSigningRequestCommand.RaiseCanExecuteChanged();
         _exportCertificateSigningRequestCommand.RaiseCanExecuteChanged();
         _exportCertificateSigningRequestToFileCommand.RaiseCanExecuteChanged();
@@ -1443,6 +1599,7 @@ public sealed class ShellViewModel : ViewModelBase
         _navigateCrlIssuerCommand.RaiseCanExecuteChanged();
         _refreshTemplatesCommand.RaiseCanExecuteChanged();
         _createTemplateCommand.RaiseCanExecuteChanged();
+        _editTemplateCommand.RaiseCanExecuteChanged();
         _saveTemplateCommand.RaiseCanExecuteChanged();
         _cloneTemplateCommand.RaiseCanExecuteChanged();
         _toggleTemplateFavoriteCommand.RaiseCanExecuteChanged();
@@ -1451,6 +1608,7 @@ public sealed class ShellViewModel : ViewModelBase
         _applySelfSignedCaTemplateCommand.RaiseCanExecuteChanged();
         _applyCertificateSigningRequestTemplateCommand.RaiseCanExecuteChanged();
         _applyIssuanceTemplateCommand.RaiseCanExecuteChanged();
+        _closeAuthoringDialogCommand.RaiseCanExecuteChanged();
     }
 
     private static IReadOnlyList<SanEntry> ParseSubjectAlternativeNames(string value)

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -76,6 +76,7 @@ public sealed class ShellViewModel : ViewModelBase
     private string _subtitle = "Core UI workflows";
     private bool _isBusy;
     private string _busyMessage = string.Empty;
+    private string _searchText = string.Empty;
     private AuthoringDialogKind _authoringDialogKind;
     private CertificateAuthoringViewModel? _activeCertificateAuthoring;
     private string _authoringDialogTitle = string.Empty;
@@ -204,10 +205,10 @@ public sealed class ShellViewModel : ViewModelBase
         WorkspaceNavigationItems =
         [
             new NavigationItemViewModel("Private Keys", "Keys", new DelegateCommand(() => SelectPage(PrivateKeysPage))),
-            new NavigationItemViewModel("CSRs", "Requests", new DelegateCommand(() => SelectPage(CertificateRequestsPage))),
+            new NavigationItemViewModel("Certificate signing requests", "Requests", new DelegateCommand(() => SelectPage(CertificateRequestsPage))),
             new NavigationItemViewModel("Certificates", "Certificates", new DelegateCommand(() => SelectPage(CertificatesPage))),
             new NavigationItemViewModel("Templates", "Templates", new DelegateCommand(() => SelectPage(TemplatesPage))),
-            new NavigationItemViewModel("CRLs", "Revocation", new DelegateCommand(() => SelectPage(CertificateRevocationListsPage)))
+            new NavigationItemViewModel("Revocation lists", "Revocation", new DelegateCommand(() => SelectPage(CertificateRevocationListsPage)))
         ];
         UtilityNavigationItems =
         [
@@ -257,6 +258,12 @@ public sealed class ShellViewModel : ViewModelBase
     {
         get => _busyMessage;
         private set => SetProperty(ref _busyMessage, value);
+    }
+
+    public string SearchText
+    {
+        get => _searchText;
+        set => SetProperty(ref _searchText, value);
     }
 
     public bool IsAuthoringDialogOpen => AuthoringDialogKind != AuthoringDialogKind.None;
@@ -330,6 +337,20 @@ public sealed class ShellViewModel : ViewModelBase
 
     public DatabaseSessionSnapshot Snapshot => _databaseSessionService.GetSnapshot();
 
+    public string WorkspaceStatus => Snapshot.DisplayName is null
+        ? Snapshot.StatusMessage
+        : $"{Snapshot.DisplayName} | {Snapshot.StatusMessage}";
+
+    public string CurrentSelectionSummary => CurrentPage switch
+    {
+        var _ when CurrentPage == PrivateKeysPage => PrivateKeysPage.SelectedItem is null ? "No private key selected" : $"Selected key: {PrivateKeysPage.SelectedItem.DisplayName}",
+        var _ when CurrentPage == CertificateRequestsPage => CertificateRequestsPage.SelectedItem is null ? "No request selected" : $"Selected request: {CertificateRequestsPage.SelectedItem.DisplayName}",
+        var _ when CurrentPage == CertificatesPage => CertificatesPage.SelectedItem is null ? "No certificate selected" : $"Selected certificate: {CertificatesPage.SelectedItem.DisplayName}",
+        var _ when CurrentPage == TemplatesPage => TemplatesPage.SelectedItem is null ? "No template selected" : $"Selected template: {TemplatesPage.SelectedItem.Name}",
+        var _ when CurrentPage == CertificateRevocationListsPage => CertificateRevocationListsPage.SelectedItem is null ? "No revocation list selected" : $"Selected CRL: {CertificateRevocationListsPage.SelectedItem.DisplayName}",
+        _ => Snapshot.DatabasePath ?? "No workspace selected"
+    };
+
     public ICommand CreateDatabaseCommand => _createDatabaseCommand;
 
     public ICommand OpenDatabaseCommand => _openDatabaseCommand;
@@ -339,6 +360,10 @@ public sealed class ShellViewModel : ViewModelBase
     public ICommand LockDatabaseCommand => _lockDatabaseCommand;
 
     public ICommand RefreshWorkspaceCommand => _refreshWorkspaceCommand;
+
+    public ICommand DashboardCommand => UtilityNavigationItems[0].Command;
+
+    public ICommand SettingsSecurityCommand => UtilityNavigationItems[1].Command;
 
     private async Task CreateDatabaseAsync()
     {
@@ -1404,6 +1429,8 @@ public sealed class ShellViewModel : ViewModelBase
         {
             item.IsSelected = item.Title == page.Title;
         }
+
+        OnPropertyChanged(nameof(CurrentSelectionSummary));
     }
 
     private void OnCertificatesPagePropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -1418,6 +1445,7 @@ public sealed class ShellViewModel : ViewModelBase
                 _ = LoadSelectedCertificateInspectorAsync();
             }
 
+            OnPropertyChanged(nameof(CurrentSelectionSummary));
             RefreshCommandStates();
         }
     }
@@ -1452,6 +1480,7 @@ public sealed class ShellViewModel : ViewModelBase
                 _ = LoadSelectedTemplateAsync();
             }
 
+            OnPropertyChanged(nameof(CurrentSelectionSummary));
             RefreshCommandStates();
         }
     }
@@ -1498,6 +1527,8 @@ public sealed class ShellViewModel : ViewModelBase
         DashboardPage.DatabaseDisplayName = snapshot.DisplayName ?? "No database selected";
         DashboardPage.DatabasePath = snapshot.DatabasePath ?? "Open or create a database to begin.";
 
+        OnPropertyChanged(nameof(WorkspaceStatus));
+        OnPropertyChanged(nameof(CurrentSelectionSummary));
         RefreshCommandStates();
     }
 

--- a/src/XcaNet.App/Views/MainWindow.axaml
+++ b/src/XcaNet.App/Views/MainWindow.axaml
@@ -1,5 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:shared="using:XcaNet.App.Views.Shared"
         x:Class="XcaNet.App.Views.MainWindow"
         Width="1400"
         Height="920"
@@ -76,5 +77,36 @@
     </Border>
 
     <ContentControl Grid.Row="2" Grid.Column="1" Background="{DynamicResource AppBackgroundBrush}" Content="{Binding CurrentPage}" Margin="20" />
+
+    <Border Grid.Column="1"
+            Grid.RowSpan="3"
+            Background="{DynamicResource DialogOverlayBrush}"
+            IsVisible="{Binding IsAuthoringDialogOpen}">
+      <Grid Margin="32">
+        <Border Classes="authoring-dialog-shell"
+                Width="1080"
+                MaxWidth="1080"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Padding="22">
+          <Grid RowDefinitions="Auto,*" RowSpacing="16">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+              <StackPanel Spacing="4">
+                <TextBlock Text="{Binding AuthoringDialogTitle}" FontSize="26" FontWeight="SemiBold" />
+                <TextBlock Text="{Binding AuthoringDialogSubtitle}" Classes="secondary-text" />
+              </StackPanel>
+              <Button Grid.Column="1" Content="Close" Command="{Binding CloseAuthoringDialogCommand}" />
+            </Grid>
+
+            <Grid Grid.Row="1">
+              <shared:CertificateAuthoringSurfaceView DataContext="{Binding ActiveCertificateAuthoring}"
+                                                     IsVisible="{Binding IsCertificateAuthoringDialogOpen}" />
+              <shared:TemplateAuthoringDialogView DataContext="{Binding TemplatesPage}"
+                                                 IsVisible="{Binding IsTemplateAuthoringDialogOpen}" />
+            </Grid>
+          </Grid>
+        </Border>
+      </Grid>
+    </Border>
   </Grid>
 </Window>

--- a/src/XcaNet.App/Views/MainWindow.axaml
+++ b/src/XcaNet.App/Views/MainWindow.axaml
@@ -8,50 +8,78 @@
         MinHeight="760"
         DragDrop.AllowDrop="True"
         Title="XcaNet">
-  <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,Auto,*">
-    <Border Grid.RowSpan="3" Background="{DynamicResource ShellSidebarBrush}" Padding="18">
-      <StackPanel Spacing="16">
+  <Grid RowDefinitions="Auto,Auto,Auto,*">
+    <Border Classes="workspace-shell" Margin="16,16,16,0" Padding="18">
+      <Grid ColumnDefinitions="2.2*,1.6*,Auto" ColumnSpacing="18">
         <StackPanel Spacing="4">
-          <TextBlock Text="{Binding Title}" FontSize="28" FontWeight="Bold" Foreground="{DynamicResource ShellSidebarTextBrush}" />
-          <TextBlock Text="{Binding Subtitle}" Foreground="{DynamicResource ShellSidebarMutedTextBrush}" TextWrapping="Wrap" />
+          <TextBlock Text="{Binding Title}" FontSize="28" FontWeight="Bold" />
+          <TextBlock Text="XCA-style object workspace" Classes="secondary-text" />
         </StackPanel>
 
-        <ItemsControl ItemsSource="{Binding NavigationItems}">
+        <StackPanel Grid.Column="1" Spacing="4">
+          <TextBlock Text="{Binding SettingsSecurityPage.DisplayName}" FontSize="18" FontWeight="SemiBold" />
+          <TextBlock Text="{Binding SettingsSecurityPage.StatusMessage}" Classes="secondary-text" TextWrapping="Wrap" />
+          <TextBlock Text="{Binding SettingsSecurityPage.DatabasePath}" Classes="muted-text" TextWrapping="Wrap" />
+        </StackPanel>
+
+        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8" VerticalAlignment="Top">
+          <Border Classes="status-pill" Padding="12,8">
+            <TextBlock Text="{Binding SettingsSecurityPage.SessionState}" FontWeight="SemiBold" />
+          </Border>
+          <Button Classes="toolbar-action" Content="Create" Command="{Binding CreateDatabaseCommand}" />
+          <Button Classes="toolbar-action" Content="Open" Command="{Binding OpenDatabaseCommand}" />
+          <Button Classes="toolbar-action" Content="Unlock" Command="{Binding UnlockDatabaseCommand}" />
+          <Button Classes="toolbar-action" Content="Lock" Command="{Binding LockDatabaseCommand}" />
+          <Button Classes="toolbar-action" Content="Refresh" Command="{Binding RefreshWorkspaceCommand}" />
+        </StackPanel>
+      </Grid>
+    </Border>
+
+    <Border Grid.Row="1" Classes="workspace-shell" Margin="16,12,16,0" Padding="14">
+      <Grid ColumnDefinitions="*,Auto" ColumnSpacing="14">
+        <ItemsControl ItemsSource="{Binding WorkspaceNavigationItems}">
+          <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+              <StackPanel Orientation="Horizontal" Spacing="10" />
+            </ItemsPanelTemplate>
+          </ItemsControl.ItemsPanel>
           <ItemsControl.ItemTemplate>
             <DataTemplate>
               <Button Command="{Binding Command}"
-                      Classes="nav-item"
-                      Classes.is-selected="{Binding IsSelected}"
-                      HorizontalContentAlignment="Left"
-                      Padding="14,10"
-                      Margin="0,0,0,8">
-                <StackPanel Orientation="Horizontal" Spacing="10">
-                  <TextBlock Text="{Binding Glyph}" FontWeight="SemiBold" />
-                  <TextBlock Text="{Binding Title}" />
+                      Classes="workspace-tab"
+                      Classes.is-selected="{Binding IsSelected}">
+                <StackPanel Spacing="2">
+                  <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
+                  <TextBlock Text="{Binding Glyph}" Classes="muted-text" FontSize="11" />
                 </StackPanel>
               </Button>
             </DataTemplate>
           </ItemsControl.ItemTemplate>
         </ItemsControl>
-      </StackPanel>
-    </Border>
 
-    <Border Grid.Column="1" Background="{DynamicResource AppBackgroundBrush}" Padding="20,16" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
-      <Grid ColumnDefinitions="*,Auto">
-        <StackPanel Spacing="4">
-          <TextBlock Text="{Binding CurrentPage.Title}" FontSize="26" FontWeight="SemiBold" />
-          <TextBlock Text="{Binding SettingsSecurityPage.StatusMessage}" Classes="secondary-text" TextWrapping="Wrap" />
-        </StackPanel>
-        <Border Grid.Column="1"
-                Classes="status-pill"
-                Padding="12,8"
-                IsVisible="{Binding IsBusy}">
-          <TextBlock Text="{Binding BusyMessage}" FontWeight="SemiBold" />
-        </Border>
+        <ItemsControl Grid.Column="1" ItemsSource="{Binding UtilityNavigationItems}">
+          <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+              <StackPanel Orientation="Horizontal" Spacing="8" />
+            </ItemsPanelTemplate>
+          </ItemsControl.ItemsPanel>
+          <ItemsControl.ItemTemplate>
+            <DataTemplate>
+              <Button Command="{Binding Command}"
+                      Classes="utility-tab"
+                      Classes.is-selected="{Binding IsSelected}">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                  <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
+                  <TextBlock Text="{Binding Glyph}" Classes="muted-text" />
+                </StackPanel>
+              </Button>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
       </Grid>
     </Border>
 
-    <Border Grid.Row="1" Grid.Column="1" Padding="20,10" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+    <Border Grid.Row="2" Margin="16,12,16,0">
       <ItemsControl ItemsSource="{Binding Notifications}">
         <ItemsControl.ItemsPanel>
           <ItemsPanelTemplate>
@@ -76,10 +104,9 @@
       </ItemsControl>
     </Border>
 
-    <ContentControl Grid.Row="2" Grid.Column="1" Background="{DynamicResource AppBackgroundBrush}" Content="{Binding CurrentPage}" Margin="20" />
+    <ContentControl Grid.Row="3" Content="{Binding CurrentPage}" Margin="16" />
 
-    <Border Grid.Column="1"
-            Grid.RowSpan="3"
+    <Border Grid.RowSpan="4"
             Background="{DynamicResource DialogOverlayBrush}"
             IsVisible="{Binding IsAuthoringDialogOpen}">
       <Grid Margin="32">

--- a/src/XcaNet.App/Views/MainWindow.axaml
+++ b/src/XcaNet.App/Views/MainWindow.axaml
@@ -8,118 +8,75 @@
         MinHeight="760"
         DragDrop.AllowDrop="True"
         Title="XcaNet">
-  <Grid RowDefinitions="Auto,Auto,Auto,*">
-    <Border Classes="workspace-shell" Margin="16,16,16,0" Padding="18">
-      <Grid ColumnDefinitions="2.2*,1.6*,Auto" ColumnSpacing="18">
-        <StackPanel Spacing="4">
-          <TextBlock Text="{Binding Title}" FontSize="28" FontWeight="Bold" />
-          <TextBlock Text="XCA-style object workspace" Classes="secondary-text" />
-        </StackPanel>
+  <Grid RowDefinitions="Auto,Auto,*,Auto">
+    <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Background="{DynamicResource SurfaceBrush}">
+      <Menu>
+        <MenuItem Header="_File">
+          <MenuItem Header="Create Database" Command="{Binding CreateDatabaseCommand}" />
+          <MenuItem Header="Open Database" Command="{Binding OpenDatabaseCommand}" />
+          <Separator />
+          <MenuItem Header="Unlock" Command="{Binding UnlockDatabaseCommand}" />
+          <MenuItem Header="Lock" Command="{Binding LockDatabaseCommand}" />
+          <Separator />
+          <MenuItem Header="Refresh" Command="{Binding RefreshWorkspaceCommand}" />
+        </MenuItem>
+        <MenuItem Header="_Token">
+          <MenuItem Header="No token actions yet" IsEnabled="False" />
+        </MenuItem>
+        <MenuItem Header="_Help">
+          <MenuItem Header="Overview" Command="{Binding DashboardCommand}" />
+          <MenuItem Header="Settings / Security" Command="{Binding SettingsSecurityCommand}" />
+        </MenuItem>
+      </Menu>
+      <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,8,0" Spacing="10">
+        <TextBlock Text="{Binding SettingsSecurityPage.DisplayName}" VerticalAlignment="Center" />
+        <TextBlock Text="{Binding SettingsSecurityPage.SessionState}" Classes="secondary-text" VerticalAlignment="Center" />
+      </StackPanel>
+    </Grid>
 
-        <StackPanel Grid.Column="1" Spacing="4">
-          <TextBlock Text="{Binding SettingsSecurityPage.DisplayName}" FontSize="18" FontWeight="SemiBold" />
-          <TextBlock Text="{Binding SettingsSecurityPage.StatusMessage}" Classes="secondary-text" TextWrapping="Wrap" />
-          <TextBlock Text="{Binding SettingsSecurityPage.DatabasePath}" Classes="muted-text" TextWrapping="Wrap" />
-        </StackPanel>
-
-        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8" VerticalAlignment="Top">
-          <Border Classes="status-pill" Padding="12,8">
-            <TextBlock Text="{Binding SettingsSecurityPage.SessionState}" FontWeight="SemiBold" />
-          </Border>
-          <Button Classes="toolbar-action" Content="Create" Command="{Binding CreateDatabaseCommand}" />
-          <Button Classes="toolbar-action" Content="Open" Command="{Binding OpenDatabaseCommand}" />
-          <Button Classes="toolbar-action" Content="Unlock" Command="{Binding UnlockDatabaseCommand}" />
-          <Button Classes="toolbar-action" Content="Lock" Command="{Binding LockDatabaseCommand}" />
-          <Button Classes="toolbar-action" Content="Refresh" Command="{Binding RefreshWorkspaceCommand}" />
-        </StackPanel>
-      </Grid>
-    </Border>
-
-    <Border Grid.Row="1" Classes="workspace-shell" Margin="16,12,16,0" Padding="14">
-      <Grid ColumnDefinitions="*,Auto" ColumnSpacing="14">
-        <ItemsControl ItemsSource="{Binding WorkspaceNavigationItems}">
-          <ItemsControl.ItemsPanel>
-            <ItemsPanelTemplate>
-              <StackPanel Orientation="Horizontal" Spacing="10" />
-            </ItemsPanelTemplate>
-          </ItemsControl.ItemsPanel>
-          <ItemsControl.ItemTemplate>
-            <DataTemplate>
-              <Button Command="{Binding Command}"
-                      Classes="workspace-tab"
-                      Classes.is-selected="{Binding IsSelected}">
-                <StackPanel Spacing="2">
-                  <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
-                  <TextBlock Text="{Binding Glyph}" Classes="muted-text" FontSize="11" />
-                </StackPanel>
-              </Button>
-            </DataTemplate>
-          </ItemsControl.ItemTemplate>
-        </ItemsControl>
-
-        <ItemsControl Grid.Column="1" ItemsSource="{Binding UtilityNavigationItems}">
-          <ItemsControl.ItemsPanel>
-            <ItemsPanelTemplate>
-              <StackPanel Orientation="Horizontal" Spacing="8" />
-            </ItemsPanelTemplate>
-          </ItemsControl.ItemsPanel>
-          <ItemsControl.ItemTemplate>
-            <DataTemplate>
-              <Button Command="{Binding Command}"
-                      Classes="utility-tab"
-                      Classes.is-selected="{Binding IsSelected}">
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                  <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
-                  <TextBlock Text="{Binding Glyph}" Classes="muted-text" />
-                </StackPanel>
-              </Button>
-            </DataTemplate>
-          </ItemsControl.ItemTemplate>
-        </ItemsControl>
-      </Grid>
-    </Border>
-
-    <Border Grid.Row="2" Margin="16,12,16,0">
-      <ItemsControl ItemsSource="{Binding Notifications}">
+    <Border Grid.Row="1" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1" Background="{DynamicResource SurfaceAltBrush}" Padding="6,4">
+      <ItemsControl ItemsSource="{Binding WorkspaceNavigationItems}">
         <ItemsControl.ItemsPanel>
           <ItemsPanelTemplate>
-            <StackPanel Orientation="Horizontal" Spacing="10" />
+            <StackPanel Orientation="Horizontal" Spacing="4" />
           </ItemsPanelTemplate>
         </ItemsControl.ItemsPanel>
         <ItemsControl.ItemTemplate>
           <DataTemplate>
-            <Border Classes="notification-chip"
-                    Classes.success="{Binding IsSuccess}"
-                    Classes.warning="{Binding IsWarning}"
-                    Classes.error="{Binding IsError}"
-                    Classes.info="{Binding IsInfo}"
-                    Padding="12,8">
-              <StackPanel Spacing="2">
-                <TextBlock Text="{Binding Level}" FontWeight="SemiBold" />
-                <TextBlock Text="{Binding Message}" MaxWidth="420" TextWrapping="Wrap" />
-              </StackPanel>
-            </Border>
+            <Button Command="{Binding Command}" Classes="workspace-tab" Classes.is-selected="{Binding IsSelected}">
+              <TextBlock Text="{Binding Title}" />
+            </Button>
           </DataTemplate>
         </ItemsControl.ItemTemplate>
       </ItemsControl>
     </Border>
 
-    <ContentControl Grid.Row="3" Content="{Binding CurrentPage}" Margin="16" />
+    <Grid Grid.Row="2" Margin="8,6,8,0">
+      <ContentControl Content="{Binding CurrentPage}" />
+    </Grid>
+
+    <Border Grid.Row="3" Classes="classic-status-bar" Padding="6,4">
+      <Grid ColumnDefinitions="2.2*,1.2*,1.3*">
+        <TextBlock Text="{Binding WorkspaceStatus}" VerticalAlignment="Center" TextWrapping="Wrap" />
+        <TextBox Grid.Column="1" Margin="8,0" Text="{Binding SearchText}" Watermark="Search current workspace" />
+        <TextBlock Grid.Column="2" Text="{Binding CurrentSelectionSummary}" VerticalAlignment="Center" TextAlignment="Right" TextWrapping="Wrap" />
+      </Grid>
+    </Border>
 
     <Border Grid.RowSpan="4"
             Background="{DynamicResource DialogOverlayBrush}"
             IsVisible="{Binding IsAuthoringDialogOpen}">
-      <Grid Margin="32">
+      <Grid Margin="36">
         <Border Classes="authoring-dialog-shell"
-                Width="1080"
-                MaxWidth="1080"
+                Width="980"
+                MaxWidth="980"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
-                Padding="22">
-          <Grid RowDefinitions="Auto,*" RowSpacing="16">
-            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
-              <StackPanel Spacing="4">
-                <TextBlock Text="{Binding AuthoringDialogTitle}" FontSize="26" FontWeight="SemiBold" />
+                Padding="12">
+          <Grid RowDefinitions="Auto,*" RowSpacing="10">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+              <StackPanel Spacing="2">
+                <TextBlock Text="{Binding AuthoringDialogTitle}" FontSize="18" FontWeight="SemiBold" />
                 <TextBlock Text="{Binding AuthoringDialogSubtitle}" Classes="secondary-text" />
               </StackPanel>
               <Button Grid.Column="1" Content="Close" Command="{Binding CloseAuthoringDialogCommand}" />

--- a/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
@@ -1,112 +1,78 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Pages.CertificateRequestsPageView">
-  <Grid ColumnDefinitions="1.45*,1*" ColumnSpacing="16">
-    <Border Classes="workspace-pane">
+  <Grid ColumnDefinitions="*,150" RowDefinitions="*,170" ColumnSpacing="8" RowSpacing="8">
+    <Border Grid.Row="0" Classes="workspace-pane">
       <Grid RowDefinitions="Auto,*">
-        <Border Classes="workspace-toolbar" Padding="14">
-          <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="8">
-            <StackPanel Spacing="2">
-              <TextBlock Text="Certificate Requests" FontSize="20" FontWeight="SemiBold" />
-              <TextBlock Text="Request-first workspace with compact signing and transform actions." Classes="secondary-text" />
-            </StackPanel>
-            <Button Grid.Column="1" Classes="toolbar-action" Content="Open Key" Command="{Binding OpenSelectedPrivateKeyCommand}" />
-            <Button Grid.Column="2" Classes="toolbar-action" Content="Sign Request" Command="{Binding OpenIssuanceAuthoringCommand}" />
-            <Button Grid.Column="3" Classes="toolbar-action" Content="Similar Request" Command="{Binding CreateSimilarRequestCommand}" />
-            <Button Grid.Column="4" Classes="toolbar-action" Content="To Template" Command="{Binding CreateTemplateFromRequestCommand}" />
-            <Button Grid.Column="5" Classes="toolbar-action" Content="Export" Command="{Binding ExportSelectedToFileCommand}" />
-            <Button Grid.Column="6" Classes="toolbar-action" Content="Refresh" Command="{Binding RefreshCommand}" />
+        <Border Classes="table-header" Padding="8,6">
+          <Grid ColumnDefinitions="1.2*,2.2*,1.0*,0.9*,1.0*" ColumnSpacing="10">
+            <TextBlock Text="Certificate signing requests" FontWeight="SemiBold" />
+            <TextBlock Grid.Column="1" Text="Subject" Classes="table-header-text" />
+            <TextBlock Grid.Column="2" Text="Key" Classes="table-header-text" />
+            <TextBlock Grid.Column="3" Text="Created" Classes="table-header-text" />
+            <TextBlock Grid.Column="4" Text="Algorithm" Classes="table-header-text" />
           </Grid>
         </Border>
-
-        <Grid Grid.Row="1" Margin="0,12,0,0" RowDefinitions="Auto,*">
-          <Border Classes="table-header" Padding="14,10">
-            <Grid ColumnDefinitions="1.4*,2.1*,1.1*,1.0*,0.9*" ColumnSpacing="12">
-              <TextBlock Text="Name" Classes="table-header-text" />
-              <TextBlock Grid.Column="1" Text="Subject" Classes="table-header-text" />
-              <TextBlock Grid.Column="2" Text="Key" Classes="table-header-text" />
-              <TextBlock Grid.Column="3" Text="Created" Classes="table-header-text" />
-              <TextBlock Grid.Column="4" Text="Algorithm" Classes="table-header-text" />
-            </Grid>
+        <Grid Grid.Row="1">
+          <Border Classes="empty-state" Margin="8" Padding="12" IsVisible="{Binding IsEmpty}">
+            <TextBlock Text="{Binding EmptyStateMessage}" TextWrapping="Wrap" />
           </Border>
-          <Grid Grid.Row="1">
-            <Border Classes="empty-state" Margin="14" Padding="16" IsVisible="{Binding IsEmpty}">
-              <StackPanel Spacing="6">
-                <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
-                <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
-              </StackPanel>
-            </Border>
-            <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
-              <ListBox.ItemTemplate>
-                <DataTemplate>
-                  <Border Padding="14,10" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
-                    <Grid ColumnDefinitions="1.4*,2.1*,1.1*,1.0*,0.9*" ColumnSpacing="12">
-                      <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
-                      <StackPanel Grid.Column="1">
-                        <TextBlock Text="{Binding Subject}" TextWrapping="Wrap" />
-                        <TextBlock Text="{Binding SubjectAlternativeNames}" Classes="muted-text" TextWrapping="Wrap" />
-                      </StackPanel>
-                      <TextBlock Grid.Column="2" Text="{Binding PrivateKeySummary}" />
-                      <TextBlock Grid.Column="3" Text="{Binding CreatedUtc, StringFormat='{}{0:yyyy-MM-dd}'}" />
-                      <TextBlock Grid.Column="4" Text="{Binding KeyAlgorithm}" />
-                    </Grid>
-                  </Border>
-                </DataTemplate>
-              </ListBox.ItemTemplate>
-            </ListBox>
-          </Grid>
+          <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+            <ListBox.ItemTemplate>
+              <DataTemplate>
+                <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                  <Grid ColumnDefinitions="1.2*,2.2*,1.0*,0.9*,1.0*" ColumnSpacing="10">
+                    <TextBlock Text="{Binding DisplayName}" />
+                    <TextBlock Grid.Column="1" Text="{Binding Subject}" TextWrapping="Wrap" />
+                    <TextBlock Grid.Column="2" Text="{Binding PrivateKeySummary}" />
+                    <TextBlock Grid.Column="3" Text="{Binding CreatedUtc, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                    <TextBlock Grid.Column="4" Text="{Binding KeyAlgorithm}" />
+                  </Grid>
+                </Border>
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
         </Grid>
       </Grid>
     </Border>
 
-    <Border Grid.Column="1" Classes="workspace-pane">
-      <Grid RowDefinitions="Auto,*">
-        <Border Classes="workspace-toolbar" Padding="14">
-          <Grid ColumnDefinitions="*,Auto">
-            <StackPanel Spacing="2">
-              <TextBlock Text="Request Properties" FontSize="20" FontWeight="SemiBold" />
-              <TextBlock Text="Selected request details, signing actions, and export preview." Classes="secondary-text" />
-            </StackPanel>
-            <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" VerticalAlignment="Center" FontWeight="SemiBold" />
-          </Grid>
-        </Border>
+    <Border Grid.Column="1" Classes="classic-side-panel" Padding="8">
+      <StackPanel>
+        <Button Classes="side-action" Content="New Request" IsEnabled="False" />
+        <Button Classes="side-action" Content="Sign" Command="{Binding OpenIssuanceAuthoringCommand}" />
+        <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedToFileCommand}" />
+        <Button Classes="side-action" Content="Import" IsEnabled="False" />
+        <Button Classes="side-action" Content="Show Details" IsEnabled="False" />
+        <Button Classes="side-action" Content="Delete" IsEnabled="False" />
+        <Button Classes="side-action" Content="Similar Request" Command="{Binding CreateSimilarRequestCommand}" />
+        <Button Classes="side-action" Content="To Template" Command="{Binding CreateTemplateFromRequestCommand}" />
+        <Button Classes="side-action" Content="Open Key" Command="{Binding OpenSelectedPrivateKeyCommand}" />
+        <Button Classes="side-action" Content="Refresh" Command="{Binding RefreshCommand}" />
+      </StackPanel>
+    </Border>
 
-        <TabControl Grid.Row="1" Classes="workspace-inspector-tabs" Margin="14">
-          <TabItem Header="General">
-            <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8" Margin="0,12,0,0">
-              <TextBlock Text="Name" />
-              <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" />
-              <TextBlock Grid.Row="1" Text="Subject" />
-              <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.Subject}" TextWrapping="Wrap" />
-              <TextBlock Grid.Row="2" Text="SAN" />
-              <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedItem.SubjectAlternativeNames}" TextWrapping="Wrap" />
-              <TextBlock Grid.Row="3" Text="Algorithm" />
-              <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.KeyAlgorithm}" />
-            </Grid>
-          </TabItem>
-          <TabItem Header="Actions">
-            <StackPanel Spacing="10" Margin="0,12,0,0">
-              <Border Classes="surface-subtle" Padding="12">
-                <TextBlock Text="Issuance opens the shared certificate input dialog with the acting CA and signing key chosen in one place, matching the M13.1 authoring flow."
-                           Classes="secondary-text"
-                           TextWrapping="Wrap" />
-              </Border>
-              <StackPanel Orientation="Horizontal" Spacing="10">
-                <Button Classes="toolbar-action" Content="Sign Request" Command="{Binding OpenIssuanceAuthoringCommand}" />
-                <Button Classes="toolbar-action" Content="Create Similar" Command="{Binding CreateSimilarRequestCommand}" />
-                <Button Classes="toolbar-action" Content="To Template" Command="{Binding CreateTemplateFromRequestCommand}" />
-                <Button Classes="toolbar-action" Content="Open Key" Command="{Binding OpenSelectedPrivateKeyCommand}" />
-              </StackPanel>
-            </StackPanel>
-          </TabItem>
-          <TabItem Header="Export">
-            <StackPanel Spacing="10" Margin="0,12,0,0">
-              <ComboBox Width="220" ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
-              <TextBox Classes="readonly-surface" Text="{Binding ExportPreview}" AcceptsReturn="True" Height="260" TextWrapping="Wrap" />
-            </StackPanel>
-          </TabItem>
-        </TabControl>
-      </Grid>
+    <Border Grid.Row="1" Grid.ColumnSpan="2" Classes="workspace-pane" Padding="8">
+      <TabControl Classes="workspace-inspector-tabs">
+        <TabItem Header="Details">
+          <Grid Margin="6" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="6">
+            <TextBlock Text="Name" />
+            <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" />
+            <TextBlock Grid.Row="1" Text="Subject" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.Subject}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="2" Text="Alternative names" />
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedItem.SubjectAlternativeNames}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="3" Text="Algorithm" />
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.KeyAlgorithm}" />
+          </Grid>
+        </TabItem>
+        <TabItem Header="Export">
+          <Grid Margin="6" ColumnDefinitions="220,*" RowDefinitions="Auto,*" ColumnSpacing="10" RowSpacing="8">
+            <ComboBox ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
+            <Button Grid.Column="1" Content="Preview Export" HorizontalAlignment="Left" Command="{Binding ExportSelectedCommand}" />
+            <TextBox Grid.Row="1" Grid.ColumnSpan="2" Classes="readonly-surface" Text="{Binding ExportPreview}" AcceptsReturn="True" TextWrapping="Wrap" />
+          </Grid>
+        </TabItem>
+      </TabControl>
     </Border>
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:shared="using:XcaNet.App.Views.Shared"
              x:Class="XcaNet.App.Views.Pages.CertificateRequestsPageView">
   <Grid ColumnDefinitions="1.1*,1*" ColumnSpacing="16">
     <StackPanel Spacing="14">
@@ -38,21 +39,12 @@
     <StackPanel Grid.Column="1" Spacing="14">
       <Border Classes="surface-card" Padding="16">
         <StackPanel Spacing="10">
-          <TextBlock Text="Sign Selected CSR" FontSize="18" FontWeight="SemiBold" />
-          <Border Classes="info-panel" Padding="12">
-            <TextBlock Text="Choose a CA certificate and the matching issuer key to produce a managed or routed certificate according to the backend policy." Classes="secondary-text" TextWrapping="Wrap" />
-          </Border>
-          <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-            <ComboBox ItemsSource="{Binding IssuanceTemplates}" SelectedItem="{Binding SelectedIssuanceTemplate}" />
-            <Button Grid.Column="1" Content="Apply Template" Command="{Binding ApplyIssuanceTemplateCommand}" />
+          <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
+            <TextBlock Text="Certificate Input" FontSize="18" FontWeight="SemiBold" />
+            <Button Grid.Column="1" Content="Similar Request" Command="{Binding CreateSimilarRequestCommand}" />
+            <Button Grid.Column="2" Content="CSR to Template" Command="{Binding CreateTemplateFromRequestCommand}" />
           </Grid>
-          <TextBox Text="{Binding IssuedCertificateDisplayName}" Watermark="Issued certificate display name" />
-          <ComboBox ItemsSource="{Binding IssuerCertificates}" SelectedItem="{Binding SelectedIssuerCertificate}" />
-          <ComboBox ItemsSource="{Binding IssuerPrivateKeys}" SelectedItem="{Binding SelectedIssuerPrivateKey}" />
-          <Grid ColumnDefinitions="180,Auto" ColumnSpacing="10">
-            <NumericUpDown Minimum="1" Maximum="36500" Value="{Binding ValidityDays}" />
-            <Button Grid.Column="1" Content="Sign CSR" Command="{Binding SignSelectedCommand}" />
-          </Grid>
+          <shared:CertificateAuthoringSurfaceView DataContext="{Binding IssuanceAuthoring}" />
         </StackPanel>
       </Border>
 

--- a/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
@@ -1,68 +1,112 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Pages.CertificateRequestsPageView">
-  <Grid ColumnDefinitions="1.1*,1*" ColumnSpacing="16">
-    <StackPanel Spacing="14">
-      <Border Classes="surface-card" Padding="12">
-        <StackPanel Spacing="10">
-          <Grid ColumnDefinitions="*,Auto,Auto">
-            <TextBlock Text="Certificate Signing Requests" FontSize="18" FontWeight="SemiBold" />
-            <Button Grid.Column="1" Content="Open Key" Command="{Binding OpenSelectedPrivateKeyCommand}" Margin="0,0,10,0" />
-            <Button Grid.Column="2" Content="Refresh" Command="{Binding RefreshCommand}" />
-          </Grid>
-          <Border Classes="empty-state" Padding="16" IsVisible="{Binding IsEmpty}">
-            <StackPanel Spacing="6">
-              <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
-              <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
+  <Grid ColumnDefinitions="1.45*,1*" ColumnSpacing="16">
+    <Border Classes="workspace-pane">
+      <Grid RowDefinitions="Auto,*">
+        <Border Classes="workspace-toolbar" Padding="14">
+          <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="8">
+            <StackPanel Spacing="2">
+              <TextBlock Text="Certificate Requests" FontSize="20" FontWeight="SemiBold" />
+              <TextBlock Text="Request-first workspace with compact signing and transform actions." Classes="secondary-text" />
             </StackPanel>
+            <Button Grid.Column="1" Classes="toolbar-action" Content="Open Key" Command="{Binding OpenSelectedPrivateKeyCommand}" />
+            <Button Grid.Column="2" Classes="toolbar-action" Content="Sign Request" Command="{Binding OpenIssuanceAuthoringCommand}" />
+            <Button Grid.Column="3" Classes="toolbar-action" Content="Similar Request" Command="{Binding CreateSimilarRequestCommand}" />
+            <Button Grid.Column="4" Classes="toolbar-action" Content="To Template" Command="{Binding CreateTemplateFromRequestCommand}" />
+            <Button Grid.Column="5" Classes="toolbar-action" Content="Export" Command="{Binding ExportSelectedToFileCommand}" />
+            <Button Grid.Column="6" Classes="toolbar-action" Content="Refresh" Command="{Binding RefreshCommand}" />
+          </Grid>
+        </Border>
+
+        <Grid Grid.Row="1" Margin="0,12,0,0" RowDefinitions="Auto,*">
+          <Border Classes="table-header" Padding="14,10">
+            <Grid ColumnDefinitions="1.4*,2.1*,1.1*,1.0*,0.9*" ColumnSpacing="12">
+              <TextBlock Text="Name" Classes="table-header-text" />
+              <TextBlock Grid.Column="1" Text="Subject" Classes="table-header-text" />
+              <TextBlock Grid.Column="2" Text="Key" Classes="table-header-text" />
+              <TextBlock Grid.Column="3" Text="Created" Classes="table-header-text" />
+              <TextBlock Grid.Column="4" Text="Algorithm" Classes="table-header-text" />
+            </Grid>
           </Border>
-          <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}" Height="360">
-            <ListBox.ItemTemplate>
-              <DataTemplate>
-                <Border Padding="8">
-                  <Grid ColumnDefinitions="2*,Auto" ColumnSpacing="10">
-                    <StackPanel>
+          <Grid Grid.Row="1">
+            <Border Classes="empty-state" Margin="14" Padding="16" IsVisible="{Binding IsEmpty}">
+              <StackPanel Spacing="6">
+                <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
+                <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
+              </StackPanel>
+            </Border>
+            <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+              <ListBox.ItemTemplate>
+                <DataTemplate>
+                  <Border Padding="14,10" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                    <Grid ColumnDefinitions="1.4*,2.1*,1.1*,1.0*,0.9*" ColumnSpacing="12">
                       <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
-                      <TextBlock Text="{Binding Subject}" Classes="secondary-text" TextWrapping="Wrap" />
-                    </StackPanel>
-                    <TextBlock Grid.Column="1" Text="{Binding KeyAlgorithm}" />
-                  </Grid>
-                </Border>
-              </DataTemplate>
-            </ListBox.ItemTemplate>
-          </ListBox>
-        </StackPanel>
-      </Border>
-    </StackPanel>
+                      <StackPanel Grid.Column="1">
+                        <TextBlock Text="{Binding Subject}" TextWrapping="Wrap" />
+                        <TextBlock Text="{Binding SubjectAlternativeNames}" Classes="muted-text" TextWrapping="Wrap" />
+                      </StackPanel>
+                      <TextBlock Grid.Column="2" Text="{Binding PrivateKeySummary}" />
+                      <TextBlock Grid.Column="3" Text="{Binding CreatedUtc, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                      <TextBlock Grid.Column="4" Text="{Binding KeyAlgorithm}" />
+                    </Grid>
+                  </Border>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Border>
 
-    <StackPanel Grid.Column="1" Spacing="14">
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <TextBlock Text="Request Actions" FontSize="18" FontWeight="SemiBold" />
-          <Border Classes="info-panel" Padding="12">
-            <TextBlock Text="Selected requests now open a dedicated certificate input workbench for issuance instead of editing in a persistent workspace panel."
-                       Classes="secondary-text"
-                       TextWrapping="Wrap" />
-          </Border>
-          <StackPanel Orientation="Horizontal" Spacing="10">
-            <Button Content="Open Signing Input" Command="{Binding OpenIssuanceAuthoringCommand}" />
-            <Button Content="Similar Request" Command="{Binding CreateSimilarRequestCommand}" />
-            <Button Content="CSR to Template" Command="{Binding CreateTemplateFromRequestCommand}" />
-          </StackPanel>
-        </StackPanel>
-      </Border>
+    <Border Grid.Column="1" Classes="workspace-pane">
+      <Grid RowDefinitions="Auto,*">
+        <Border Classes="workspace-toolbar" Padding="14">
+          <Grid ColumnDefinitions="*,Auto">
+            <StackPanel Spacing="2">
+              <TextBlock Text="Request Properties" FontSize="20" FontWeight="SemiBold" />
+              <TextBlock Text="Selected request details, signing actions, and export preview." Classes="secondary-text" />
+            </StackPanel>
+            <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" VerticalAlignment="Center" FontWeight="SemiBold" />
+          </Grid>
+        </Border>
 
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <TextBlock Text="Export CSR" FontSize="18" FontWeight="SemiBold" />
-          <ComboBox ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
-          <StackPanel Orientation="Horizontal" Spacing="10">
-            <Button Content="Preview Export" Command="{Binding ExportSelectedCommand}" />
-            <Button Content="Export to File" Command="{Binding ExportSelectedToFileCommand}" />
-          </StackPanel>
-          <TextBox Classes="readonly-surface" Text="{Binding ExportPreview}" AcceptsReturn="True" Height="180" TextWrapping="Wrap" />
-        </StackPanel>
-      </Border>
-    </StackPanel>
+        <TabControl Grid.Row="1" Classes="workspace-inspector-tabs" Margin="14">
+          <TabItem Header="General">
+            <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8" Margin="0,12,0,0">
+              <TextBlock Text="Name" />
+              <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" />
+              <TextBlock Grid.Row="1" Text="Subject" />
+              <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.Subject}" TextWrapping="Wrap" />
+              <TextBlock Grid.Row="2" Text="SAN" />
+              <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedItem.SubjectAlternativeNames}" TextWrapping="Wrap" />
+              <TextBlock Grid.Row="3" Text="Algorithm" />
+              <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.KeyAlgorithm}" />
+            </Grid>
+          </TabItem>
+          <TabItem Header="Actions">
+            <StackPanel Spacing="10" Margin="0,12,0,0">
+              <Border Classes="surface-subtle" Padding="12">
+                <TextBlock Text="Issuance opens the shared certificate input dialog with the acting CA and signing key chosen in one place, matching the M13.1 authoring flow."
+                           Classes="secondary-text"
+                           TextWrapping="Wrap" />
+              </Border>
+              <StackPanel Orientation="Horizontal" Spacing="10">
+                <Button Classes="toolbar-action" Content="Sign Request" Command="{Binding OpenIssuanceAuthoringCommand}" />
+                <Button Classes="toolbar-action" Content="Create Similar" Command="{Binding CreateSimilarRequestCommand}" />
+                <Button Classes="toolbar-action" Content="To Template" Command="{Binding CreateTemplateFromRequestCommand}" />
+                <Button Classes="toolbar-action" Content="Open Key" Command="{Binding OpenSelectedPrivateKeyCommand}" />
+              </StackPanel>
+            </StackPanel>
+          </TabItem>
+          <TabItem Header="Export">
+            <StackPanel Spacing="10" Margin="0,12,0,0">
+              <ComboBox Width="220" ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
+              <TextBox Classes="readonly-surface" Text="{Binding ExportPreview}" AcceptsReturn="True" Height="260" TextWrapping="Wrap" />
+            </StackPanel>
+          </TabItem>
+        </TabControl>
+      </Grid>
+    </Border>
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
@@ -1,6 +1,5 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:shared="using:XcaNet.App.Views.Shared"
              x:Class="XcaNet.App.Views.Pages.CertificateRequestsPageView">
   <Grid ColumnDefinitions="1.1*,1*" ColumnSpacing="16">
     <StackPanel Spacing="14">
@@ -39,12 +38,17 @@
     <StackPanel Grid.Column="1" Spacing="14">
       <Border Classes="surface-card" Padding="16">
         <StackPanel Spacing="10">
-          <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
-            <TextBlock Text="Certificate Input" FontSize="18" FontWeight="SemiBold" />
-            <Button Grid.Column="1" Content="Similar Request" Command="{Binding CreateSimilarRequestCommand}" />
-            <Button Grid.Column="2" Content="CSR to Template" Command="{Binding CreateTemplateFromRequestCommand}" />
-          </Grid>
-          <shared:CertificateAuthoringSurfaceView DataContext="{Binding IssuanceAuthoring}" />
+          <TextBlock Text="Request Actions" FontSize="18" FontWeight="SemiBold" />
+          <Border Classes="info-panel" Padding="12">
+            <TextBlock Text="Selected requests now open a dedicated certificate input workbench for issuance instead of editing in a persistent workspace panel."
+                       Classes="secondary-text"
+                       TextWrapping="Wrap" />
+          </Border>
+          <StackPanel Orientation="Horizontal" Spacing="10">
+            <Button Content="Open Signing Input" Command="{Binding OpenIssuanceAuthoringCommand}" />
+            <Button Content="Similar Request" Command="{Binding CreateSimilarRequestCommand}" />
+            <Button Content="CSR to Template" Command="{Binding CreateTemplateFromRequestCommand}" />
+          </StackPanel>
         </StackPanel>
       </Border>
 

--- a/src/XcaNet.App/Views/Pages/CertificateRevocationListsPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificateRevocationListsPageView.axaml
@@ -1,74 +1,103 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Pages.CertificateRevocationListsPageView">
-  <Grid ColumnDefinitions="1.2*,1*" ColumnSpacing="16">
-    <Border Classes="surface-card" Padding="16">
-      <StackPanel Spacing="10">
-        <Grid ColumnDefinitions="*,Auto">
-          <TextBlock Text="Certificate Revocation Lists" FontSize="18" FontWeight="SemiBold" />
-          <Button Grid.Column="1" Content="Refresh" Command="{Binding RefreshCommand}" />
-        </Grid>
-        <TextBlock Text="{Binding PlaceholderMessage}" Classes="secondary-text" TextWrapping="Wrap" />
-        <Border Classes="empty-state" Padding="16" IsVisible="{Binding IsEmpty}">
-          <StackPanel Spacing="6">
-            <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
-            <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
-          </StackPanel>
+  <Grid ColumnDefinitions="1.35*,1*" ColumnSpacing="16">
+    <Border Classes="workspace-pane">
+      <Grid RowDefinitions="Auto,*">
+        <Border Classes="workspace-toolbar" Padding="14">
+          <Grid ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="8">
+            <StackPanel Spacing="2">
+              <TextBlock Text="Certificate Revocation Lists" FontSize="20" FontWeight="SemiBold" />
+              <TextBlock Text="CRL object workspace with issuer and publication windows kept visible from the list." Classes="secondary-text" />
+            </StackPanel>
+            <Button Grid.Column="1" Classes="toolbar-action" Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
+            <Button Grid.Column="2" Classes="toolbar-action" Content="Export" Command="{Binding ExportSelectedCommand}" />
+            <Button Grid.Column="3" Classes="toolbar-action" Content="Refresh" Command="{Binding RefreshCommand}" />
+          </Grid>
         </Border>
-        <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}" Height="500">
-          <ListBox.ItemTemplate>
-            <DataTemplate>
-              <Border Padding="8">
-                <Grid ColumnDefinitions="1.7*,1.2*,Auto,Auto,Auto" ColumnSpacing="10">
-                  <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
-                  <TextBlock Grid.Column="1" Text="{Binding IssuerDisplayName}" />
-                  <TextBlock Grid.Column="2" Text="{Binding CrlNumber}" />
-                  <TextBlock Grid.Column="3" Text="{Binding ThisUpdate}" />
-                  <TextBlock Grid.Column="4" Text="{Binding RevokedEntryCount}" />
-                </Grid>
-              </Border>
-            </DataTemplate>
-          </ListBox.ItemTemplate>
-        </ListBox>
-      </StackPanel>
+
+        <Grid Grid.Row="1" Margin="0,12,0,0" RowDefinitions="Auto,*">
+          <Border Classes="table-header" Padding="14,10">
+            <Grid ColumnDefinitions="1.6*,1.4*,0.9*,1.1*,1.1*,0.9*" ColumnSpacing="12">
+              <TextBlock Text="Issuer" Classes="table-header-text" />
+              <TextBlock Grid.Column="1" Text="Name" Classes="table-header-text" />
+              <TextBlock Grid.Column="2" Text="CRL #" Classes="table-header-text" />
+              <TextBlock Grid.Column="3" Text="This Update" Classes="table-header-text" />
+              <TextBlock Grid.Column="4" Text="Next Update" Classes="table-header-text" />
+              <TextBlock Grid.Column="5" Text="Revoked" Classes="table-header-text" />
+            </Grid>
+          </Border>
+          <Grid Grid.Row="1">
+            <Border Classes="empty-state" Margin="14" Padding="16" IsVisible="{Binding IsEmpty}">
+              <StackPanel Spacing="6">
+                <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
+                <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
+              </StackPanel>
+            </Border>
+            <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+              <ListBox.ItemTemplate>
+                <DataTemplate>
+                  <Border Padding="14,10" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                    <Grid ColumnDefinitions="1.6*,1.4*,0.9*,1.1*,1.1*,0.9*" ColumnSpacing="12">
+                      <TextBlock Text="{Binding IssuerDisplayName}" FontWeight="SemiBold" />
+                      <TextBlock Grid.Column="1" Text="{Binding DisplayName}" />
+                      <TextBlock Grid.Column="2" Text="{Binding CrlNumber}" />
+                      <TextBlock Grid.Column="3" Text="{Binding ThisUpdate, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                      <TextBlock Grid.Column="4" Text="{Binding NextUpdateUtc, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                      <TextBlock Grid.Column="5" Text="{Binding RevokedEntryCount}" />
+                    </Grid>
+                  </Border>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+          </Grid>
+        </Grid>
+      </Grid>
     </Border>
 
-    <Border Grid.Column="1" Classes="surface-card" Padding="16">
-      <StackPanel Spacing="10">
-        <Grid ColumnDefinitions="*,Auto">
-          <TextBlock Text="CRL Inspector" FontSize="18" FontWeight="SemiBold" />
-          <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10">
-            <Button Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
-            <Button Content="Export" Command="{Binding ExportSelectedCommand}" />
-          </StackPanel>
-        </Grid>
-        <TextBlock Text="Select a CRL to inspect issuer metadata, publication windows, and revoked entries." Classes="secondary-text" TextWrapping="Wrap" />
-        <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="8">
-          <TextBlock Text="Issuer" />
-          <TextBlock Grid.Column="1" Text="{Binding Inspector.IssuerDisplayName}" TextWrapping="Wrap" />
-          <TextBlock Grid.Row="1" Text="CRL Number" />
-          <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.CrlNumber}" />
-          <TextBlock Grid.Row="2" Text="This Update" />
-          <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.ThisUpdate}" />
-          <TextBlock Grid.Row="3" Text="Next Update" />
-          <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Inspector.NextUpdate}" />
-        </Grid>
-        <TextBlock Text="Revoked Certificates" FontWeight="SemiBold" />
-        <ListBox ItemsSource="{Binding Inspector.RevokedEntries}" Height="320">
-          <ListBox.ItemTemplate>
-            <DataTemplate>
-              <Border Padding="8">
-                <Grid ColumnDefinitions="1.3*,1.2*,Auto,Auto" ColumnSpacing="10">
-                  <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
-                  <TextBlock Grid.Column="1" Text="{Binding SerialNumber}" />
-                  <TextBlock Grid.Column="2" Text="{Binding Reason}" />
-                  <TextBlock Grid.Column="3" Text="{Binding RevokedAt}" />
-                </Grid>
-              </Border>
-            </DataTemplate>
-          </ListBox.ItemTemplate>
-        </ListBox>
-      </StackPanel>
+    <Border Grid.Column="1" Classes="workspace-pane">
+      <Grid RowDefinitions="Auto,*">
+        <Border Classes="workspace-toolbar" Padding="14">
+          <Grid ColumnDefinitions="*,Auto">
+            <StackPanel Spacing="2">
+              <TextBlock Text="CRL Properties" FontSize="20" FontWeight="SemiBold" />
+              <TextBlock Text="{Binding PlaceholderMessage}" Classes="secondary-text" TextWrapping="Wrap" />
+            </StackPanel>
+            <TextBlock Grid.Column="1" Text="{Binding Inspector.IssuerDisplayName}" VerticalAlignment="Center" FontWeight="SemiBold" />
+          </Grid>
+        </Border>
+
+        <TabControl Grid.Row="1" Classes="workspace-inspector-tabs" Margin="14">
+          <TabItem Header="General">
+            <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8" Margin="0,12,0,0">
+              <TextBlock Text="Issuer" />
+              <TextBlock Grid.Column="1" Text="{Binding Inspector.IssuerDisplayName}" TextWrapping="Wrap" />
+              <TextBlock Grid.Row="1" Text="CRL Number" />
+              <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.CrlNumber}" />
+              <TextBlock Grid.Row="2" Text="This Update" />
+              <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.ThisUpdate}" />
+              <TextBlock Grid.Row="3" Text="Next Update" />
+              <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Inspector.NextUpdate}" />
+            </Grid>
+          </TabItem>
+          <TabItem Header="Revoked Entries">
+            <ListBox Margin="0,12,0,0" ItemsSource="{Binding Inspector.RevokedEntries}">
+              <ListBox.ItemTemplate>
+                <DataTemplate>
+                  <Border Padding="10" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                    <Grid ColumnDefinitions="1.4*,1.2*,1*,1*" ColumnSpacing="10">
+                      <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
+                      <TextBlock Grid.Column="1" Text="{Binding SerialNumber}" />
+                      <TextBlock Grid.Column="2" Text="{Binding Reason}" />
+                      <TextBlock Grid.Column="3" Text="{Binding RevokedAt}" />
+                    </Grid>
+                  </Border>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+          </TabItem>
+        </TabControl>
+      </Grid>
     </Border>
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Pages/CertificateRevocationListsPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificateRevocationListsPageView.axaml
@@ -1,103 +1,86 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Pages.CertificateRevocationListsPageView">
-  <Grid ColumnDefinitions="1.35*,1*" ColumnSpacing="16">
+  <Grid ColumnDefinitions="*,150" RowDefinitions="*,170" ColumnSpacing="8" RowSpacing="8">
     <Border Classes="workspace-pane">
       <Grid RowDefinitions="Auto,*">
-        <Border Classes="workspace-toolbar" Padding="14">
-          <Grid ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="8">
-            <StackPanel Spacing="2">
-              <TextBlock Text="Certificate Revocation Lists" FontSize="20" FontWeight="SemiBold" />
-              <TextBlock Text="CRL object workspace with issuer and publication windows kept visible from the list." Classes="secondary-text" />
-            </StackPanel>
-            <Button Grid.Column="1" Classes="toolbar-action" Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
-            <Button Grid.Column="2" Classes="toolbar-action" Content="Export" Command="{Binding ExportSelectedCommand}" />
-            <Button Grid.Column="3" Classes="toolbar-action" Content="Refresh" Command="{Binding RefreshCommand}" />
+        <Border Classes="table-header" Padding="8,6">
+          <Grid ColumnDefinitions="1.6*,1.2*,0.8*,1.0*,1.0*,0.8*" ColumnSpacing="8">
+            <TextBlock Text="Revocation lists" FontWeight="SemiBold" />
+            <TextBlock Grid.Column="1" Text="CRL number" Classes="table-header-text" />
+            <TextBlock Grid.Column="2" Text="Issuer" Classes="table-header-text" />
+            <TextBlock Grid.Column="3" Text="This update" Classes="table-header-text" />
+            <TextBlock Grid.Column="4" Text="Next update" Classes="table-header-text" />
+            <TextBlock Grid.Column="5" Text="Revoked" Classes="table-header-text" />
           </Grid>
         </Border>
-
-        <Grid Grid.Row="1" Margin="0,12,0,0" RowDefinitions="Auto,*">
-          <Border Classes="table-header" Padding="14,10">
-            <Grid ColumnDefinitions="1.6*,1.4*,0.9*,1.1*,1.1*,0.9*" ColumnSpacing="12">
-              <TextBlock Text="Issuer" Classes="table-header-text" />
-              <TextBlock Grid.Column="1" Text="Name" Classes="table-header-text" />
-              <TextBlock Grid.Column="2" Text="CRL #" Classes="table-header-text" />
-              <TextBlock Grid.Column="3" Text="This Update" Classes="table-header-text" />
-              <TextBlock Grid.Column="4" Text="Next Update" Classes="table-header-text" />
-              <TextBlock Grid.Column="5" Text="Revoked" Classes="table-header-text" />
-            </Grid>
+        <Grid Grid.Row="1">
+          <Border Classes="empty-state" Margin="8" Padding="12" IsVisible="{Binding IsEmpty}">
+            <TextBlock Text="{Binding EmptyStateMessage}" TextWrapping="Wrap" />
           </Border>
-          <Grid Grid.Row="1">
-            <Border Classes="empty-state" Margin="14" Padding="16" IsVisible="{Binding IsEmpty}">
-              <StackPanel Spacing="6">
-                <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
-                <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
-              </StackPanel>
-            </Border>
-            <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
-              <ListBox.ItemTemplate>
-                <DataTemplate>
-                  <Border Padding="14,10" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
-                    <Grid ColumnDefinitions="1.6*,1.4*,0.9*,1.1*,1.1*,0.9*" ColumnSpacing="12">
-                      <TextBlock Text="{Binding IssuerDisplayName}" FontWeight="SemiBold" />
-                      <TextBlock Grid.Column="1" Text="{Binding DisplayName}" />
-                      <TextBlock Grid.Column="2" Text="{Binding CrlNumber}" />
-                      <TextBlock Grid.Column="3" Text="{Binding ThisUpdate, StringFormat='{}{0:yyyy-MM-dd}'}" />
-                      <TextBlock Grid.Column="4" Text="{Binding NextUpdateUtc, StringFormat='{}{0:yyyy-MM-dd}'}" />
-                      <TextBlock Grid.Column="5" Text="{Binding RevokedEntryCount}" />
-                    </Grid>
-                  </Border>
-                </DataTemplate>
-              </ListBox.ItemTemplate>
-            </ListBox>
-          </Grid>
+          <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+            <ListBox.ItemTemplate>
+              <DataTemplate>
+                <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                  <Grid ColumnDefinitions="1.6*,1.2*,0.8*,1.0*,1.0*,0.8*" ColumnSpacing="8">
+                    <TextBlock Text="{Binding DisplayName}" />
+                    <TextBlock Grid.Column="1" Text="{Binding CrlNumber}" />
+                    <TextBlock Grid.Column="2" Text="{Binding IssuerDisplayName}" TextWrapping="Wrap" />
+                    <TextBlock Grid.Column="3" Text="{Binding ThisUpdate, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                    <TextBlock Grid.Column="4" Text="{Binding NextUpdateUtc, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                    <TextBlock Grid.Column="5" Text="{Binding RevokedEntryCount}" />
+                  </Grid>
+                </Border>
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
         </Grid>
       </Grid>
     </Border>
 
-    <Border Grid.Column="1" Classes="workspace-pane">
-      <Grid RowDefinitions="Auto,*">
-        <Border Classes="workspace-toolbar" Padding="14">
-          <Grid ColumnDefinitions="*,Auto">
-            <StackPanel Spacing="2">
-              <TextBlock Text="CRL Properties" FontSize="20" FontWeight="SemiBold" />
-              <TextBlock Text="{Binding PlaceholderMessage}" Classes="secondary-text" TextWrapping="Wrap" />
-            </StackPanel>
-            <TextBlock Grid.Column="1" Text="{Binding Inspector.IssuerDisplayName}" VerticalAlignment="Center" FontWeight="SemiBold" />
-          </Grid>
-        </Border>
+    <Border Grid.Column="1" Classes="classic-side-panel" Padding="8">
+      <StackPanel>
+        <Button Classes="side-action" Content="Generate CRL" IsEnabled="False" />
+        <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedCommand}" />
+        <Button Classes="side-action" Content="Import" IsEnabled="False" />
+        <Button Classes="side-action" Content="Show Details" IsEnabled="False" />
+        <Button Classes="side-action" Content="Delete" IsEnabled="False" />
+        <Button Classes="side-action" Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
+        <Button Classes="side-action" Content="Refresh" Command="{Binding RefreshCommand}" />
+      </StackPanel>
+    </Border>
 
-        <TabControl Grid.Row="1" Classes="workspace-inspector-tabs" Margin="14">
-          <TabItem Header="General">
-            <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8" Margin="0,12,0,0">
-              <TextBlock Text="Issuer" />
-              <TextBlock Grid.Column="1" Text="{Binding Inspector.IssuerDisplayName}" TextWrapping="Wrap" />
-              <TextBlock Grid.Row="1" Text="CRL Number" />
-              <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.CrlNumber}" />
-              <TextBlock Grid.Row="2" Text="This Update" />
-              <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.ThisUpdate}" />
-              <TextBlock Grid.Row="3" Text="Next Update" />
-              <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Inspector.NextUpdate}" />
-            </Grid>
-          </TabItem>
-          <TabItem Header="Revoked Entries">
-            <ListBox Margin="0,12,0,0" ItemsSource="{Binding Inspector.RevokedEntries}">
-              <ListBox.ItemTemplate>
-                <DataTemplate>
-                  <Border Padding="10" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
-                    <Grid ColumnDefinitions="1.4*,1.2*,1*,1*" ColumnSpacing="10">
-                      <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
-                      <TextBlock Grid.Column="1" Text="{Binding SerialNumber}" />
-                      <TextBlock Grid.Column="2" Text="{Binding Reason}" />
-                      <TextBlock Grid.Column="3" Text="{Binding RevokedAt}" />
-                    </Grid>
-                  </Border>
-                </DataTemplate>
-              </ListBox.ItemTemplate>
-            </ListBox>
-          </TabItem>
-        </TabControl>
-      </Grid>
+    <Border Grid.Row="1" Grid.ColumnSpan="2" Classes="workspace-pane" Padding="8">
+      <TabControl Classes="workspace-inspector-tabs">
+        <TabItem Header="Details">
+          <Grid Margin="6" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="6">
+            <TextBlock Text="Issuer" />
+            <TextBlock Grid.Column="1" Text="{Binding Inspector.IssuerDisplayName}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="1" Text="CRL number" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.CrlNumber}" />
+            <TextBlock Grid.Row="2" Text="This update" />
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.ThisUpdate}" />
+            <TextBlock Grid.Row="3" Text="Next update" />
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Inspector.NextUpdate}" />
+          </Grid>
+        </TabItem>
+        <TabItem Header="Revoked entries">
+          <ListBox Margin="6" ItemsSource="{Binding Inspector.RevokedEntries}">
+            <ListBox.ItemTemplate>
+              <DataTemplate>
+                <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                  <Grid ColumnDefinitions="1.4*,1.2*,1*,1*" ColumnSpacing="8">
+                    <TextBlock Text="{Binding DisplayName}" />
+                    <TextBlock Grid.Column="1" Text="{Binding SerialNumber}" />
+                    <TextBlock Grid.Column="2" Text="{Binding Reason}" />
+                    <TextBlock Grid.Column="3" Text="{Binding RevokedAt}" />
+                  </Grid>
+                </Border>
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
+        </TabItem>
+      </TabControl>
     </Border>
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
@@ -1,169 +1,202 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Pages.CertificatesPageView">
-  <Grid ColumnDefinitions="1.3*,1*" ColumnSpacing="16">
-    <StackPanel Spacing="14">
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <TextBlock Text="Search and Filter" FontSize="18" FontWeight="SemiBold" />
-          <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,*,*" ColumnSpacing="10" RowSpacing="10">
-            <TextBox Watermark="Display name" Text="{Binding Filter.DisplayName}" />
+  <Grid ColumnDefinitions="1.55*,1*" ColumnSpacing="16">
+    <Grid RowDefinitions="Auto,*">
+      <Border Classes="workspace-pane">
+        <Grid RowDefinitions="Auto,Auto,Auto,*">
+          <Border Classes="workspace-toolbar" Padding="14">
+            <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="8">
+              <StackPanel Spacing="2">
+                <TextBlock Text="Certificates" FontSize="20" FontWeight="SemiBold" />
+                <TextBlock Text="Table-first certificate workspace with visible issuer and child relationships." Classes="secondary-text" />
+              </StackPanel>
+              <Button Grid.Column="1" Classes="toolbar-action" Content="Import Files" Command="{Binding ImportFilesCommand}" />
+              <Button Grid.Column="2" Classes="toolbar-action" Content="Manual Import" Command="{Binding ImportMaterialCommand}" />
+              <Button Grid.Column="3" Classes="toolbar-action" Content="Export" Command="{Binding ExportSelectedCommand}" />
+              <Button Grid.Column="4" Classes="toolbar-action" Content="To Template" Command="{Binding CreateTemplateFromCertificateCommand}" />
+              <Button Grid.Column="5" Classes="toolbar-action" Content="Revoke" Command="{Binding RevokeSelectedCommand}" />
+              <Button Grid.Column="6" Classes="toolbar-action" Content="Generate CRL" Command="{Binding GenerateCertificateRevocationListCommand}" />
+            </Grid>
+          </Border>
+
+          <Grid Grid.Row="1" Margin="14,12,14,0" ColumnDefinitions="*,*,*,*,*" ColumnSpacing="10">
+            <TextBox Watermark="Name" Text="{Binding Filter.DisplayName}" />
             <TextBox Grid.Column="1" Watermark="Subject" Text="{Binding Filter.Subject}" />
             <TextBox Grid.Column="2" Watermark="Issuer" Text="{Binding Filter.Issuer}" />
-            <TextBox Grid.Row="1" Watermark="Serial" Text="{Binding Filter.SerialNumber}" />
-            <TextBox Grid.Row="1" Grid.Column="1" Watermark="Thumbprint" Text="{Binding Filter.Thumbprint}" />
-            <StackPanel Grid.Row="1" Grid.Column="2" Orientation="Horizontal" Spacing="10">
-              <ComboBox Width="150" ItemsSource="{Binding ValidityFilters}" SelectedItem="{Binding Filter.ValidityFilter}" />
-              <ComboBox Width="150" ItemsSource="{Binding AuthorityFilters}" SelectedItem="{Binding Filter.AuthorityFilter}" />
-              <Button Content="Refresh" Command="{Binding RefreshCommand}" />
-            </StackPanel>
+            <TextBox Grid.Column="3" Watermark="Serial" Text="{Binding Filter.SerialNumber}" />
+            <TextBox Grid.Column="4" Watermark="Thumbprint" Text="{Binding Filter.Thumbprint}" />
           </Grid>
-        </StackPanel>
-      </Border>
 
-      <Border Classes="surface-card" Padding="12">
-        <StackPanel Spacing="10">
+          <Grid Grid.Row="2" Margin="14,10,14,0" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,*" ColumnSpacing="10">
+            <ComboBox Width="170" ItemsSource="{Binding ValidityFilters}" SelectedItem="{Binding Filter.ValidityFilter}" />
+            <ComboBox Grid.Column="1" Width="170" ItemsSource="{Binding AuthorityFilters}" SelectedItem="{Binding Filter.AuthorityFilter}" />
+            <TextBox Grid.Column="2" Width="190" Text="{Binding ImportDisplayName}" Watermark="Import display name" />
+            <ComboBox Grid.Column="3" Width="160" ItemsSource="{Binding ImportKinds}" SelectedItem="{Binding SelectedImportKind}" />
+            <ComboBox Grid.Column="4" Width="160" ItemsSource="{Binding ImportFormats}" SelectedItem="{Binding SelectedImportFormat}" />
+            <Button Grid.Column="5" Classes="toolbar-action" HorizontalAlignment="Right" Content="Refresh" Command="{Binding RefreshCommand}" />
+          </Grid>
+
+          <Grid Grid.Row="3" Margin="0,12,0,0" RowDefinitions="Auto,Auto,*">
+            <Border Classes="surface-subtle" Margin="14,0,14,12" Padding="12">
+              <Grid ColumnDefinitions="1.1*,0.8*,1.3*" ColumnSpacing="12">
+                <StackPanel Spacing="4">
+                  <TextBlock Text="Issuer Chain" FontWeight="SemiBold" />
+                  <TextBlock Text="{Binding Inspector.Display.IssuerDisplayName}" TextWrapping="Wrap" />
+                  <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button Classes="toolbar-action" Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
+                    <Button Classes="toolbar-action" Content="Open Key" Command="{Binding OpenPrivateKeyCommand}" />
+                  </StackPanel>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Spacing="4">
+                  <TextBlock Text="Selected Certificate" FontWeight="SemiBold" />
+                  <TextBlock Text="{Binding Inspector.Display.DisplayName}" TextWrapping="Wrap" />
+                  <TextBlock Text="{Binding Inspector.Display.CertificateKind}" Classes="secondary-text" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Spacing="4">
+                  <TextBlock Text="Issued Children" FontWeight="SemiBold" />
+                  <ComboBox ItemsSource="{Binding Inspector.Navigation.Children}" SelectedItem="{Binding SelectedChildNavigationItem}" />
+                  <Button Classes="toolbar-action" HorizontalAlignment="Left" Content="Open Child" Command="{Binding OpenChildCertificateCommand}" />
+                </StackPanel>
+              </Grid>
+            </Border>
+
+            <Border Grid.Row="1" Classes="table-header" Padding="14,10">
+              <Grid ColumnDefinitions="1.2*,1.7*,1.4*,1.0*,0.9*,0.9*,0.7*,0.8*,0.8*" ColumnSpacing="12">
+                <TextBlock Text="Name" Classes="table-header-text" />
+                <TextBlock Grid.Column="1" Text="Subject" Classes="table-header-text" />
+                <TextBlock Grid.Column="2" Text="Issuer" Classes="table-header-text" />
+                <TextBlock Grid.Column="3" Text="Serial" Classes="table-header-text" />
+                <TextBlock Grid.Column="4" Text="Valid From" Classes="table-header-text" />
+                <TextBlock Grid.Column="5" Text="Valid To" Classes="table-header-text" />
+                <TextBlock Grid.Column="6" Text="Type" Classes="table-header-text" />
+                <TextBlock Grid.Column="7" Text="Revoked" Classes="table-header-text" />
+                <TextBlock Grid.Column="8" Text="Key" Classes="table-header-text" />
+              </Grid>
+            </Border>
+
+            <Grid Grid.Row="2">
+              <Border Classes="empty-state" Margin="14" Padding="16" IsVisible="{Binding IsEmpty}">
+                <StackPanel Spacing="6">
+                  <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
+                  <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
+                </StackPanel>
+              </Border>
+              <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+                <ListBox.ItemTemplate>
+                  <DataTemplate>
+                    <Border Padding="14,10" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                      <Grid ColumnDefinitions="1.2*,1.7*,1.4*,1.0*,0.9*,0.9*,0.7*,0.8*,0.8*" ColumnSpacing="12">
+                        <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
+                        <TextBlock Grid.Column="1" Text="{Binding Subject}" TextWrapping="Wrap" />
+                        <TextBlock Grid.Column="2" Text="{Binding Issuer}" TextWrapping="Wrap" />
+                        <TextBlock Grid.Column="3" Text="{Binding SerialNumber}" />
+                        <TextBlock Grid.Column="4" Text="{Binding NotBefore, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                        <TextBlock Grid.Column="5" Text="{Binding NotAfter, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                        <TextBlock Grid.Column="6" Text="{Binding CertificateKind}" />
+                        <TextBlock Grid.Column="7" Text="{Binding RevocationStatus}" />
+                        <TextBlock Grid.Column="8" Text="{Binding PrivateKeyStatus}" />
+                      </Grid>
+                    </Border>
+                  </DataTemplate>
+                </ListBox.ItemTemplate>
+              </ListBox>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Border>
+    </Grid>
+
+    <Border Grid.Column="1" Classes="workspace-pane">
+      <Grid RowDefinitions="Auto,*">
+        <Border Classes="workspace-toolbar" Padding="14">
           <Grid ColumnDefinitions="*,Auto,Auto">
-            <TextBlock Text="Certificates" FontSize="18" FontWeight="SemiBold" />
-            <Button Grid.Column="1" Content="Import Files" Command="{Binding ImportFilesCommand}" Margin="0,0,10,0" />
-            <Button Grid.Column="2" Content="Export to File" Command="{Binding ExportSelectedCommand}" />
-          </Grid>
-          <Border Classes="empty-state" Padding="16" IsVisible="{Binding IsEmpty}">
-            <StackPanel Spacing="6">
-              <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
-              <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
+            <StackPanel Spacing="2">
+              <TextBlock Text="Certificate Properties" FontSize="20" FontWeight="SemiBold" />
+              <TextBlock Text="Compact tabs for general details, extensions, relationships, and raw fields." Classes="secondary-text" />
             </StackPanel>
-          </Border>
-          <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}" Height="320">
-            <ListBox.ItemTemplate>
-              <DataTemplate>
-                <Border Padding="8">
-                  <Grid ColumnDefinitions="2.4*,1.4*,1.3*,Auto" ColumnSpacing="12">
-                    <StackPanel>
-                      <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
-                      <TextBlock Text="{Binding Subject}" Classes="secondary-text" TextWrapping="Wrap" />
-                    </StackPanel>
-                    <TextBlock Grid.Column="1" Text="{Binding Issuer}" TextWrapping="Wrap" />
-                    <StackPanel Grid.Column="2">
-                      <TextBlock Text="{Binding RevocationStatus}" />
-                      <TextBlock Text="{Binding RevocationReason}" Classes="warning-text" IsVisible="{Binding RevocationReason}" />
-                    </StackPanel>
-                    <TextBlock Grid.Column="3" Text="{Binding KeyAlgorithm}" />
-                  </Grid>
-                </Border>
-              </DataTemplate>
-            </ListBox.ItemTemplate>
-          </ListBox>
-        </StackPanel>
-      </Border>
+            <Button Grid.Column="1" Classes="toolbar-action" Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
+            <Button Grid.Column="2" Classes="toolbar-action" Content="Open Key" Command="{Binding OpenPrivateKeyCommand}" />
+          </Grid>
+        </Border>
 
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <TextBlock Text="Import Workflow" FontSize="18" FontWeight="SemiBold" />
-          <Border Classes="info-panel" Padding="12">
-            <TextBlock Text="Use native file selection or drag supported files onto the window. Manual paste import remains available for advanced or test workflows." Classes="secondary-text" TextWrapping="Wrap" />
-          </Border>
-          <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-            <TextBox Text="{Binding ImportPassword}" PasswordChar="*" Watermark="Import password for PKCS#12 or encrypted key material" />
-            <Button Grid.Column="1" Content="Choose Files" Command="{Binding ImportFilesCommand}" />
-          </Grid>
-          <Separator />
-          <TextBlock Text="Manual Import" FontWeight="SemiBold" />
-          <Grid ColumnDefinitions="*,180,180" ColumnSpacing="10">
-            <TextBox Watermark="Display name" Text="{Binding ImportDisplayName}" />
-            <ComboBox Grid.Column="1" ItemsSource="{Binding ImportKinds}" SelectedItem="{Binding SelectedImportKind}" />
-            <ComboBox Grid.Column="2" ItemsSource="{Binding ImportFormats}" SelectedItem="{Binding SelectedImportFormat}" />
-          </Grid>
-          <TextBox Text="{Binding ImportPayload}" AcceptsReturn="True" Height="120" TextWrapping="Wrap" Watermark="Paste PEM, DER-as-base64, PKCS#10, PKCS#12 or key material here." />
-          <Button Content="Import Pasted Material" HorizontalAlignment="Left" Command="{Binding ImportMaterialCommand}" />
-        </StackPanel>
-      </Border>
-    </StackPanel>
-
-    <StackPanel Grid.Column="1" Spacing="14">
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <Grid ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="10">
-            <TextBlock Text="Certificate Inspector" FontSize="18" FontWeight="SemiBold" />
-            <Button Grid.Column="1" Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
-            <Button Grid.Column="2" Content="Open Key" Command="{Binding OpenPrivateKeyCommand}" />
-            <Button Grid.Column="3" Content="To Template" Command="{Binding CreateTemplateFromCertificateCommand}" />
-          </Grid>
-          <TextBlock Text="Select a certificate to inspect its parsed fields, relationship links, and revocation status." Classes="secondary-text" TextWrapping="Wrap" />
-          <Grid ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
-            <TextBlock Text="Display Name" />
-            <TextBlock Grid.Column="1" Text="{Binding Inspector.Display.DisplayName}" TextWrapping="Wrap" />
-            <TextBlock Grid.Row="1" Text="Subject" />
-            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.Raw.Subject}" TextWrapping="Wrap" />
-            <TextBlock Grid.Row="2" Text="Issuer" />
-            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.Display.IssuerDisplayName}" TextWrapping="Wrap" />
-            <TextBlock Grid.Row="3" Text="Serial" />
-            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Inspector.Raw.SerialNumber}" TextWrapping="Wrap" />
-            <TextBlock Grid.Row="4" Text="Not Before" />
-            <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Inspector.Raw.NotBefore}" />
-            <TextBlock Grid.Row="5" Text="Not After" />
-            <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding Inspector.Raw.NotAfter}" />
-            <TextBlock Grid.Row="6" Text="SHA-1" />
-            <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding Inspector.Raw.Sha1Thumbprint}" TextWrapping="Wrap" />
-            <TextBlock Grid.Row="7" Text="SHA-256" />
-            <TextBlock Grid.Row="7" Grid.Column="1" Text="{Binding Inspector.Raw.Sha256Thumbprint}" TextWrapping="Wrap" />
-            <TextBlock Grid.Row="8" Text="Key Algorithm" />
-            <TextBlock Grid.Row="8" Grid.Column="1" Text="{Binding Inspector.Raw.KeyAlgorithm}" />
-            <TextBlock Grid.Row="9" Text="CA Status" />
-            <TextBlock Grid.Row="9" Grid.Column="1" Text="{Binding Inspector.Display.CertificateKind}" />
-            <TextBlock Grid.Row="10" Text="Revocation" />
-            <TextBlock Grid.Row="10" Grid.Column="1" Text="{Binding Inspector.Revocation.Status}" />
-            <TextBlock Grid.Row="11" Text="Private Key" />
-            <TextBlock Grid.Row="11" Grid.Column="1" Text="{Binding Inspector.Display.PrivateKeyDisplayName}" />
-          </Grid>
-
-          <TextBlock Text="Subject Alternative Names" FontWeight="SemiBold" />
-          <ItemsControl ItemsSource="{Binding Inspector.Extensions.SubjectAlternativeNames}" />
-          <TextBlock Text="Key Usage" FontWeight="SemiBold" />
-          <ItemsControl ItemsSource="{Binding Inspector.Extensions.KeyUsages}" />
-          <TextBlock Text="Enhanced Key Usage" FontWeight="SemiBold" />
-          <ItemsControl ItemsSource="{Binding Inspector.Extensions.EnhancedKeyUsages}" />
-          <TextBlock Text="Revocation Details" FontWeight="SemiBold" />
-          <TextBlock Text="{Binding Inspector.Revocation.ReasonDisplayName}" />
-          <TextBlock Text="{Binding Inspector.Revocation.RevokedAt}" />
-          <TextBlock Text="Child Certificates" FontWeight="SemiBold" />
-          <ComboBox ItemsSource="{Binding Inspector.Navigation.Children}" SelectedItem="{Binding SelectedChildNavigationItem}" />
-          <Button Content="Open Child" HorizontalAlignment="Left" Command="{Binding OpenChildCertificateCommand}" />
-        </StackPanel>
-      </Border>
-
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <TextBlock Text="Export Workflow" FontSize="18" FontWeight="SemiBold" />
-          <Grid ColumnDefinitions="*,180" ColumnSpacing="10">
-            <ComboBox ItemsSource="{Binding ExportTargets}" SelectedItem="{Binding SelectedExportTarget}" />
-            <ComboBox Grid.Column="1" ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
-          </Grid>
-          <TextBox Text="{Binding SelectedExportPassword}" PasswordChar="*" Watermark="Optional password for PEM bundle or PKCS#12" />
-          <Border Classes="info-panel" Padding="12">
-            <TextBlock Text="Certificate-only, chain, PEM bundle, and PKCS#12 export stay behind the application export abstractions." Classes="secondary-text" TextWrapping="Wrap" />
-          </Border>
-          <Button Content="Export Selected Certificate" HorizontalAlignment="Left" Command="{Binding ExportSelectedCommand}" />
-        </StackPanel>
-      </Border>
-
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <TextBlock Text="Revoke Certificate" FontSize="18" FontWeight="SemiBold" />
-          <Grid ColumnDefinitions="220,*" ColumnSpacing="10">
-            <ComboBox ItemsSource="{Binding RevocationReasons}" SelectedItem="{Binding SelectedRevocationReason}" />
-            <DatePicker Grid.Column="1" SelectedDate="{Binding SelectedRevocationDate}" />
-          </Grid>
-          <TextBox Text="{Binding RevocationConfirmationText}" Watermark="Type REVOKE to confirm" />
-          <Border Classes="validation-panel" Padding="12">
-            <TextBlock Text="Revocation is irreversible. Confirm the selected reason and timestamp before applying the change or generating the next CRL." Classes="secondary-text" TextWrapping="Wrap" />
-          </Border>
-          <StackPanel Orientation="Horizontal" Spacing="10">
-            <Button Content="Revoke Selected" Command="{Binding RevokeSelectedCommand}" />
-            <Button Content="Generate CRL" Command="{Binding GenerateCertificateRevocationListCommand}" />
-          </StackPanel>
-        </StackPanel>
-      </Border>
-    </StackPanel>
+        <TabControl Grid.Row="1" Classes="workspace-inspector-tabs" Margin="14">
+          <TabItem Header="General">
+            <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8" Margin="0,12,0,0">
+              <TextBlock Text="Name" />
+              <TextBlock Grid.Column="1" Text="{Binding Inspector.Display.DisplayName}" />
+              <TextBlock Grid.Row="1" Text="Subject" />
+              <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.Raw.Subject}" TextWrapping="Wrap" />
+              <TextBlock Grid.Row="2" Text="Issuer" />
+              <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.Raw.Issuer}" TextWrapping="Wrap" />
+              <TextBlock Grid.Row="3" Text="Serial" />
+              <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Inspector.Raw.SerialNumber}" />
+              <TextBlock Grid.Row="4" Text="Validity" />
+              <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Inspector.Display.ValidityRange}" />
+              <TextBlock Grid.Row="5" Text="Private Key" />
+              <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding Inspector.Display.PrivateKeyDisplayName}" />
+            </Grid>
+          </TabItem>
+          <TabItem Header="Details">
+            <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8" Margin="0,12,0,0">
+              <TextBlock Text="SHA-1" />
+              <TextBlock Grid.Column="1" Text="{Binding Inspector.Raw.Sha1Thumbprint}" TextWrapping="Wrap" />
+              <TextBlock Grid.Row="1" Text="SHA-256" />
+              <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.Raw.Sha256Thumbprint}" TextWrapping="Wrap" />
+              <TextBlock Grid.Row="2" Text="Key Algorithm" />
+              <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.Raw.KeyAlgorithm}" />
+              <TextBlock Grid.Row="3" Text="Revocation" />
+              <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Inspector.Revocation.Status}" />
+              <TextBlock Grid.Row="4" Text="Reason" />
+              <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Inspector.Revocation.ReasonDisplayName}" />
+            </Grid>
+          </TabItem>
+          <TabItem Header="Extensions">
+            <StackPanel Spacing="8" Margin="0,12,0,0">
+              <TextBlock Text="Subject Alternative Names" FontWeight="SemiBold" />
+              <ItemsControl ItemsSource="{Binding Inspector.Extensions.SubjectAlternativeNames}" />
+              <TextBlock Text="Key Usage" FontWeight="SemiBold" />
+              <ItemsControl ItemsSource="{Binding Inspector.Extensions.KeyUsages}" />
+              <TextBlock Text="Enhanced Key Usage" FontWeight="SemiBold" />
+              <ItemsControl ItemsSource="{Binding Inspector.Extensions.EnhancedKeyUsages}" />
+            </StackPanel>
+          </TabItem>
+          <TabItem Header="Relationships">
+            <StackPanel Spacing="10" Margin="0,12,0,0">
+              <TextBlock Text="Issuer and child certificates stay visible from the main workspace so CA relationships do not disappear behind a generic detail card." TextWrapping="Wrap" Classes="secondary-text" />
+              <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+                <TextBlock Text="Kind" />
+                <TextBlock Grid.Column="1" Text="{Binding Inspector.Display.CertificateKind}" />
+                <TextBlock Grid.Row="1" Text="Issuer" />
+                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.Display.IssuerDisplayName}" TextWrapping="Wrap" />
+                <TextBlock Grid.Row="2" Text="Children" />
+                <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedItem.ChildCertificateCount, StringFormat='{}{0} child certificate(s)'}" />
+              </Grid>
+              <ComboBox ItemsSource="{Binding Inspector.Navigation.Children}" SelectedItem="{Binding SelectedChildNavigationItem}" />
+              <StackPanel Orientation="Horizontal" Spacing="10">
+                <Button Classes="toolbar-action" Content="Open Child" Command="{Binding OpenChildCertificateCommand}" />
+                <Button Classes="toolbar-action" Content="Generate CRL" Command="{Binding GenerateCertificateRevocationListCommand}" />
+                <Button Classes="toolbar-action" Content="Revoke" Command="{Binding RevokeSelectedCommand}" />
+              </StackPanel>
+              <StackPanel Orientation="Horizontal" Spacing="10">
+                <Button Classes="toolbar-action" Content="Sign Request (from CSRs)" IsEnabled="False" />
+                <Button Classes="toolbar-action" Content="Renew (planned)" IsEnabled="False" />
+                <Button Classes="toolbar-action" Content="CA Properties (planned)" IsEnabled="False" />
+              </StackPanel>
+            </StackPanel>
+          </TabItem>
+          <TabItem Header="Raw / PEM">
+            <StackPanel Spacing="10" Margin="0,12,0,0">
+              <Grid ColumnDefinitions="*,180" ColumnSpacing="10">
+                <ComboBox ItemsSource="{Binding ExportTargets}" SelectedItem="{Binding SelectedExportTarget}" />
+                <ComboBox Grid.Column="1" ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
+              </Grid>
+              <TextBox Text="{Binding SelectedExportPassword}" PasswordChar="*" Watermark="Optional password for PEM bundle or PKCS#12" />
+              <TextBox Text="{Binding ImportPayload}" AcceptsReturn="True" Height="170" TextWrapping="Wrap" Watermark="Manual import payload remains available for PEM, DER, PKCS#10, PKCS#12, or key material." />
+            </StackPanel>
+          </TabItem>
+        </TabControl>
+      </Grid>
+    </Border>
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
@@ -87,7 +87,7 @@
             <TextBlock Text="Certificate Inspector" FontSize="18" FontWeight="SemiBold" />
             <Button Grid.Column="1" Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
             <Button Grid.Column="2" Content="Open Key" Command="{Binding OpenPrivateKeyCommand}" />
-            <Button Grid.Column="3" Content="Open Child" Command="{Binding OpenChildCertificateCommand}" />
+            <Button Grid.Column="3" Content="To Template" Command="{Binding CreateTemplateFromCertificateCommand}" />
           </Grid>
           <TextBlock Text="Select a certificate to inspect its parsed fields, relationship links, and revocation status." Classes="secondary-text" TextWrapping="Wrap" />
           <Grid ColumnDefinitions="170,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
@@ -128,6 +128,7 @@
           <TextBlock Text="{Binding Inspector.Revocation.RevokedAt}" />
           <TextBlock Text="Child Certificates" FontWeight="SemiBold" />
           <ComboBox ItemsSource="{Binding Inspector.Navigation.Children}" SelectedItem="{Binding SelectedChildNavigationItem}" />
+          <Button Content="Open Child" HorizontalAlignment="Left" Command="{Binding OpenChildCertificateCommand}" />
         </StackPanel>
       </Border>
 

--- a/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
@@ -1,202 +1,135 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Pages.CertificatesPageView">
-  <Grid ColumnDefinitions="1.55*,1*" ColumnSpacing="16">
-    <Grid RowDefinitions="Auto,*">
-      <Border Classes="workspace-pane">
-        <Grid RowDefinitions="Auto,Auto,Auto,*">
-          <Border Classes="workspace-toolbar" Padding="14">
-            <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="8">
-              <StackPanel Spacing="2">
-                <TextBlock Text="Certificates" FontSize="20" FontWeight="SemiBold" />
-                <TextBlock Text="Table-first certificate workspace with visible issuer and child relationships." Classes="secondary-text" />
-              </StackPanel>
-              <Button Grid.Column="1" Classes="toolbar-action" Content="Import Files" Command="{Binding ImportFilesCommand}" />
-              <Button Grid.Column="2" Classes="toolbar-action" Content="Manual Import" Command="{Binding ImportMaterialCommand}" />
-              <Button Grid.Column="3" Classes="toolbar-action" Content="Export" Command="{Binding ExportSelectedCommand}" />
-              <Button Grid.Column="4" Classes="toolbar-action" Content="To Template" Command="{Binding CreateTemplateFromCertificateCommand}" />
-              <Button Grid.Column="5" Classes="toolbar-action" Content="Revoke" Command="{Binding RevokeSelectedCommand}" />
-              <Button Grid.Column="6" Classes="toolbar-action" Content="Generate CRL" Command="{Binding GenerateCertificateRevocationListCommand}" />
-            </Grid>
-          </Border>
-
-          <Grid Grid.Row="1" Margin="14,12,14,0" ColumnDefinitions="*,*,*,*,*" ColumnSpacing="10">
-            <TextBox Watermark="Name" Text="{Binding Filter.DisplayName}" />
-            <TextBox Grid.Column="1" Watermark="Subject" Text="{Binding Filter.Subject}" />
-            <TextBox Grid.Column="2" Watermark="Issuer" Text="{Binding Filter.Issuer}" />
-            <TextBox Grid.Column="3" Watermark="Serial" Text="{Binding Filter.SerialNumber}" />
-            <TextBox Grid.Column="4" Watermark="Thumbprint" Text="{Binding Filter.Thumbprint}" />
-          </Grid>
-
-          <Grid Grid.Row="2" Margin="14,10,14,0" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,*" ColumnSpacing="10">
-            <ComboBox Width="170" ItemsSource="{Binding ValidityFilters}" SelectedItem="{Binding Filter.ValidityFilter}" />
-            <ComboBox Grid.Column="1" Width="170" ItemsSource="{Binding AuthorityFilters}" SelectedItem="{Binding Filter.AuthorityFilter}" />
-            <TextBox Grid.Column="2" Width="190" Text="{Binding ImportDisplayName}" Watermark="Import display name" />
-            <ComboBox Grid.Column="3" Width="160" ItemsSource="{Binding ImportKinds}" SelectedItem="{Binding SelectedImportKind}" />
-            <ComboBox Grid.Column="4" Width="160" ItemsSource="{Binding ImportFormats}" SelectedItem="{Binding SelectedImportFormat}" />
-            <Button Grid.Column="5" Classes="toolbar-action" HorizontalAlignment="Right" Content="Refresh" Command="{Binding RefreshCommand}" />
-          </Grid>
-
-          <Grid Grid.Row="3" Margin="0,12,0,0" RowDefinitions="Auto,Auto,*">
-            <Border Classes="surface-subtle" Margin="14,0,14,12" Padding="12">
-              <Grid ColumnDefinitions="1.1*,0.8*,1.3*" ColumnSpacing="12">
-                <StackPanel Spacing="4">
-                  <TextBlock Text="Issuer Chain" FontWeight="SemiBold" />
-                  <TextBlock Text="{Binding Inspector.Display.IssuerDisplayName}" TextWrapping="Wrap" />
-                  <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Button Classes="toolbar-action" Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
-                    <Button Classes="toolbar-action" Content="Open Key" Command="{Binding OpenPrivateKeyCommand}" />
-                  </StackPanel>
-                </StackPanel>
-                <StackPanel Grid.Column="1" Spacing="4">
-                  <TextBlock Text="Selected Certificate" FontWeight="SemiBold" />
-                  <TextBlock Text="{Binding Inspector.Display.DisplayName}" TextWrapping="Wrap" />
-                  <TextBlock Text="{Binding Inspector.Display.CertificateKind}" Classes="secondary-text" />
-                </StackPanel>
-                <StackPanel Grid.Column="2" Spacing="4">
-                  <TextBlock Text="Issued Children" FontWeight="SemiBold" />
-                  <ComboBox ItemsSource="{Binding Inspector.Navigation.Children}" SelectedItem="{Binding SelectedChildNavigationItem}" />
-                  <Button Classes="toolbar-action" HorizontalAlignment="Left" Content="Open Child" Command="{Binding OpenChildCertificateCommand}" />
-                </StackPanel>
-              </Grid>
-            </Border>
-
-            <Border Grid.Row="1" Classes="table-header" Padding="14,10">
-              <Grid ColumnDefinitions="1.2*,1.7*,1.4*,1.0*,0.9*,0.9*,0.7*,0.8*,0.8*" ColumnSpacing="12">
-                <TextBlock Text="Name" Classes="table-header-text" />
-                <TextBlock Grid.Column="1" Text="Subject" Classes="table-header-text" />
-                <TextBlock Grid.Column="2" Text="Issuer" Classes="table-header-text" />
-                <TextBlock Grid.Column="3" Text="Serial" Classes="table-header-text" />
-                <TextBlock Grid.Column="4" Text="Valid From" Classes="table-header-text" />
-                <TextBlock Grid.Column="5" Text="Valid To" Classes="table-header-text" />
-                <TextBlock Grid.Column="6" Text="Type" Classes="table-header-text" />
-                <TextBlock Grid.Column="7" Text="Revoked" Classes="table-header-text" />
-                <TextBlock Grid.Column="8" Text="Key" Classes="table-header-text" />
-              </Grid>
-            </Border>
-
-            <Grid Grid.Row="2">
-              <Border Classes="empty-state" Margin="14" Padding="16" IsVisible="{Binding IsEmpty}">
-                <StackPanel Spacing="6">
-                  <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
-                  <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
-                </StackPanel>
-              </Border>
-              <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
-                <ListBox.ItemTemplate>
-                  <DataTemplate>
-                    <Border Padding="14,10" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
-                      <Grid ColumnDefinitions="1.2*,1.7*,1.4*,1.0*,0.9*,0.9*,0.7*,0.8*,0.8*" ColumnSpacing="12">
-                        <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
-                        <TextBlock Grid.Column="1" Text="{Binding Subject}" TextWrapping="Wrap" />
-                        <TextBlock Grid.Column="2" Text="{Binding Issuer}" TextWrapping="Wrap" />
-                        <TextBlock Grid.Column="3" Text="{Binding SerialNumber}" />
-                        <TextBlock Grid.Column="4" Text="{Binding NotBefore, StringFormat='{}{0:yyyy-MM-dd}'}" />
-                        <TextBlock Grid.Column="5" Text="{Binding NotAfter, StringFormat='{}{0:yyyy-MM-dd}'}" />
-                        <TextBlock Grid.Column="6" Text="{Binding CertificateKind}" />
-                        <TextBlock Grid.Column="7" Text="{Binding RevocationStatus}" />
-                        <TextBlock Grid.Column="8" Text="{Binding PrivateKeyStatus}" />
-                      </Grid>
-                    </Border>
-                  </DataTemplate>
-                </ListBox.ItemTemplate>
-              </ListBox>
-            </Grid>
-          </Grid>
+  <Grid ColumnDefinitions="*,160" RowDefinitions="*,210" ColumnSpacing="8" RowSpacing="8">
+    <Border Classes="workspace-pane">
+      <Grid RowDefinitions="Auto,Auto,*">
+        <Grid Margin="8,6,8,0" ColumnDefinitions="*,*,*,*,Auto" ColumnSpacing="8">
+          <TextBox Watermark="Name" Text="{Binding Filter.DisplayName}" />
+          <TextBox Grid.Column="1" Watermark="Subject" Text="{Binding Filter.Subject}" />
+          <TextBox Grid.Column="2" Watermark="Issuer" Text="{Binding Filter.Issuer}" />
+          <TextBox Grid.Column="3" Watermark="Serial" Text="{Binding Filter.SerialNumber}" />
+          <Button Grid.Column="4" Content="Refresh" Command="{Binding RefreshCommand}" />
         </Grid>
-      </Border>
-    </Grid>
 
-    <Border Grid.Column="1" Classes="workspace-pane">
-      <Grid RowDefinitions="Auto,*">
-        <Border Classes="workspace-toolbar" Padding="14">
-          <Grid ColumnDefinitions="*,Auto,Auto">
-            <StackPanel Spacing="2">
-              <TextBlock Text="Certificate Properties" FontSize="20" FontWeight="SemiBold" />
-              <TextBlock Text="Compact tabs for general details, extensions, relationships, and raw fields." Classes="secondary-text" />
-            </StackPanel>
-            <Button Grid.Column="1" Classes="toolbar-action" Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
-            <Button Grid.Column="2" Classes="toolbar-action" Content="Open Key" Command="{Binding OpenPrivateKeyCommand}" />
+        <Border Grid.Row="1" Classes="table-header" Padding="8,6" Margin="0,6,0,0">
+          <Grid ColumnDefinitions="1.2*,1.5*,1.3*,0.9*,0.9*,0.9*,0.6*,0.8*,0.7*" ColumnSpacing="8">
+            <TextBlock Text="Certificates" FontWeight="SemiBold" />
+            <TextBlock Grid.Column="1" Text="Subject" Classes="table-header-text" />
+            <TextBlock Grid.Column="2" Text="Issuer" Classes="table-header-text" />
+            <TextBlock Grid.Column="3" Text="Serial" Classes="table-header-text" />
+            <TextBlock Grid.Column="4" Text="Valid From" Classes="table-header-text" />
+            <TextBlock Grid.Column="5" Text="Valid To" Classes="table-header-text" />
+            <TextBlock Grid.Column="6" Text="CA" Classes="table-header-text" />
+            <TextBlock Grid.Column="7" Text="Revoked" Classes="table-header-text" />
+            <TextBlock Grid.Column="8" Text="Key" Classes="table-header-text" />
           </Grid>
         </Border>
 
-        <TabControl Grid.Row="1" Classes="workspace-inspector-tabs" Margin="14">
-          <TabItem Header="General">
-            <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8" Margin="0,12,0,0">
-              <TextBlock Text="Name" />
-              <TextBlock Grid.Column="1" Text="{Binding Inspector.Display.DisplayName}" />
-              <TextBlock Grid.Row="1" Text="Subject" />
-              <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.Raw.Subject}" TextWrapping="Wrap" />
-              <TextBlock Grid.Row="2" Text="Issuer" />
-              <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.Raw.Issuer}" TextWrapping="Wrap" />
-              <TextBlock Grid.Row="3" Text="Serial" />
-              <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Inspector.Raw.SerialNumber}" />
-              <TextBlock Grid.Row="4" Text="Validity" />
-              <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Inspector.Display.ValidityRange}" />
-              <TextBlock Grid.Row="5" Text="Private Key" />
-              <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding Inspector.Display.PrivateKeyDisplayName}" />
-            </Grid>
-          </TabItem>
-          <TabItem Header="Details">
-            <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8" Margin="0,12,0,0">
-              <TextBlock Text="SHA-1" />
-              <TextBlock Grid.Column="1" Text="{Binding Inspector.Raw.Sha1Thumbprint}" TextWrapping="Wrap" />
-              <TextBlock Grid.Row="1" Text="SHA-256" />
-              <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.Raw.Sha256Thumbprint}" TextWrapping="Wrap" />
-              <TextBlock Grid.Row="2" Text="Key Algorithm" />
-              <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.Raw.KeyAlgorithm}" />
-              <TextBlock Grid.Row="3" Text="Revocation" />
-              <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Inspector.Revocation.Status}" />
-              <TextBlock Grid.Row="4" Text="Reason" />
-              <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Inspector.Revocation.ReasonDisplayName}" />
-            </Grid>
-          </TabItem>
-          <TabItem Header="Extensions">
-            <StackPanel Spacing="8" Margin="0,12,0,0">
+        <Grid Grid.Row="2">
+          <Border Classes="empty-state" Margin="8" Padding="12" IsVisible="{Binding IsEmpty}">
+            <TextBlock Text="{Binding EmptyStateMessage}" TextWrapping="Wrap" />
+          </Border>
+          <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+            <ListBox.ItemTemplate>
+              <DataTemplate>
+                <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                  <Grid ColumnDefinitions="1.2*,1.5*,1.3*,0.9*,0.9*,0.9*,0.6*,0.8*,0.7*" ColumnSpacing="8">
+                    <TextBlock Text="{Binding DisplayName}" />
+                    <TextBlock Grid.Column="1" Text="{Binding Subject}" TextWrapping="Wrap" />
+                    <TextBlock Grid.Column="2" Text="{Binding Issuer}" TextWrapping="Wrap" />
+                    <TextBlock Grid.Column="3" Text="{Binding SerialNumber}" />
+                    <TextBlock Grid.Column="4" Text="{Binding NotBefore, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                    <TextBlock Grid.Column="5" Text="{Binding NotAfter, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                    <TextBlock Grid.Column="6" Text="{Binding CertificateKind}" />
+                    <TextBlock Grid.Column="7" Text="{Binding RevocationStatus}" />
+                    <TextBlock Grid.Column="8" Text="{Binding PrivateKeyStatus}" />
+                  </Grid>
+                </Border>
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
+        </Grid>
+      </Grid>
+    </Border>
+
+    <Border Grid.Column="1" Classes="classic-side-panel" Padding="8">
+      <StackPanel>
+        <Button Classes="side-action" Content="New Certificate" IsEnabled="False" />
+        <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedCommand}" />
+        <Button Classes="side-action" Content="Import" Command="{Binding ImportFilesCommand}" />
+        <Button Classes="side-action" Content="Show Details" IsEnabled="False" />
+        <Button Classes="side-action" Content="Delete" IsEnabled="False" />
+        <Button Classes="side-action" Content="Revoke" Command="{Binding RevokeSelectedCommand}" />
+        <Button Classes="side-action" Content="Generate CRL" Command="{Binding GenerateCertificateRevocationListCommand}" />
+        <Button Classes="side-action" Content="To Template" Command="{Binding CreateTemplateFromCertificateCommand}" />
+        <Button Classes="side-action" Content="Plain View" IsEnabled="False" />
+        <Button Classes="side-action" Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
+      </StackPanel>
+    </Border>
+
+    <Border Grid.Row="1" Grid.ColumnSpan="2" Classes="workspace-pane" Padding="8">
+      <TabControl Classes="workspace-inspector-tabs">
+        <TabItem Header="General">
+          <Grid Margin="6" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="6">
+            <TextBlock Text="Display name" />
+            <TextBlock Grid.Column="1" Text="{Binding Inspector.Display.DisplayName}" />
+            <TextBlock Grid.Row="1" Text="Subject" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.Raw.Subject}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="2" Text="Issuer" />
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.Raw.Issuer}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="3" Text="Validity" />
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Inspector.Display.ValidityRange}" />
+            <TextBlock Grid.Row="4" Text="Private key" />
+            <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Inspector.Display.PrivateKeyDisplayName}" />
+          </Grid>
+        </TabItem>
+        <TabItem Header="Details">
+          <Grid Margin="6" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="6">
+            <TextBlock Text="Serial" />
+            <TextBlock Grid.Column="1" Text="{Binding Inspector.Raw.SerialNumber}" />
+            <TextBlock Grid.Row="1" Text="SHA-1" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.Raw.Sha1Thumbprint}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="2" Text="SHA-256" />
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.Raw.Sha256Thumbprint}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="3" Text="Key algorithm" />
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Inspector.Raw.KeyAlgorithm}" />
+          </Grid>
+        </TabItem>
+        <TabItem Header="Extensions">
+          <Grid Margin="6" ColumnDefinitions="1*,1*">
+            <StackPanel>
               <TextBlock Text="Subject Alternative Names" FontWeight="SemiBold" />
               <ItemsControl ItemsSource="{Binding Inspector.Extensions.SubjectAlternativeNames}" />
+            </StackPanel>
+            <StackPanel Grid.Column="1">
               <TextBlock Text="Key Usage" FontWeight="SemiBold" />
               <ItemsControl ItemsSource="{Binding Inspector.Extensions.KeyUsages}" />
-              <TextBlock Text="Enhanced Key Usage" FontWeight="SemiBold" />
+              <TextBlock Text="Enhanced Key Usage" FontWeight="SemiBold" Margin="0,8,0,0" />
               <ItemsControl ItemsSource="{Binding Inspector.Extensions.EnhancedKeyUsages}" />
             </StackPanel>
-          </TabItem>
-          <TabItem Header="Relationships">
-            <StackPanel Spacing="10" Margin="0,12,0,0">
-              <TextBlock Text="Issuer and child certificates stay visible from the main workspace so CA relationships do not disappear behind a generic detail card." TextWrapping="Wrap" Classes="secondary-text" />
-              <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
-                <TextBlock Text="Kind" />
-                <TextBlock Grid.Column="1" Text="{Binding Inspector.Display.CertificateKind}" />
-                <TextBlock Grid.Row="1" Text="Issuer" />
-                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.Display.IssuerDisplayName}" TextWrapping="Wrap" />
-                <TextBlock Grid.Row="2" Text="Children" />
-                <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedItem.ChildCertificateCount, StringFormat='{}{0} child certificate(s)'}" />
-              </Grid>
-              <ComboBox ItemsSource="{Binding Inspector.Navigation.Children}" SelectedItem="{Binding SelectedChildNavigationItem}" />
-              <StackPanel Orientation="Horizontal" Spacing="10">
-                <Button Classes="toolbar-action" Content="Open Child" Command="{Binding OpenChildCertificateCommand}" />
-                <Button Classes="toolbar-action" Content="Generate CRL" Command="{Binding GenerateCertificateRevocationListCommand}" />
-                <Button Classes="toolbar-action" Content="Revoke" Command="{Binding RevokeSelectedCommand}" />
-              </StackPanel>
-              <StackPanel Orientation="Horizontal" Spacing="10">
-                <Button Classes="toolbar-action" Content="Sign Request (from CSRs)" IsEnabled="False" />
-                <Button Classes="toolbar-action" Content="Renew (planned)" IsEnabled="False" />
-                <Button Classes="toolbar-action" Content="CA Properties (planned)" IsEnabled="False" />
-              </StackPanel>
-            </StackPanel>
-          </TabItem>
-          <TabItem Header="Raw / PEM">
-            <StackPanel Spacing="10" Margin="0,12,0,0">
-              <Grid ColumnDefinitions="*,180" ColumnSpacing="10">
-                <ComboBox ItemsSource="{Binding ExportTargets}" SelectedItem="{Binding SelectedExportTarget}" />
-                <ComboBox Grid.Column="1" ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
-              </Grid>
-              <TextBox Text="{Binding SelectedExportPassword}" PasswordChar="*" Watermark="Optional password for PEM bundle or PKCS#12" />
-              <TextBox Text="{Binding ImportPayload}" AcceptsReturn="True" Height="170" TextWrapping="Wrap" Watermark="Manual import payload remains available for PEM, DER, PKCS#10, PKCS#12, or key material." />
-            </StackPanel>
-          </TabItem>
-        </TabControl>
-      </Grid>
+          </Grid>
+        </TabItem>
+        <TabItem Header="Relationships">
+          <Grid Margin="6" ColumnDefinitions="140,*,220" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="6">
+            <TextBlock Text="Type" />
+            <TextBlock Grid.Column="1" Text="{Binding Inspector.Display.CertificateKind}" />
+            <TextBlock Grid.Row="1" Text="Issuer" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.Display.IssuerDisplayName}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="2" Text="Children" />
+            <ComboBox Grid.Row="2" Grid.Column="1" ItemsSource="{Binding Inspector.Navigation.Children}" SelectedItem="{Binding SelectedChildNavigationItem}" />
+            <Button Grid.Row="2" Grid.Column="2" Content="Open Child" HorizontalAlignment="Left" Command="{Binding OpenChildCertificateCommand}" />
+          </Grid>
+        </TabItem>
+        <TabItem Header="Raw / PEM">
+          <Grid Margin="6" ColumnDefinitions="*,180" RowDefinitions="Auto,Auto,*" ColumnSpacing="10" RowSpacing="8">
+            <ComboBox ItemsSource="{Binding ExportTargets}" SelectedItem="{Binding SelectedExportTarget}" />
+            <ComboBox Grid.Column="1" ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
+            <TextBox Grid.Row="1" Grid.ColumnSpan="2" Text="{Binding SelectedExportPassword}" PasswordChar="*" Watermark="Optional password for PEM bundle or PKCS#12" />
+            <TextBox Grid.Row="2" Grid.ColumnSpan="2" Text="{Binding ImportPayload}" AcceptsReturn="True" TextWrapping="Wrap" />
+          </Grid>
+        </TabItem>
+      </TabControl>
     </Border>
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
@@ -1,122 +1,85 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Pages.PrivateKeysPageView">
-  <Grid ColumnDefinitions="1.45*,1*" ColumnSpacing="16">
-    <Border Classes="workspace-pane">
-      <Grid RowDefinitions="Auto,Auto,*">
-        <Border Classes="workspace-toolbar" Padding="14">
-          <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="8">
-            <StackPanel Spacing="2">
-              <TextBlock Text="Private Keys" FontSize="20" FontWeight="SemiBold" />
-              <TextBlock Text="Object-first key workspace with direct CSR and self-signed certificate entry points." Classes="secondary-text" />
-            </StackPanel>
-            <Button Grid.Column="1" Classes="toolbar-action" Content="Generate Key" Command="{Binding GenerateKeyCommand}" />
-            <Button Grid.Column="2" Classes="toolbar-action" Content="Create CSR" Command="{Binding OpenCertificateSigningRequestAuthoringCommand}" />
-            <Button Grid.Column="3" Classes="toolbar-action" Content="Create Self-Signed" Command="{Binding OpenSelfSignedCaAuthoringCommand}" />
-            <Button Grid.Column="4" Classes="toolbar-action" Content="Export" Command="{Binding ExportSelectedToFileCommand}" />
-            <Button Grid.Column="5" Classes="toolbar-action" Content="Refresh" Command="{Binding RefreshCommand}" />
+  <Grid ColumnDefinitions="*,150" RowDefinitions="*,170" ColumnSpacing="8" RowSpacing="8">
+    <Border Grid.Row="0" Grid.Column="0" Classes="workspace-pane">
+      <Grid RowDefinitions="Auto,*">
+        <Border Classes="table-header" Padding="8,6">
+          <Grid ColumnDefinitions="2.0*,1.0*,1.0*,1.0*,0.9*" ColumnSpacing="10">
+            <TextBlock Text="Private Keys" FontWeight="SemiBold" />
+            <TextBlock Grid.Column="1" Text="Algorithm" Classes="table-header-text" />
+            <TextBlock Grid.Column="2" Text="Size / Curve" Classes="table-header-text" />
+            <TextBlock Grid.Column="3" Text="Created" Classes="table-header-text" />
+            <TextBlock Grid.Column="4" Text="Related" Classes="table-header-text" />
           </Grid>
         </Border>
-
-        <Grid Grid.Row="1" Margin="14,12,14,0" ColumnDefinitions="*,180,180" ColumnSpacing="10">
-          <TextBox Text="{Binding NewKeyDisplayName}" Watermark="Key name" />
-          <ComboBox Grid.Column="1" ItemsSource="{Binding Algorithms}" SelectedItem="{Binding SelectedAlgorithm}" />
-          <ComboBox Grid.Column="2" ItemsSource="{Binding Curves}" SelectedItem="{Binding SelectedCurve}" />
-        </Grid>
-
-        <Grid Grid.Row="2" Margin="0,12,0,0" RowDefinitions="Auto,*">
-          <Border Classes="table-header" Padding="14,10">
-            <Grid ColumnDefinitions="2.1*,1.1*,1.1*,1.1*,0.9*" ColumnSpacing="12">
-              <TextBlock Text="Name" Classes="table-header-text" />
-              <TextBlock Grid.Column="1" Text="Algorithm" Classes="table-header-text" />
-              <TextBlock Grid.Column="2" Text="Size / Curve" Classes="table-header-text" />
-              <TextBlock Grid.Column="3" Text="Created" Classes="table-header-text" />
-              <TextBlock Grid.Column="4" Text="Related" Classes="table-header-text" />
-            </Grid>
+        <Grid Grid.Row="1">
+          <Border Classes="empty-state" Margin="8" Padding="12" IsVisible="{Binding IsEmpty}">
+            <TextBlock Text="{Binding EmptyStateMessage}" TextWrapping="Wrap" />
           </Border>
-          <Grid Grid.Row="1">
-            <Border Classes="empty-state" Margin="14" Padding="16" IsVisible="{Binding IsEmpty}">
-              <StackPanel Spacing="6">
-                <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
-                <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
-              </StackPanel>
-            </Border>
-            <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
-              <ListBox.ItemTemplate>
-                <DataTemplate>
-                  <Border Padding="14,10" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
-                    <Grid ColumnDefinitions="2.1*,1.1*,1.1*,1.1*,0.9*" ColumnSpacing="12">
-                      <StackPanel>
-                        <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
-                        <TextBlock Text="{Binding PublicKeyFingerprint}" Classes="muted-text" TextWrapping="Wrap" />
-                      </StackPanel>
-                      <TextBlock Grid.Column="1" Text="{Binding Algorithm}" />
-                      <TextBlock Grid.Column="2" Text="{Binding SizeOrCurve}" />
-                      <TextBlock Grid.Column="3" Text="{Binding CreatedUtc, StringFormat='{}{0:yyyy-MM-dd}'}" />
-                      <TextBlock Grid.Column="4" Text="{Binding RelatedObjectSummary}" />
-                    </Grid>
-                  </Border>
-                </DataTemplate>
-              </ListBox.ItemTemplate>
-            </ListBox>
-          </Grid>
+          <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+            <ListBox.ItemTemplate>
+              <DataTemplate>
+                <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                  <Grid ColumnDefinitions="2.0*,1.0*,1.0*,1.0*,0.9*" ColumnSpacing="10">
+                    <TextBlock Text="{Binding DisplayName}" />
+                    <TextBlock Grid.Column="1" Text="{Binding Algorithm}" />
+                    <TextBlock Grid.Column="2" Text="{Binding SizeOrCurve}" />
+                    <TextBlock Grid.Column="3" Text="{Binding CreatedUtc, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                    <TextBlock Grid.Column="4" Text="{Binding RelatedObjectSummary}" />
+                  </Grid>
+                </Border>
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
         </Grid>
       </Grid>
     </Border>
 
-    <Border Grid.Column="1" Classes="workspace-pane">
-      <Grid RowDefinitions="Auto,*">
-        <Border Classes="workspace-toolbar" Padding="14">
-          <Grid ColumnDefinitions="*,Auto">
-            <StackPanel Spacing="2">
-              <TextBlock Text="Key Properties" FontSize="20" FontWeight="SemiBold" />
-              <TextBlock Text="Selection-driven export, relationships, and XCA-style authoring actions." Classes="secondary-text" />
-            </StackPanel>
-            <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" VerticalAlignment="Center" FontWeight="SemiBold" />
-          </Grid>
-        </Border>
+    <Border Grid.Row="0" Grid.Column="1" Classes="classic-side-panel" Padding="8">
+      <StackPanel>
+        <Button Classes="side-action" Content="New Key" Command="{Binding GenerateKeyCommand}" />
+        <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedToFileCommand}" />
+        <Button Classes="side-action" Content="Import" IsEnabled="False" />
+        <Button Classes="side-action" Content="Show Details" IsEnabled="False" />
+        <Button Classes="side-action" Content="Delete" IsEnabled="False" />
+        <Button Classes="side-action" Content="Create CSR" Command="{Binding OpenCertificateSigningRequestAuthoringCommand}" />
+        <Button Classes="side-action" Content="Create Certificate" Command="{Binding OpenSelfSignedCaAuthoringCommand}" />
+        <Button Classes="side-action" Content="Preview Export" Command="{Binding ExportSelectedCommand}" />
+        <Button Classes="side-action" Content="Refresh" Command="{Binding RefreshCommand}" />
+      </StackPanel>
+    </Border>
 
-        <TabControl Grid.Row="1" Classes="workspace-inspector-tabs" Margin="14">
-          <TabItem Header="General">
-            <Grid ColumnDefinitions="150,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8" Margin="0,12,0,0">
-              <TextBlock Text="Name" />
-              <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" TextWrapping="Wrap" />
-              <TextBlock Grid.Row="1" Text="Algorithm" />
-              <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.Algorithm}" />
-              <TextBlock Grid.Row="2" Text="Created" />
-              <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedItem.CreatedUtc, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" />
-              <TextBlock Grid.Row="3" Text="Related certificates" />
-              <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.LinkedCertificateCount}" />
-              <TextBlock Grid.Row="4" Text="Fingerprint" />
-              <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding SelectedItem.PublicKeyFingerprint}" TextWrapping="Wrap" />
-            </Grid>
-          </TabItem>
-          <TabItem Header="Actions">
-            <StackPanel Spacing="10" Margin="0,12,0,0">
-              <Border Classes="surface-subtle" Padding="12">
-                <TextBlock Text="Creation now launches a dedicated certificate input workbench from the selected key, preserving the M13.1 authoring model while keeping the workspace table-first."
-                           Classes="secondary-text"
-                           TextWrapping="Wrap" />
-              </Border>
-              <StackPanel Orientation="Horizontal" Spacing="10">
-                <Button Classes="toolbar-action" Content="Create CSR" Command="{Binding OpenCertificateSigningRequestAuthoringCommand}" />
-                <Button Classes="toolbar-action" Content="Create Self-Signed CA" Command="{Binding OpenSelfSignedCaAuthoringCommand}" />
-                <Button Classes="toolbar-action" Content="Preview Export" Command="{Binding ExportSelectedCommand}" />
-                <Button Classes="toolbar-action" Content="Export to File" Command="{Binding ExportSelectedToFileCommand}" />
-              </StackPanel>
-            </StackPanel>
-          </TabItem>
-          <TabItem Header="Export">
-            <StackPanel Spacing="10" Margin="0,12,0,0">
-              <Grid ColumnDefinitions="180,*" ColumnSpacing="10">
-                <ComboBox ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
-                <TextBox Grid.Column="1" Text="{Binding SelectedExportPassword}" PasswordChar="*" Watermark="Optional export password" />
-              </Grid>
-              <TextBox Classes="readonly-surface" Text="{Binding ExportPreview}" AcceptsReturn="True" Height="260" TextWrapping="Wrap" />
-            </StackPanel>
-          </TabItem>
-        </TabControl>
-      </Grid>
+    <Border Grid.Row="1" Grid.ColumnSpan="2" Classes="workspace-pane" Padding="8">
+      <TabControl Classes="workspace-inspector-tabs">
+        <TabItem Header="Details">
+          <Grid Margin="6" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="6">
+            <TextBlock Text="Name" />
+            <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" />
+            <TextBlock Grid.Row="1" Text="Algorithm" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.Algorithm}" />
+            <TextBlock Grid.Row="2" Text="Fingerprint" />
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedItem.PublicKeyFingerprint}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="3" Text="Created" />
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.CreatedUtc, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" />
+          </Grid>
+        </TabItem>
+        <TabItem Header="New Key">
+          <Grid Margin="6" ColumnDefinitions="220,180,180,Auto" ColumnSpacing="10">
+            <TextBox Text="{Binding NewKeyDisplayName}" Watermark="Key name" />
+            <ComboBox Grid.Column="1" ItemsSource="{Binding Algorithms}" SelectedItem="{Binding SelectedAlgorithm}" />
+            <ComboBox Grid.Column="2" ItemsSource="{Binding Curves}" SelectedItem="{Binding SelectedCurve}" />
+            <Button Grid.Column="3" Content="Generate" Command="{Binding GenerateKeyCommand}" />
+          </Grid>
+        </TabItem>
+        <TabItem Header="Export">
+          <Grid Margin="6" ColumnDefinitions="180,*" RowDefinitions="Auto,*" ColumnSpacing="10" RowSpacing="8">
+            <ComboBox ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
+            <TextBox Grid.Column="1" Text="{Binding SelectedExportPassword}" PasswordChar="*" Watermark="Optional export password" />
+            <TextBox Grid.Row="1" Grid.ColumnSpan="2" Classes="readonly-surface" Text="{Binding ExportPreview}" AcceptsReturn="True" TextWrapping="Wrap" />
+          </Grid>
+        </TabItem>
+      </TabControl>
     </Border>
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
@@ -1,6 +1,5 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:shared="using:XcaNet.App.Views.Shared"
              x:Class="XcaNet.App.Views.Pages.PrivateKeysPageView">
   <Grid ColumnDefinitions="1.2*,1*" ColumnSpacing="16">
     <StackPanel Spacing="14">
@@ -51,13 +50,32 @@
     <StackPanel Grid.Column="1" Spacing="14">
       <Border Classes="surface-card" Padding="16">
         <StackPanel Spacing="10">
-          <shared:CertificateAuthoringSurfaceView DataContext="{Binding SelfSignedCaAuthoring}" />
-        </StackPanel>
-      </Border>
-
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <shared:CertificateAuthoringSurfaceView DataContext="{Binding CertificateSigningRequestAuthoring}" />
+          <TextBlock Text="Certificate Input" FontSize="18" FontWeight="SemiBold" />
+          <Border Classes="info-panel" Padding="12">
+            <TextBlock Text="Launch a dedicated certificate input workbench from the selected key. The input surface uses the shared XCA-style authoring model instead of an always-visible side panel."
+                       Classes="secondary-text"
+                       TextWrapping="Wrap" />
+          </Border>
+          <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+            <Border Classes="surface-subtle" Padding="14">
+              <StackPanel Spacing="8">
+                <TextBlock Text="Self-Signed CA" FontWeight="SemiBold" />
+                <TextBlock Text="Open the certificate input workbench with CA defaults sourced from the selected private key."
+                           Classes="secondary-text"
+                           TextWrapping="Wrap" />
+                <Button Content="Open CA Input" HorizontalAlignment="Left" Command="{Binding OpenSelfSignedCaAuthoringCommand}" />
+              </StackPanel>
+            </Border>
+            <Border Grid.Column="1" Classes="surface-subtle" Padding="14">
+              <StackPanel Spacing="8">
+                <TextBlock Text="Certificate Request" FontWeight="SemiBold" />
+                <TextBlock Text="Open the request input workbench for subject, key, extension, and template-driven CSR authoring."
+                           Classes="secondary-text"
+                           TextWrapping="Wrap" />
+                <Button Content="Open CSR Input" HorizontalAlignment="Left" Command="{Binding OpenCertificateSigningRequestAuthoringCommand}" />
+              </StackPanel>
+            </Border>
+          </Grid>
         </StackPanel>
       </Border>
 

--- a/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:shared="using:XcaNet.App.Views.Shared"
              x:Class="XcaNet.App.Views.Pages.PrivateKeysPageView">
   <Grid ColumnDefinitions="1.2*,1*" ColumnSpacing="16">
     <StackPanel Spacing="14">
@@ -50,31 +51,13 @@
     <StackPanel Grid.Column="1" Spacing="14">
       <Border Classes="surface-card" Padding="16">
         <StackPanel Spacing="10">
-          <TextBlock Text="Create Self-Signed CA" FontSize="18" FontWeight="SemiBold" />
-          <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-            <ComboBox ItemsSource="{Binding SelfSignedCaTemplates}" SelectedItem="{Binding SelectedSelfSignedCaTemplate}" />
-            <Button Grid.Column="1" Content="Apply Template" Command="{Binding ApplySelfSignedCaTemplateCommand}" />
-          </Grid>
-          <TextBox Text="{Binding SelfSignedCaDisplayName}" Watermark="Certificate display name" />
-          <TextBox Text="{Binding SelfSignedCaSubjectName}" Watermark="Subject name" />
-          <Grid ColumnDefinitions="180,Auto" ColumnSpacing="10">
-            <NumericUpDown Minimum="1" Maximum="36500" Value="{Binding SelfSignedCaValidityDays}" />
-            <Button Grid.Column="1" Content="Create CA" Command="{Binding CreateSelfSignedCaCommand}" />
-          </Grid>
+          <shared:CertificateAuthoringSurfaceView DataContext="{Binding SelfSignedCaAuthoring}" />
         </StackPanel>
       </Border>
 
       <Border Classes="surface-card" Padding="16">
         <StackPanel Spacing="10">
-          <TextBlock Text="Create CSR" FontSize="18" FontWeight="SemiBold" />
-          <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-            <ComboBox ItemsSource="{Binding CertificateSigningRequestTemplates}" SelectedItem="{Binding SelectedCertificateSigningRequestTemplate}" />
-            <Button Grid.Column="1" Content="Apply Template" Command="{Binding ApplyCertificateSigningRequestTemplateCommand}" />
-          </Grid>
-          <TextBox Text="{Binding CertificateSigningRequestDisplayName}" Watermark="CSR display name" />
-          <TextBox Text="{Binding CertificateSigningRequestSubjectName}" Watermark="Subject name" />
-          <TextBox Text="{Binding CertificateSigningRequestSubjectAlternativeNames}" Watermark="SAN entries separated by comma or semicolon" />
-          <Button Content="Create CSR" HorizontalAlignment="Left" Command="{Binding CreateCertificateSigningRequestCommand}" />
+          <shared:CertificateAuthoringSurfaceView DataContext="{Binding CertificateSigningRequestAuthoring}" />
         </StackPanel>
       </Border>
 

--- a/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
@@ -1,98 +1,122 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Pages.PrivateKeysPageView">
-  <Grid ColumnDefinitions="1.2*,1*" ColumnSpacing="16">
-    <StackPanel Spacing="14">
-      <Border Classes="surface-card" Padding="12">
-        <StackPanel Spacing="10">
-          <Grid ColumnDefinitions="*,Auto">
-            <TextBlock Text="Stored Private Keys" FontSize="18" FontWeight="SemiBold" />
-            <Button Grid.Column="1" Content="Refresh" Command="{Binding RefreshCommand}" />
-          </Grid>
-          <Border Classes="empty-state" Padding="16" IsVisible="{Binding IsEmpty}">
-            <StackPanel Spacing="6">
-              <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
-              <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
+  <Grid ColumnDefinitions="1.45*,1*" ColumnSpacing="16">
+    <Border Classes="workspace-pane">
+      <Grid RowDefinitions="Auto,Auto,*">
+        <Border Classes="workspace-toolbar" Padding="14">
+          <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="8">
+            <StackPanel Spacing="2">
+              <TextBlock Text="Private Keys" FontSize="20" FontWeight="SemiBold" />
+              <TextBlock Text="Object-first key workspace with direct CSR and self-signed certificate entry points." Classes="secondary-text" />
             </StackPanel>
-          </Border>
-          <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}" Height="320">
-            <ListBox.ItemTemplate>
-              <DataTemplate>
-                <Border Padding="8">
-                  <Grid ColumnDefinitions="2*,Auto,Auto" ColumnSpacing="10">
-                    <StackPanel>
-                      <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
-                      <TextBlock Text="{Binding PublicKeyFingerprint}" Classes="secondary-text" TextWrapping="Wrap" />
-                    </StackPanel>
-                    <TextBlock Grid.Column="1" Text="{Binding Algorithm}" />
-                    <TextBlock Grid.Column="2" Text="{Binding LinkedCertificateCount}" />
-                  </Grid>
-                </Border>
-              </DataTemplate>
-            </ListBox.ItemTemplate>
-          </ListBox>
-        </StackPanel>
-      </Border>
-
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <TextBlock Text="Generate Key" FontSize="18" FontWeight="SemiBold" />
-          <Grid ColumnDefinitions="*,180,180,Auto" ColumnSpacing="10">
-            <TextBox Text="{Binding NewKeyDisplayName}" />
-            <ComboBox Grid.Column="1" ItemsSource="{Binding Algorithms}" SelectedItem="{Binding SelectedAlgorithm}" />
-            <ComboBox Grid.Column="2" ItemsSource="{Binding Curves}" SelectedItem="{Binding SelectedCurve}" />
-            <Button Grid.Column="3" Content="Generate" Command="{Binding GenerateKeyCommand}" />
+            <Button Grid.Column="1" Classes="toolbar-action" Content="Generate Key" Command="{Binding GenerateKeyCommand}" />
+            <Button Grid.Column="2" Classes="toolbar-action" Content="Create CSR" Command="{Binding OpenCertificateSigningRequestAuthoringCommand}" />
+            <Button Grid.Column="3" Classes="toolbar-action" Content="Create Self-Signed" Command="{Binding OpenSelfSignedCaAuthoringCommand}" />
+            <Button Grid.Column="4" Classes="toolbar-action" Content="Export" Command="{Binding ExportSelectedToFileCommand}" />
+            <Button Grid.Column="5" Classes="toolbar-action" Content="Refresh" Command="{Binding RefreshCommand}" />
           </Grid>
-        </StackPanel>
-      </Border>
-    </StackPanel>
+        </Border>
 
-    <StackPanel Grid.Column="1" Spacing="14">
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <TextBlock Text="Certificate Input" FontSize="18" FontWeight="SemiBold" />
-          <Border Classes="info-panel" Padding="12">
-            <TextBlock Text="Launch a dedicated certificate input workbench from the selected key. The input surface uses the shared XCA-style authoring model instead of an always-visible side panel."
-                       Classes="secondary-text"
-                       TextWrapping="Wrap" />
+        <Grid Grid.Row="1" Margin="14,12,14,0" ColumnDefinitions="*,180,180" ColumnSpacing="10">
+          <TextBox Text="{Binding NewKeyDisplayName}" Watermark="Key name" />
+          <ComboBox Grid.Column="1" ItemsSource="{Binding Algorithms}" SelectedItem="{Binding SelectedAlgorithm}" />
+          <ComboBox Grid.Column="2" ItemsSource="{Binding Curves}" SelectedItem="{Binding SelectedCurve}" />
+        </Grid>
+
+        <Grid Grid.Row="2" Margin="0,12,0,0" RowDefinitions="Auto,*">
+          <Border Classes="table-header" Padding="14,10">
+            <Grid ColumnDefinitions="2.1*,1.1*,1.1*,1.1*,0.9*" ColumnSpacing="12">
+              <TextBlock Text="Name" Classes="table-header-text" />
+              <TextBlock Grid.Column="1" Text="Algorithm" Classes="table-header-text" />
+              <TextBlock Grid.Column="2" Text="Size / Curve" Classes="table-header-text" />
+              <TextBlock Grid.Column="3" Text="Created" Classes="table-header-text" />
+              <TextBlock Grid.Column="4" Text="Related" Classes="table-header-text" />
+            </Grid>
           </Border>
-          <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
-            <Border Classes="surface-subtle" Padding="14">
-              <StackPanel Spacing="8">
-                <TextBlock Text="Self-Signed CA" FontWeight="SemiBold" />
-                <TextBlock Text="Open the certificate input workbench with CA defaults sourced from the selected private key."
-                           Classes="secondary-text"
-                           TextWrapping="Wrap" />
-                <Button Content="Open CA Input" HorizontalAlignment="Left" Command="{Binding OpenSelfSignedCaAuthoringCommand}" />
+          <Grid Grid.Row="1">
+            <Border Classes="empty-state" Margin="14" Padding="16" IsVisible="{Binding IsEmpty}">
+              <StackPanel Spacing="6">
+                <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
+                <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
               </StackPanel>
             </Border>
-            <Border Grid.Column="1" Classes="surface-subtle" Padding="14">
-              <StackPanel Spacing="8">
-                <TextBlock Text="Certificate Request" FontWeight="SemiBold" />
-                <TextBlock Text="Open the request input workbench for subject, key, extension, and template-driven CSR authoring."
+            <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+              <ListBox.ItemTemplate>
+                <DataTemplate>
+                  <Border Padding="14,10" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                    <Grid ColumnDefinitions="2.1*,1.1*,1.1*,1.1*,0.9*" ColumnSpacing="12">
+                      <StackPanel>
+                        <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" />
+                        <TextBlock Text="{Binding PublicKeyFingerprint}" Classes="muted-text" TextWrapping="Wrap" />
+                      </StackPanel>
+                      <TextBlock Grid.Column="1" Text="{Binding Algorithm}" />
+                      <TextBlock Grid.Column="2" Text="{Binding SizeOrCurve}" />
+                      <TextBlock Grid.Column="3" Text="{Binding CreatedUtc, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                      <TextBlock Grid.Column="4" Text="{Binding RelatedObjectSummary}" />
+                    </Grid>
+                  </Border>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Border>
+
+    <Border Grid.Column="1" Classes="workspace-pane">
+      <Grid RowDefinitions="Auto,*">
+        <Border Classes="workspace-toolbar" Padding="14">
+          <Grid ColumnDefinitions="*,Auto">
+            <StackPanel Spacing="2">
+              <TextBlock Text="Key Properties" FontSize="20" FontWeight="SemiBold" />
+              <TextBlock Text="Selection-driven export, relationships, and XCA-style authoring actions." Classes="secondary-text" />
+            </StackPanel>
+            <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" VerticalAlignment="Center" FontWeight="SemiBold" />
+          </Grid>
+        </Border>
+
+        <TabControl Grid.Row="1" Classes="workspace-inspector-tabs" Margin="14">
+          <TabItem Header="General">
+            <Grid ColumnDefinitions="150,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8" Margin="0,12,0,0">
+              <TextBlock Text="Name" />
+              <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" TextWrapping="Wrap" />
+              <TextBlock Grid.Row="1" Text="Algorithm" />
+              <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.Algorithm}" />
+              <TextBlock Grid.Row="2" Text="Created" />
+              <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedItem.CreatedUtc, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" />
+              <TextBlock Grid.Row="3" Text="Related certificates" />
+              <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.LinkedCertificateCount}" />
+              <TextBlock Grid.Row="4" Text="Fingerprint" />
+              <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding SelectedItem.PublicKeyFingerprint}" TextWrapping="Wrap" />
+            </Grid>
+          </TabItem>
+          <TabItem Header="Actions">
+            <StackPanel Spacing="10" Margin="0,12,0,0">
+              <Border Classes="surface-subtle" Padding="12">
+                <TextBlock Text="Creation now launches a dedicated certificate input workbench from the selected key, preserving the M13.1 authoring model while keeping the workspace table-first."
                            Classes="secondary-text"
                            TextWrapping="Wrap" />
-                <Button Content="Open CSR Input" HorizontalAlignment="Left" Command="{Binding OpenCertificateSigningRequestAuthoringCommand}" />
+              </Border>
+              <StackPanel Orientation="Horizontal" Spacing="10">
+                <Button Classes="toolbar-action" Content="Create CSR" Command="{Binding OpenCertificateSigningRequestAuthoringCommand}" />
+                <Button Classes="toolbar-action" Content="Create Self-Signed CA" Command="{Binding OpenSelfSignedCaAuthoringCommand}" />
+                <Button Classes="toolbar-action" Content="Preview Export" Command="{Binding ExportSelectedCommand}" />
+                <Button Classes="toolbar-action" Content="Export to File" Command="{Binding ExportSelectedToFileCommand}" />
               </StackPanel>
-            </Border>
-          </Grid>
-        </StackPanel>
-      </Border>
-
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <TextBlock Text="Export Private Key" FontSize="18" FontWeight="SemiBold" />
-          <Grid ColumnDefinitions="180,*" ColumnSpacing="10">
-            <ComboBox ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
-            <TextBox Grid.Column="1" Text="{Binding SelectedExportPassword}" PasswordChar="*" Watermark="Optional export password" />
-          </Grid>
-          <StackPanel Orientation="Horizontal" Spacing="10">
-            <Button Content="Preview Export" Command="{Binding ExportSelectedCommand}" />
-            <Button Content="Export to File" Command="{Binding ExportSelectedToFileCommand}" />
-          </StackPanel>
-          <TextBox Classes="readonly-surface" Text="{Binding ExportPreview}" AcceptsReturn="True" Height="160" TextWrapping="Wrap" />
-        </StackPanel>
-      </Border>
-    </StackPanel>
+            </StackPanel>
+          </TabItem>
+          <TabItem Header="Export">
+            <StackPanel Spacing="10" Margin="0,12,0,0">
+              <Grid ColumnDefinitions="180,*" ColumnSpacing="10">
+                <ComboBox ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
+                <TextBox Grid.Column="1" Text="{Binding SelectedExportPassword}" PasswordChar="*" Watermark="Optional export password" />
+              </Grid>
+              <TextBox Classes="readonly-surface" Text="{Binding ExportPreview}" AcceptsReturn="True" Height="260" TextWrapping="Wrap" />
+            </StackPanel>
+          </TabItem>
+        </TabControl>
+      </Grid>
+    </Border>
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Pages/TemplatesPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/TemplatesPageView.axaml
@@ -1,106 +1,84 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Pages.TemplatesPageView">
-  <Grid ColumnDefinitions="1.45*,1*" ColumnSpacing="16">
+  <Grid ColumnDefinitions="*,150" RowDefinitions="*,170" ColumnSpacing="8" RowSpacing="8">
     <Border Classes="workspace-pane">
-      <Grid RowDefinitions="Auto,*">
-        <Border Classes="workspace-toolbar" Padding="14">
-          <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="8">
-            <StackPanel Spacing="2">
-              <TextBlock Text="Templates" FontSize="20" FontWeight="SemiBold" />
-              <TextBlock Text="Table-first template library with XCA-style edit and clone actions." Classes="secondary-text" />
-            </StackPanel>
-            <ComboBox Grid.Column="1" Width="170" ItemsSource="{Binding UsageFilters}" SelectedItem="{Binding UsageFilter}" />
-            <ComboBox Grid.Column="2" Width="150" ItemsSource="{Binding StatusFilters}" SelectedItem="{Binding StatusFilter}" />
-            <Button Grid.Column="3" Classes="toolbar-action" Content="New" Command="{Binding CreateNewCommand}" />
-            <Button Grid.Column="4" Classes="toolbar-action" Content="Edit" Command="{Binding EditTemplateCommand}" />
-            <Button Grid.Column="5" Classes="toolbar-action" Content="Clone" Command="{Binding CloneTemplateCommand}" />
-            <Button Grid.Column="6" Classes="toolbar-action" Content="Enable / Disable" Command="{Binding ToggleEnabledCommand}" />
-            <Button Grid.Column="7" Classes="toolbar-action" Content="Refresh" Command="{Binding RefreshCommand}" />
+      <Grid RowDefinitions="Auto,Auto,*">
+        <Grid Margin="8,6,8,0" ColumnDefinitions="180,160,*" ColumnSpacing="8">
+          <ComboBox ItemsSource="{Binding UsageFilters}" SelectedItem="{Binding UsageFilter}" />
+          <ComboBox Grid.Column="1" ItemsSource="{Binding StatusFilters}" SelectedItem="{Binding StatusFilter}" />
+          <Button Grid.Column="2" Content="Refresh" HorizontalAlignment="Right" Command="{Binding RefreshCommand}" />
+        </Grid>
+        <Border Grid.Row="1" Classes="table-header" Padding="8,6" Margin="0,6,0,0">
+          <Grid ColumnDefinitions="1.5*,1.0*,0.8*,0.8*,1.4*,1.4*" ColumnSpacing="8">
+            <TextBlock Text="Templates" FontWeight="SemiBold" />
+            <TextBlock Grid.Column="1" Text="Usage" Classes="table-header-text" />
+            <TextBlock Grid.Column="2" Text="Enabled" Classes="table-header-text" />
+            <TextBlock Grid.Column="3" Text="Favorite" Classes="table-header-text" />
+            <TextBlock Grid.Column="4" Text="Subject preset" Classes="table-header-text" />
+            <TextBlock Grid.Column="5" Text="Extension preset" Classes="table-header-text" />
           </Grid>
         </Border>
-
-        <Grid Grid.Row="1" Margin="0,12,0,0" RowDefinitions="Auto,*">
-          <Border Classes="table-header" Padding="14,10">
-            <Grid ColumnDefinitions="1.5*,1.1*,0.8*,0.8*,1.6*,1.6*" ColumnSpacing="12">
-              <TextBlock Text="Name" Classes="table-header-text" />
-              <TextBlock Grid.Column="1" Text="Usage" Classes="table-header-text" />
-              <TextBlock Grid.Column="2" Text="Enabled" Classes="table-header-text" />
-              <TextBlock Grid.Column="3" Text="Favorite" Classes="table-header-text" />
-              <TextBlock Grid.Column="4" Text="Subject Preset" Classes="table-header-text" />
-              <TextBlock Grid.Column="5" Text="Extension Preset" Classes="table-header-text" />
-            </Grid>
+        <Grid Grid.Row="2">
+          <Border Classes="empty-state" Margin="8" Padding="12" IsVisible="{Binding IsEmpty}">
+            <TextBlock Text="{Binding EmptyStateMessage}" TextWrapping="Wrap" />
           </Border>
-          <Grid Grid.Row="1">
-            <Border Classes="empty-state" Margin="14" Padding="16" IsVisible="{Binding IsEmpty}">
-              <StackPanel Spacing="6">
-                <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
-                <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
-              </StackPanel>
-            </Border>
-            <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
-              <ListBox.ItemTemplate>
-                <DataTemplate>
-                  <Border Padding="14,10" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
-                    <Grid ColumnDefinitions="1.5*,1.1*,0.8*,0.8*,1.6*,1.6*" ColumnSpacing="12">
-                      <StackPanel>
-                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
-                        <TextBlock Text="{Binding Description}" Classes="muted-text" TextWrapping="Wrap" />
-                      </StackPanel>
-                      <TextBlock Grid.Column="1" Text="{Binding IntendedUsage}" />
-                      <TextBlock Grid.Column="2" Text="{Binding EnabledState}" />
-                      <TextBlock Grid.Column="3" Text="{Binding FavoriteState}" />
-                      <TextBlock Grid.Column="4" Text="{Binding Summary}" TextWrapping="Wrap" />
-                      <TextBlock Grid.Column="5" Text="{Binding Summary}" TextWrapping="Wrap" />
-                    </Grid>
-                  </Border>
-                </DataTemplate>
-              </ListBox.ItemTemplate>
-            </ListBox>
-          </Grid>
+          <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+            <ListBox.ItemTemplate>
+              <DataTemplate>
+                <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                  <Grid ColumnDefinitions="1.5*,1.0*,0.8*,0.8*,1.4*,1.4*" ColumnSpacing="8">
+                    <TextBlock Text="{Binding Name}" />
+                    <TextBlock Grid.Column="1" Text="{Binding IntendedUsage}" />
+                    <TextBlock Grid.Column="2" Text="{Binding EnabledState}" />
+                    <TextBlock Grid.Column="3" Text="{Binding FavoriteState}" />
+                    <TextBlock Grid.Column="4" Text="{Binding Summary}" TextWrapping="Wrap" />
+                    <TextBlock Grid.Column="5" Text="{Binding Summary}" TextWrapping="Wrap" />
+                  </Grid>
+                </Border>
+              </DataTemplate>
+            </ListBox.ItemTemplate>
+          </ListBox>
         </Grid>
       </Grid>
     </Border>
 
-    <Border Grid.Column="1" Classes="workspace-pane">
-      <Grid RowDefinitions="Auto,*">
-        <Border Classes="workspace-toolbar" Padding="14">
-          <Grid ColumnDefinitions="*,Auto,Auto,Auto">
-            <StackPanel Spacing="2">
-              <TextBlock Text="Template Properties" FontSize="20" FontWeight="SemiBold" />
-              <TextBlock Text="Selection-driven summary and edit commands using the shared M13 authoring surface." Classes="secondary-text" />
-            </StackPanel>
-            <Button Grid.Column="1" Classes="toolbar-action" Content="Favorite" Command="{Binding ToggleFavoriteCommand}" />
-            <Button Grid.Column="2" Classes="toolbar-action" Content="Delete" Command="{Binding DeleteTemplateCommand}" />
-            <TextBlock Grid.Column="3" Text="{Binding SelectedItem.Name}" VerticalAlignment="Center" FontWeight="SemiBold" />
-          </Grid>
-        </Border>
+    <Border Grid.Column="1" Classes="classic-side-panel" Padding="8">
+      <StackPanel>
+        <Button Classes="side-action" Content="New Template" Command="{Binding CreateNewCommand}" />
+        <Button Classes="side-action" Content="Edit" Command="{Binding EditTemplateCommand}" />
+        <Button Classes="side-action" Content="Clone" Command="{Binding CloneTemplateCommand}" />
+        <Button Classes="side-action" Content="Delete" Command="{Binding DeleteTemplateCommand}" />
+        <Button Classes="side-action" Content="Enable/Disable" Command="{Binding ToggleEnabledCommand}" />
+        <Button Classes="side-action" Content="Favorite" Command="{Binding ToggleFavoriteCommand}" />
+        <Button Classes="side-action" Content="Export/Import" IsEnabled="False" />
+      </StackPanel>
+    </Border>
 
-        <TabControl Grid.Row="1" Classes="workspace-inspector-tabs" Margin="14">
-          <TabItem Header="General">
-            <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8" Margin="0,12,0,0">
-              <TextBlock Text="Name" />
-              <TextBlock Grid.Column="1" Text="{Binding SelectedItem.Name}" />
-              <TextBlock Grid.Row="1" Text="Usage" />
-              <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.IntendedUsage}" />
-              <TextBlock Grid.Row="2" Text="State" />
-              <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding PreviewStateSummary}" />
-              <TextBlock Grid.Row="3" Text="Summary" />
-              <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.Summary}" TextWrapping="Wrap" />
-            </Grid>
-          </TabItem>
-          <TabItem Header="Details">
-            <StackPanel Spacing="10" Margin="0,12,0,0">
-              <TextBlock Text="{Binding PreviewSubjectSummary}" TextWrapping="Wrap" />
-              <TextBlock Text="{Binding PreviewExtensionSummary}" TextWrapping="Wrap" />
-              <TextBox Classes="readonly-surface" Text="{Binding PreviewSummary}" IsReadOnly="True" AcceptsReturn="True" Height="180" TextWrapping="Wrap" />
-            </StackPanel>
-          </TabItem>
-          <TabItem Header="Validation">
-            <TextBox Margin="0,12,0,0" Classes="readonly-surface" Text="{Binding ValidationSummary}" IsReadOnly="True" AcceptsReturn="True" Height="240" TextWrapping="Wrap" />
-          </TabItem>
-        </TabControl>
-      </Grid>
+    <Border Grid.Row="1" Grid.ColumnSpan="2" Classes="workspace-pane" Padding="8">
+      <TabControl Classes="workspace-inspector-tabs">
+        <TabItem Header="General">
+          <Grid Margin="6" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="6">
+            <TextBlock Text="Name" />
+            <TextBlock Grid.Column="1" Text="{Binding SelectedItem.Name}" />
+            <TextBlock Grid.Row="1" Text="Usage" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.IntendedUsage}" />
+            <TextBlock Grid.Row="2" Text="State" />
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding PreviewStateSummary}" />
+            <TextBlock Grid.Row="3" Text="Summary" />
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.Summary}" TextWrapping="Wrap" />
+          </Grid>
+        </TabItem>
+        <TabItem Header="Details">
+          <Grid Margin="6" ColumnDefinitions="1*,1*">
+            <TextBox Classes="readonly-surface" Text="{Binding PreviewSubjectSummary}" IsReadOnly="True" />
+            <TextBox Grid.Column="1" Classes="readonly-surface" Text="{Binding PreviewExtensionSummary}" IsReadOnly="True" />
+          </Grid>
+        </TabItem>
+        <TabItem Header="Validation">
+          <TextBox Margin="6" Classes="readonly-surface" Text="{Binding ValidationSummary}" IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap" />
+        </TabItem>
+      </TabControl>
     </Border>
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Pages/TemplatesPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/TemplatesPageView.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:shared="using:XcaNet.App.Views.Shared"
              x:Class="XcaNet.App.Views.Pages.TemplatesPageView">
   <Grid ColumnDefinitions="1.05*,1.1*" ColumnSpacing="16">
     <StackPanel Spacing="14">
@@ -51,28 +52,13 @@
           </Grid>
           <TextBox Text="{Binding Name}" Watermark="Template name" />
           <TextBox Text="{Binding Description}" Watermark="Description" AcceptsReturn="True" Height="70" TextWrapping="Wrap" />
-          <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+          <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
             <ComboBox ItemsSource="{Binding IntendedUsages}" SelectedItem="{Binding IntendedUsage}" />
-            <ComboBox Grid.Column="1" ItemsSource="{Binding KeyAlgorithms}" SelectedItem="{Binding KeyAlgorithm}" />
-          </Grid>
-          <Grid ColumnDefinitions="*,*,*" ColumnSpacing="10">
-            <NumericUpDown Minimum="3072" Maximum="16384" Value="{Binding RsaKeySize}" />
-            <ComboBox Grid.Column="1" ItemsSource="{Binding Curves}" SelectedItem="{Binding Curve}" />
-            <NumericUpDown Grid.Column="2" Minimum="1" Maximum="36500" Value="{Binding ValidityDays}" />
-          </Grid>
-          <TextBox Text="{Binding SubjectDefault}" Watermark="Subject default" />
-          <TextBox Text="{Binding SubjectAlternativeNames}" Watermark="SAN defaults separated by comma or semicolon" />
-          <Grid ColumnDefinitions="Auto,120,Auto,120,*,*" ColumnSpacing="10">
             <CheckBox Content="Enabled" IsChecked="{Binding IsEnabled}" />
             <CheckBox Grid.Column="1" Content="Favorite" IsChecked="{Binding IsFavorite}" />
-            <CheckBox Grid.Column="2" Content="CA" IsChecked="{Binding IsCertificateAuthority}" />
-            <CheckBox Grid.Column="3" Content="Path length" IsChecked="{Binding HasPathLengthConstraint}" />
-            <NumericUpDown Grid.Column="4" Minimum="0" Maximum="16" Value="{Binding PathLengthConstraint}" />
-            <TextBox Grid.Column="5" Text="{Binding SignatureAlgorithm}" Watermark="Signature algorithm" />
+            <Button Grid.Column="2" Content="Delete" HorizontalAlignment="Left" Command="{Binding DeleteTemplateCommand}" />
           </Grid>
-          <TextBox Text="{Binding KeyUsages}" Watermark="Key usages separated by comma or semicolon" />
-          <TextBox Text="{Binding EnhancedKeyUsages}" Watermark="Enhanced key usages separated by comma or semicolon" />
-          <Button Content="Delete" HorizontalAlignment="Left" Command="{Binding DeleteTemplateCommand}" />
+          <shared:CertificateAuthoringSurfaceView DataContext="{Binding Authoring}" />
         </StackPanel>
       </Border>
 

--- a/src/XcaNet.App/Views/Pages/TemplatesPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/TemplatesPageView.axaml
@@ -1,6 +1,5 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:shared="using:XcaNet.App.Views.Shared"
              x:Class="XcaNet.App.Views.Pages.TemplatesPageView">
   <Grid ColumnDefinitions="1.05*,1.1*" ColumnSpacing="16">
     <StackPanel Spacing="14">
@@ -43,22 +42,21 @@
       <Border Classes="surface-card" Padding="16">
         <StackPanel Spacing="10">
           <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="10">
-            <TextBlock Text="Template Editor" FontSize="18" FontWeight="SemiBold" />
+            <TextBlock Text="Template Actions" FontSize="18" FontWeight="SemiBold" />
             <Button Grid.Column="1" Content="New" Command="{Binding CreateNewCommand}" />
-            <Button Grid.Column="2" Content="Save" Command="{Binding SaveTemplateCommand}" />
+            <Button Grid.Column="2" Content="Edit" Command="{Binding EditTemplateCommand}" />
             <Button Grid.Column="3" Content="Clone" Command="{Binding CloneTemplateCommand}" />
             <Button Grid.Column="4" Content="Favorite" Command="{Binding ToggleFavoriteCommand}" />
             <Button Grid.Column="5" Content="Enable / Disable" Command="{Binding ToggleEnabledCommand}" />
           </Grid>
-          <TextBox Text="{Binding Name}" Watermark="Template name" />
-          <TextBox Text="{Binding Description}" Watermark="Description" AcceptsReturn="True" Height="70" TextWrapping="Wrap" />
-          <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
-            <ComboBox ItemsSource="{Binding IntendedUsages}" SelectedItem="{Binding IntendedUsage}" />
-            <CheckBox Content="Enabled" IsChecked="{Binding IsEnabled}" />
-            <CheckBox Grid.Column="1" Content="Favorite" IsChecked="{Binding IsFavorite}" />
-            <Button Grid.Column="2" Content="Delete" HorizontalAlignment="Left" Command="{Binding DeleteTemplateCommand}" />
-          </Grid>
-          <shared:CertificateAuthoringSurfaceView DataContext="{Binding Authoring}" />
+          <Border Classes="info-panel" Padding="12">
+            <TextBlock Text="Template editing now opens the same dedicated input workbench used by certificate and request authoring, while keeping template-specific metadata and validation intact."
+                       Classes="secondary-text"
+                       TextWrapping="Wrap" />
+          </Border>
+          <StackPanel Orientation="Horizontal" Spacing="10">
+            <Button Content="Delete" Command="{Binding DeleteTemplateCommand}" />
+          </StackPanel>
         </StackPanel>
       </Border>
 

--- a/src/XcaNet.App/Views/Pages/TemplatesPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/TemplatesPageView.axaml
@@ -1,73 +1,106 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Pages.TemplatesPageView">
-  <Grid ColumnDefinitions="1.05*,1.1*" ColumnSpacing="16">
-    <StackPanel Spacing="14">
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <Grid ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="10">
-            <TextBlock Text="Templates" FontSize="18" FontWeight="SemiBold" />
-            <ComboBox Grid.Column="1" Width="160" ItemsSource="{Binding UsageFilters}" SelectedItem="{Binding UsageFilter}" />
-            <ComboBox Grid.Column="2" Width="140" ItemsSource="{Binding StatusFilters}" SelectedItem="{Binding StatusFilter}" />
-            <Button Grid.Column="3" Content="Refresh" Command="{Binding RefreshCommand}" />
-          </Grid>
-          <Border Classes="empty-state" Padding="16" IsVisible="{Binding IsEmpty}">
-            <StackPanel Spacing="6">
-              <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
-              <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
+  <Grid ColumnDefinitions="1.45*,1*" ColumnSpacing="16">
+    <Border Classes="workspace-pane">
+      <Grid RowDefinitions="Auto,*">
+        <Border Classes="workspace-toolbar" Padding="14">
+          <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="8">
+            <StackPanel Spacing="2">
+              <TextBlock Text="Templates" FontSize="20" FontWeight="SemiBold" />
+              <TextBlock Text="Table-first template library with XCA-style edit and clone actions." Classes="secondary-text" />
             </StackPanel>
-          </Border>
-          <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}" Height="520">
-            <ListBox.ItemTemplate>
-              <DataTemplate>
-                <Border Padding="10">
-                  <StackPanel Spacing="4">
-                    <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
-                      <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
-                      <TextBlock Grid.Column="1" Text="{Binding IntendedUsage}" Classes="accent-text" />
-                      <TextBlock Grid.Column="2" Text="{Binding Summary}" Classes="secondary-text" />
-                    </Grid>
-                    <TextBlock Text="{Binding Description}" Classes="secondary-text" TextWrapping="Wrap" />
-                    <TextBlock Text="{Binding Summary}" Classes="muted-text" TextWrapping="Wrap" />
-                  </StackPanel>
-                </Border>
-              </DataTemplate>
-            </ListBox.ItemTemplate>
-          </ListBox>
-        </StackPanel>
-      </Border>
-    </StackPanel>
-
-    <StackPanel Grid.Column="1" Spacing="14">
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="10">
-            <TextBlock Text="Template Actions" FontSize="18" FontWeight="SemiBold" />
-            <Button Grid.Column="1" Content="New" Command="{Binding CreateNewCommand}" />
-            <Button Grid.Column="2" Content="Edit" Command="{Binding EditTemplateCommand}" />
-            <Button Grid.Column="3" Content="Clone" Command="{Binding CloneTemplateCommand}" />
-            <Button Grid.Column="4" Content="Favorite" Command="{Binding ToggleFavoriteCommand}" />
-            <Button Grid.Column="5" Content="Enable / Disable" Command="{Binding ToggleEnabledCommand}" />
+            <ComboBox Grid.Column="1" Width="170" ItemsSource="{Binding UsageFilters}" SelectedItem="{Binding UsageFilter}" />
+            <ComboBox Grid.Column="2" Width="150" ItemsSource="{Binding StatusFilters}" SelectedItem="{Binding StatusFilter}" />
+            <Button Grid.Column="3" Classes="toolbar-action" Content="New" Command="{Binding CreateNewCommand}" />
+            <Button Grid.Column="4" Classes="toolbar-action" Content="Edit" Command="{Binding EditTemplateCommand}" />
+            <Button Grid.Column="5" Classes="toolbar-action" Content="Clone" Command="{Binding CloneTemplateCommand}" />
+            <Button Grid.Column="6" Classes="toolbar-action" Content="Enable / Disable" Command="{Binding ToggleEnabledCommand}" />
+            <Button Grid.Column="7" Classes="toolbar-action" Content="Refresh" Command="{Binding RefreshCommand}" />
           </Grid>
-          <Border Classes="info-panel" Padding="12">
-            <TextBlock Text="Template editing now opens the same dedicated input workbench used by certificate and request authoring, while keeping template-specific metadata and validation intact."
-                       Classes="secondary-text"
-                       TextWrapping="Wrap" />
-          </Border>
-          <StackPanel Orientation="Horizontal" Spacing="10">
-            <Button Content="Delete" Command="{Binding DeleteTemplateCommand}" />
-          </StackPanel>
-        </StackPanel>
-      </Border>
+        </Border>
 
-      <Border Classes="surface-card" Padding="16">
-        <StackPanel Spacing="10">
-          <TextBlock Text="Template Summary" FontSize="18" FontWeight="SemiBold" />
-          <TextBox Classes="readonly-surface" Text="{Binding PreviewSummary}" IsReadOnly="True" AcceptsReturn="True" Height="150" TextWrapping="Wrap" />
-          <TextBlock Text="Validation" FontSize="16" FontWeight="SemiBold" />
-          <TextBox Classes="readonly-surface" Text="{Binding ValidationSummary}" IsReadOnly="True" AcceptsReturn="True" Height="110" TextWrapping="Wrap" />
-        </StackPanel>
-      </Border>
-    </StackPanel>
+        <Grid Grid.Row="1" Margin="0,12,0,0" RowDefinitions="Auto,*">
+          <Border Classes="table-header" Padding="14,10">
+            <Grid ColumnDefinitions="1.5*,1.1*,0.8*,0.8*,1.6*,1.6*" ColumnSpacing="12">
+              <TextBlock Text="Name" Classes="table-header-text" />
+              <TextBlock Grid.Column="1" Text="Usage" Classes="table-header-text" />
+              <TextBlock Grid.Column="2" Text="Enabled" Classes="table-header-text" />
+              <TextBlock Grid.Column="3" Text="Favorite" Classes="table-header-text" />
+              <TextBlock Grid.Column="4" Text="Subject Preset" Classes="table-header-text" />
+              <TextBlock Grid.Column="5" Text="Extension Preset" Classes="table-header-text" />
+            </Grid>
+          </Border>
+          <Grid Grid.Row="1">
+            <Border Classes="empty-state" Margin="14" Padding="16" IsVisible="{Binding IsEmpty}">
+              <StackPanel Spacing="6">
+                <TextBlock Text="{Binding EmptyStateTitle}" FontSize="16" FontWeight="SemiBold" />
+                <TextBlock Text="{Binding EmptyStateMessage}" Classes="secondary-text" TextWrapping="Wrap" />
+              </StackPanel>
+            </Border>
+            <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+              <ListBox.ItemTemplate>
+                <DataTemplate>
+                  <Border Padding="14,10" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                    <Grid ColumnDefinitions="1.5*,1.1*,0.8*,0.8*,1.6*,1.6*" ColumnSpacing="12">
+                      <StackPanel>
+                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
+                        <TextBlock Text="{Binding Description}" Classes="muted-text" TextWrapping="Wrap" />
+                      </StackPanel>
+                      <TextBlock Grid.Column="1" Text="{Binding IntendedUsage}" />
+                      <TextBlock Grid.Column="2" Text="{Binding EnabledState}" />
+                      <TextBlock Grid.Column="3" Text="{Binding FavoriteState}" />
+                      <TextBlock Grid.Column="4" Text="{Binding Summary}" TextWrapping="Wrap" />
+                      <TextBlock Grid.Column="5" Text="{Binding Summary}" TextWrapping="Wrap" />
+                    </Grid>
+                  </Border>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Border>
+
+    <Border Grid.Column="1" Classes="workspace-pane">
+      <Grid RowDefinitions="Auto,*">
+        <Border Classes="workspace-toolbar" Padding="14">
+          <Grid ColumnDefinitions="*,Auto,Auto,Auto">
+            <StackPanel Spacing="2">
+              <TextBlock Text="Template Properties" FontSize="20" FontWeight="SemiBold" />
+              <TextBlock Text="Selection-driven summary and edit commands using the shared M13 authoring surface." Classes="secondary-text" />
+            </StackPanel>
+            <Button Grid.Column="1" Classes="toolbar-action" Content="Favorite" Command="{Binding ToggleFavoriteCommand}" />
+            <Button Grid.Column="2" Classes="toolbar-action" Content="Delete" Command="{Binding DeleteTemplateCommand}" />
+            <TextBlock Grid.Column="3" Text="{Binding SelectedItem.Name}" VerticalAlignment="Center" FontWeight="SemiBold" />
+          </Grid>
+        </Border>
+
+        <TabControl Grid.Row="1" Classes="workspace-inspector-tabs" Margin="14">
+          <TabItem Header="General">
+            <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8" Margin="0,12,0,0">
+              <TextBlock Text="Name" />
+              <TextBlock Grid.Column="1" Text="{Binding SelectedItem.Name}" />
+              <TextBlock Grid.Row="1" Text="Usage" />
+              <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.IntendedUsage}" />
+              <TextBlock Grid.Row="2" Text="State" />
+              <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding PreviewStateSummary}" />
+              <TextBlock Grid.Row="3" Text="Summary" />
+              <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.Summary}" TextWrapping="Wrap" />
+            </Grid>
+          </TabItem>
+          <TabItem Header="Details">
+            <StackPanel Spacing="10" Margin="0,12,0,0">
+              <TextBlock Text="{Binding PreviewSubjectSummary}" TextWrapping="Wrap" />
+              <TextBlock Text="{Binding PreviewExtensionSummary}" TextWrapping="Wrap" />
+              <TextBox Classes="readonly-surface" Text="{Binding PreviewSummary}" IsReadOnly="True" AcceptsReturn="True" Height="180" TextWrapping="Wrap" />
+            </StackPanel>
+          </TabItem>
+          <TabItem Header="Validation">
+            <TextBox Margin="0,12,0,0" Classes="readonly-surface" Text="{Binding ValidationSummary}" IsReadOnly="True" AcceptsReturn="True" Height="240" TextWrapping="Wrap" />
+          </TabItem>
+        </TabControl>
+      </Grid>
+    </Border>
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Shared/CertificateAuthoringSurfaceView.axaml
+++ b/src/XcaNet.App/Views/Shared/CertificateAuthoringSurfaceView.axaml
@@ -1,169 +1,130 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Shared.CertificateAuthoringSurfaceView">
-  <Grid RowDefinitions="Auto,*,Auto" RowSpacing="14">
-    <Border Classes="info-panel" Padding="14">
-      <Grid ColumnDefinitions="1.1*,0.9*" ColumnSpacing="14">
-        <StackPanel Spacing="4">
-          <TextBlock Text="Source / Operation" FontWeight="SemiBold" />
-          <TextBlock Text="{Binding OperationModeSummary}" Classes="secondary-text" TextWrapping="Wrap" />
-          <TextBlock Text="{Binding SourceSummary}" Classes="secondary-text" TextWrapping="Wrap" />
-        </StackPanel>
-
-        <StackPanel Grid.Column="1" Spacing="8" IsVisible="{Binding ShowTemplateApplication}">
-          <TextBlock Text="Template Application" FontWeight="SemiBold" />
-          <Grid ColumnDefinitions="*,170,Auto" ColumnSpacing="8">
-            <ComboBox ItemsSource="{Binding Templates}" SelectedItem="{Binding SelectedTemplate}">
+  <Grid RowDefinitions="*,Auto" RowSpacing="10">
+    <TabControl Classes="authoring-tabs">
+      <TabItem Header="Source">
+        <Grid Margin="10" RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="8">
+          <Grid ColumnDefinitions="150,*" ColumnSpacing="10">
+            <TextBlock Text="Operation" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="1" Text="{Binding OperationModeSummary}" TextWrapping="Wrap" />
+          </Grid>
+          <Grid Grid.Row="1" ColumnDefinitions="150,*" ColumnSpacing="10">
+            <TextBlock Text="Source" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="1" Text="{Binding SourceSummary}" TextWrapping="Wrap" />
+          </Grid>
+          <Grid Grid.Row="2" ColumnDefinitions="150,*,170,Auto" ColumnSpacing="10" IsVisible="{Binding ShowTemplateApplication}">
+            <TextBlock Text="Template" VerticalAlignment="Center" />
+            <ComboBox Grid.Column="1" ItemsSource="{Binding Templates}" SelectedItem="{Binding SelectedTemplate}">
               <ComboBox.ItemTemplate>
                 <DataTemplate>
                   <TextBlock Text="{Binding Name}" />
                 </DataTemplate>
               </ComboBox.ItemTemplate>
             </ComboBox>
-            <ComboBox Grid.Column="1" ItemsSource="{Binding TemplateApplicationModes}" SelectedItem="{Binding SelectedTemplateApplicationMode}" />
-            <Button Grid.Column="2" Content="Apply" Command="{Binding ApplyTemplateCommand}" />
+            <ComboBox Grid.Column="2" ItemsSource="{Binding TemplateApplicationModes}" SelectedItem="{Binding SelectedTemplateApplicationMode}" />
+            <Button Grid.Column="3" Content="Apply" Command="{Binding ApplyTemplateCommand}" />
           </Grid>
-        </StackPanel>
-      </Grid>
-    </Border>
-
-    <TabControl Classes="authoring-tabs">
-      <TabItem Header="Subject">
-        <Border Classes="surface-card" Padding="16" Margin="0,10,0,0">
-          <StackPanel Spacing="12">
-            <TextBlock Text="Subject" FontSize="18" FontWeight="SemiBold" />
-            <TextBox Text="{Binding DisplayName}" Watermark="Display name" />
-            <TextBox Text="{Binding SubjectName}" Watermark="Distinguished name / subject" />
-            <TextBox Text="{Binding SubjectAlternativeNames}"
-                     AcceptsReturn="True"
-                     Height="96"
-                     TextWrapping="Wrap"
-                     Watermark="Subject Alternative Names, separated by comma or semicolon" />
-          </StackPanel>
-        </Border>
+          <Grid Grid.Row="3" ColumnDefinitions="150,220" ColumnSpacing="10" IsVisible="{Binding ShowValiditySection}">
+            <TextBlock Text="Validity days" VerticalAlignment="Center" />
+            <NumericUpDown Grid.Column="1" Minimum="1" Maximum="36500" Value="{Binding ValidityDays}" />
+          </Grid>
+        </Grid>
       </TabItem>
 
-      <TabItem Header="Key" IsVisible="{Binding ShowKeySection}">
-        <Border Classes="surface-card" Padding="16" Margin="0,10,0,0">
-          <StackPanel Spacing="12">
-            <TextBlock Text="Key" FontSize="18" FontWeight="SemiBold" />
-            <Grid ColumnDefinitions="*,180,180" ColumnSpacing="10">
-              <ComboBox ItemsSource="{Binding KeyAlgorithms}" SelectedItem="{Binding KeyAlgorithm}" />
-              <NumericUpDown Grid.Column="1"
-                             Minimum="3072"
-                             Maximum="16384"
-                             Value="{Binding RsaKeySize}"
-                             IsVisible="{Binding IsRsa}" />
-              <ComboBox Grid.Column="2"
-                        ItemsSource="{Binding Curves}"
-                        SelectedItem="{Binding Curve}"
-                        IsVisible="{Binding IsEcdsa}" />
-            </Grid>
-            <Border Classes="surface-subtle" Padding="12">
-              <TextBlock Text="The key section stays explicit for request-oriented workflows so operators can see the requested algorithm before issuing or exporting artifacts."
-                         Classes="secondary-text"
-                         TextWrapping="Wrap" />
-            </Border>
-          </StackPanel>
-        </Border>
+      <TabItem Header="Subject">
+        <Grid Margin="10" RowDefinitions="Auto,Auto,Auto" RowSpacing="8">
+          <Grid ColumnDefinitions="150,*" ColumnSpacing="10">
+            <TextBlock Text="Name" VerticalAlignment="Center" />
+            <TextBox Grid.Column="1" Text="{Binding DisplayName}" />
+          </Grid>
+          <Grid Grid.Row="1" ColumnDefinitions="150,*" ColumnSpacing="10">
+            <TextBlock Text="Subject" VerticalAlignment="Center" />
+            <TextBox Grid.Column="1" Text="{Binding SubjectName}" />
+          </Grid>
+          <Grid Grid.Row="2" ColumnDefinitions="150,*" ColumnSpacing="10">
+            <TextBlock Text="Alternative names" VerticalAlignment="Top" Margin="0,6,0,0" />
+            <TextBox Grid.Column="1" Text="{Binding SubjectAlternativeNames}" AcceptsReturn="True" Height="100" TextWrapping="Wrap" />
+          </Grid>
+        </Grid>
       </TabItem>
 
       <TabItem Header="Extensions">
-        <Border Classes="surface-card" Padding="16" Margin="0,10,0,0">
-          <StackPanel Spacing="12">
-            <TextBlock Text="Extensions" FontSize="18" FontWeight="SemiBold" />
-            <Grid ColumnDefinitions="Auto,Auto,120,*" ColumnSpacing="10">
-              <CheckBox Content="Certificate Authority" IsChecked="{Binding IsCertificateAuthority}" />
-              <CheckBox Grid.Column="1" Content="Path length constraint" IsChecked="{Binding HasPathLengthConstraint}" />
-              <NumericUpDown Grid.Column="2"
-                             Minimum="0"
-                             Maximum="16"
-                             Value="{Binding PathLengthConstraint}"
-                             IsEnabled="{Binding HasPathLengthConstraint}" />
-              <TextBox Grid.Column="3"
-                       Text="{Binding SignatureAlgorithm}"
-                       Watermark="Signature algorithm"
-                       IsVisible="{Binding ShowSignatureAlgorithm}" />
+        <Grid Margin="10" RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="8">
+          <CheckBox Content="Certificate authority" IsChecked="{Binding IsCertificateAuthority}" />
+          <Grid Grid.Row="1" ColumnDefinitions="150,Auto,120,*" ColumnSpacing="10">
+            <TextBlock Text="Path length" VerticalAlignment="Center" />
+            <CheckBox Grid.Column="1" Content="Constrained" IsChecked="{Binding HasPathLengthConstraint}" />
+            <NumericUpDown Grid.Column="2" Minimum="0" Maximum="16" Value="{Binding PathLengthConstraint}" IsEnabled="{Binding HasPathLengthConstraint}" />
+            <TextBox Grid.Column="3" Text="{Binding SignatureAlgorithm}" Watermark="Signature algorithm" IsVisible="{Binding ShowSignatureAlgorithm}" />
+          </Grid>
+          <Grid Grid.Row="2" ColumnDefinitions="150,*" ColumnSpacing="10">
+            <TextBlock Text="Key algorithm" VerticalAlignment="Center" />
+            <Grid Grid.Column="1" ColumnDefinitions="180,180,180" ColumnSpacing="10">
+              <ComboBox ItemsSource="{Binding KeyAlgorithms}" SelectedItem="{Binding KeyAlgorithm}" IsVisible="{Binding ShowKeySection}" />
+              <NumericUpDown Grid.Column="1" Minimum="3072" Maximum="16384" Value="{Binding RsaKeySize}" IsVisible="{Binding IsRsa}" />
+              <ComboBox Grid.Column="2" ItemsSource="{Binding Curves}" SelectedItem="{Binding Curve}" IsVisible="{Binding IsEcdsa}" />
             </Grid>
-            <TextBox Text="{Binding KeyUsages}"
-                     AcceptsReturn="True"
-                     Height="86"
-                     TextWrapping="Wrap"
-                     Watermark="Key usages separated by comma or semicolon" />
-            <TextBox Text="{Binding EnhancedKeyUsages}"
-                     AcceptsReturn="True"
-                     Height="86"
-                     TextWrapping="Wrap"
-                     Watermark="Enhanced key usages separated by comma or semicolon" />
-          </StackPanel>
-        </Border>
+          </Grid>
+        </Grid>
+      </TabItem>
+
+      <TabItem Header="Key usage">
+        <Grid Margin="10" RowDefinitions="Auto,Auto" RowSpacing="8">
+          <Grid ColumnDefinitions="150,*" ColumnSpacing="10">
+            <TextBlock Text="Key usage" VerticalAlignment="Top" Margin="0,6,0,0" />
+            <TextBox Grid.Column="1" Text="{Binding KeyUsages}" AcceptsReturn="True" Height="100" TextWrapping="Wrap" />
+          </Grid>
+          <Grid Grid.Row="1" ColumnDefinitions="150,*" ColumnSpacing="10">
+            <TextBlock Text="Extended key usage" VerticalAlignment="Top" Margin="0,6,0,0" />
+            <TextBox Grid.Column="1" Text="{Binding EnhancedKeyUsages}" AcceptsReturn="True" Height="100" TextWrapping="Wrap" />
+          </Grid>
+        </Grid>
       </TabItem>
 
       <TabItem Header="Advanced">
-        <Border Classes="surface-card" Padding="16" Margin="0,10,0,0">
-          <StackPanel Spacing="12">
-            <TextBlock Text="Advanced / Raw Extension Area" FontSize="18" FontWeight="SemiBold" />
-            <Border Classes="validation-panel" Padding="12">
-              <TextBlock Text="This surface keeps raw extension text editable for key usage and EKU values without introducing a separate backend path. It is still normalized through the existing application contracts."
-                         Classes="secondary-text"
-                         TextWrapping="Wrap" />
-            </Border>
-            <TextBox Text="{Binding KeyUsages}"
-                     AcceptsReturn="True"
-                     Height="110"
-                     TextWrapping="Wrap"
-                     Watermark="Raw key usage entries" />
-            <TextBox Text="{Binding EnhancedKeyUsages}"
-                     AcceptsReturn="True"
-                     Height="110"
-                     TextWrapping="Wrap"
-                     Watermark="Raw enhanced key usage entries" />
-          </StackPanel>
-        </Border>
+        <Grid Margin="10" RowDefinitions="Auto,Auto" RowSpacing="8">
+          <Grid ColumnDefinitions="150,*" ColumnSpacing="10">
+            <TextBlock Text="Raw key usage" VerticalAlignment="Top" Margin="0,6,0,0" />
+            <TextBox Grid.Column="1" Text="{Binding KeyUsages}" AcceptsReturn="True" Height="110" TextWrapping="Wrap" />
+          </Grid>
+          <Grid Grid.Row="1" ColumnDefinitions="150,*" ColumnSpacing="10">
+            <TextBlock Text="Raw extended usage" VerticalAlignment="Top" Margin="0,6,0,0" />
+            <TextBox Grid.Column="1" Text="{Binding EnhancedKeyUsages}" AcceptsReturn="True" Height="110" TextWrapping="Wrap" />
+          </Grid>
+        </Grid>
       </TabItem>
 
-      <TabItem Header="Signing" IsVisible="{Binding ShowSigningSection}">
-        <Border Classes="surface-card" Padding="16" Margin="0,10,0,0">
-          <StackPanel Spacing="12">
-            <TextBlock Text="Signing / Issuer" FontSize="18" FontWeight="SemiBold" />
-            <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
-              <ComboBox ItemsSource="{Binding IssuerCertificates}" SelectedItem="{Binding SelectedIssuerCertificate}">
-                <ComboBox.ItemTemplate>
-                  <DataTemplate>
-                    <TextBlock Text="{Binding DisplayName}" />
-                  </DataTemplate>
-                </ComboBox.ItemTemplate>
-              </ComboBox>
-              <ComboBox Grid.Column="1" ItemsSource="{Binding IssuerPrivateKeys}" SelectedItem="{Binding SelectedIssuerPrivateKey}">
-                <ComboBox.ItemTemplate>
-                  <DataTemplate>
-                    <TextBlock Text="{Binding DisplayName}" />
-                  </DataTemplate>
-                </ComboBox.ItemTemplate>
-              </ComboBox>
-            </Grid>
-          </StackPanel>
-        </Border>
-      </TabItem>
-
-      <TabItem Header="Validity" IsVisible="{Binding ShowValiditySection}">
-        <Border Classes="surface-card" Padding="16" Margin="0,10,0,0">
-          <StackPanel Spacing="12">
-            <TextBlock Text="Validity" FontSize="18" FontWeight="SemiBold" />
-            <NumericUpDown Minimum="1" Maximum="36500" Value="{Binding ValidityDays}" Width="220" />
-          </StackPanel>
-        </Border>
+      <TabItem Header="Signing / Issuer" IsVisible="{Binding ShowSigningSection}">
+        <Grid Margin="10" RowDefinitions="Auto,Auto" RowSpacing="8">
+          <Grid ColumnDefinitions="150,*" ColumnSpacing="10">
+            <TextBlock Text="Issuer certificate" VerticalAlignment="Center" />
+            <ComboBox Grid.Column="1" ItemsSource="{Binding IssuerCertificates}" SelectedItem="{Binding SelectedIssuerCertificate}">
+              <ComboBox.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Text="{Binding DisplayName}" />
+                </DataTemplate>
+              </ComboBox.ItemTemplate>
+            </ComboBox>
+          </Grid>
+          <Grid Grid.Row="1" ColumnDefinitions="150,*" ColumnSpacing="10">
+            <TextBlock Text="Issuer key" VerticalAlignment="Center" />
+            <ComboBox Grid.Column="1" ItemsSource="{Binding IssuerPrivateKeys}" SelectedItem="{Binding SelectedIssuerPrivateKey}">
+              <ComboBox.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Text="{Binding DisplayName}" />
+                </DataTemplate>
+              </ComboBox.ItemTemplate>
+            </ComboBox>
+          </Grid>
+        </Grid>
       </TabItem>
     </TabControl>
 
-    <Border Classes="surface-subtle" Padding="14">
-      <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
-        <TextBlock Text="{Binding Title}" FontWeight="SemiBold" VerticalAlignment="Center" />
-        <Button Grid.Column="1"
-                Content="{Binding PrimaryActionLabel}"
-                Command="{Binding PrimaryActionCommand}"
-                MinWidth="150" />
-      </Grid>
-    </Border>
+    <Grid Grid.Row="1" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+      <TextBlock Text="{Binding Title}" VerticalAlignment="Center" />
+      <Button Grid.Column="1" Content="Cancel" />
+      <Button Grid.Column="2" Content="{Binding PrimaryActionLabel}" Command="{Binding PrimaryActionCommand}" MinWidth="100" />
+    </Grid>
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Shared/CertificateAuthoringSurfaceView.axaml
+++ b/src/XcaNet.App/Views/Shared/CertificateAuthoringSurfaceView.axaml
@@ -1,0 +1,98 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="XcaNet.App.Views.Shared.CertificateAuthoringSurfaceView">
+  <StackPanel Spacing="12">
+    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+      <TextBlock Text="{Binding Title}" FontSize="18" FontWeight="SemiBold" />
+      <Button Grid.Column="1" Content="{Binding PrimaryActionLabel}" Command="{Binding PrimaryActionCommand}" />
+    </Grid>
+
+    <Border Classes="info-panel" Padding="12">
+      <StackPanel Spacing="4">
+        <TextBlock Text="Source / Operation Mode" FontWeight="SemiBold" />
+        <TextBlock Text="{Binding OperationModeSummary}" Classes="secondary-text" TextWrapping="Wrap" />
+        <TextBlock Text="{Binding SourceSummary}" Classes="secondary-text" TextWrapping="Wrap" />
+      </StackPanel>
+    </Border>
+
+    <Border Classes="surface-card" Padding="12" IsVisible="{Binding ShowTemplateApplication}">
+      <StackPanel Spacing="10">
+        <TextBlock Text="Template Application" FontWeight="SemiBold" />
+        <Grid ColumnDefinitions="*,180,Auto" ColumnSpacing="10">
+          <ComboBox ItemsSource="{Binding Templates}" SelectedItem="{Binding SelectedTemplate}">
+            <ComboBox.ItemTemplate>
+              <DataTemplate>
+                <TextBlock Text="{Binding Name}" />
+              </DataTemplate>
+            </ComboBox.ItemTemplate>
+          </ComboBox>
+          <ComboBox Grid.Column="1" ItemsSource="{Binding TemplateApplicationModes}" SelectedItem="{Binding SelectedTemplateApplicationMode}" />
+          <Button Grid.Column="2" Content="Apply Template" Command="{Binding ApplyTemplateCommand}" />
+        </Grid>
+      </StackPanel>
+    </Border>
+
+    <Border Classes="surface-card" Padding="12">
+      <StackPanel Spacing="10">
+        <TextBlock Text="Subject" FontWeight="SemiBold" />
+        <TextBox Text="{Binding DisplayName}" Watermark="Display name" />
+        <TextBox Text="{Binding SubjectName}" Watermark="Subject name" />
+        <TextBox Text="{Binding SubjectAlternativeNames}" Watermark="SAN entries separated by comma or semicolon" />
+      </StackPanel>
+    </Border>
+
+    <Border Classes="surface-card" Padding="12" IsVisible="{Binding ShowKeySection}">
+      <StackPanel Spacing="10">
+        <TextBlock Text="Key" FontWeight="SemiBold" />
+        <Grid ColumnDefinitions="*,180,180" ColumnSpacing="10">
+          <ComboBox ItemsSource="{Binding KeyAlgorithms}" SelectedItem="{Binding KeyAlgorithm}" />
+          <NumericUpDown Grid.Column="1" Minimum="3072" Maximum="16384" Value="{Binding RsaKeySize}" IsVisible="{Binding IsRsa}" />
+          <ComboBox Grid.Column="2" ItemsSource="{Binding Curves}" SelectedItem="{Binding Curve}" IsVisible="{Binding IsEcdsa}" />
+        </Grid>
+      </StackPanel>
+    </Border>
+
+    <Border Classes="surface-card" Padding="12">
+      <StackPanel Spacing="10">
+        <TextBlock Text="Extensions" FontWeight="SemiBold" />
+        <Grid ColumnDefinitions="Auto,Auto,120,*" ColumnSpacing="10">
+          <CheckBox Content="CA" IsChecked="{Binding IsCertificateAuthority}" />
+          <CheckBox Grid.Column="1" Content="Path length" IsChecked="{Binding HasPathLengthConstraint}" />
+          <NumericUpDown Grid.Column="2" Minimum="0" Maximum="16" Value="{Binding PathLengthConstraint}" IsEnabled="{Binding HasPathLengthConstraint}" />
+          <TextBox Grid.Column="3" Text="{Binding SignatureAlgorithm}" Watermark="Signature algorithm" IsVisible="{Binding ShowSignatureAlgorithm}" />
+        </Grid>
+        <TextBox Text="{Binding KeyUsages}" Watermark="Key usages separated by comma or semicolon" />
+        <TextBox Text="{Binding EnhancedKeyUsages}" Watermark="Enhanced key usages separated by comma or semicolon" />
+      </StackPanel>
+    </Border>
+
+    <Border Classes="surface-card" Padding="12" IsVisible="{Binding ShowSigningSection}">
+      <StackPanel Spacing="10">
+        <TextBlock Text="Signing / Issuer Controls" FontWeight="SemiBold" />
+        <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+          <ComboBox ItemsSource="{Binding IssuerCertificates}" SelectedItem="{Binding SelectedIssuerCertificate}">
+            <ComboBox.ItemTemplate>
+              <DataTemplate>
+                <TextBlock Text="{Binding DisplayName}" />
+              </DataTemplate>
+            </ComboBox.ItemTemplate>
+          </ComboBox>
+          <ComboBox Grid.Column="1" ItemsSource="{Binding IssuerPrivateKeys}" SelectedItem="{Binding SelectedIssuerPrivateKey}">
+            <ComboBox.ItemTemplate>
+              <DataTemplate>
+                <TextBlock Text="{Binding DisplayName}" />
+              </DataTemplate>
+            </ComboBox.ItemTemplate>
+          </ComboBox>
+        </Grid>
+      </StackPanel>
+    </Border>
+
+    <Border Classes="surface-card" Padding="12" IsVisible="{Binding ShowValiditySection}">
+      <StackPanel Spacing="10">
+        <TextBlock Text="Validity" FontWeight="SemiBold" />
+        <NumericUpDown Minimum="1" Maximum="36500" Value="{Binding ValidityDays}" />
+      </StackPanel>
+    </Border>
+  </StackPanel>
+</UserControl>

--- a/src/XcaNet.App/Views/Shared/CertificateAuthoringSurfaceView.axaml
+++ b/src/XcaNet.App/Views/Shared/CertificateAuthoringSurfaceView.axaml
@@ -1,98 +1,169 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Shared.CertificateAuthoringSurfaceView">
-  <StackPanel Spacing="12">
-    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
-      <TextBlock Text="{Binding Title}" FontSize="18" FontWeight="SemiBold" />
-      <Button Grid.Column="1" Content="{Binding PrimaryActionLabel}" Command="{Binding PrimaryActionCommand}" />
-    </Grid>
+  <Grid RowDefinitions="Auto,*,Auto" RowSpacing="14">
+    <Border Classes="info-panel" Padding="14">
+      <Grid ColumnDefinitions="1.1*,0.9*" ColumnSpacing="14">
+        <StackPanel Spacing="4">
+          <TextBlock Text="Source / Operation" FontWeight="SemiBold" />
+          <TextBlock Text="{Binding OperationModeSummary}" Classes="secondary-text" TextWrapping="Wrap" />
+          <TextBlock Text="{Binding SourceSummary}" Classes="secondary-text" TextWrapping="Wrap" />
+        </StackPanel>
 
-    <Border Classes="info-panel" Padding="12">
-      <StackPanel Spacing="4">
-        <TextBlock Text="Source / Operation Mode" FontWeight="SemiBold" />
-        <TextBlock Text="{Binding OperationModeSummary}" Classes="secondary-text" TextWrapping="Wrap" />
-        <TextBlock Text="{Binding SourceSummary}" Classes="secondary-text" TextWrapping="Wrap" />
-      </StackPanel>
+        <StackPanel Grid.Column="1" Spacing="8" IsVisible="{Binding ShowTemplateApplication}">
+          <TextBlock Text="Template Application" FontWeight="SemiBold" />
+          <Grid ColumnDefinitions="*,170,Auto" ColumnSpacing="8">
+            <ComboBox ItemsSource="{Binding Templates}" SelectedItem="{Binding SelectedTemplate}">
+              <ComboBox.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Text="{Binding Name}" />
+                </DataTemplate>
+              </ComboBox.ItemTemplate>
+            </ComboBox>
+            <ComboBox Grid.Column="1" ItemsSource="{Binding TemplateApplicationModes}" SelectedItem="{Binding SelectedTemplateApplicationMode}" />
+            <Button Grid.Column="2" Content="Apply" Command="{Binding ApplyTemplateCommand}" />
+          </Grid>
+        </StackPanel>
+      </Grid>
     </Border>
 
-    <Border Classes="surface-card" Padding="12" IsVisible="{Binding ShowTemplateApplication}">
-      <StackPanel Spacing="10">
-        <TextBlock Text="Template Application" FontWeight="SemiBold" />
-        <Grid ColumnDefinitions="*,180,Auto" ColumnSpacing="10">
-          <ComboBox ItemsSource="{Binding Templates}" SelectedItem="{Binding SelectedTemplate}">
-            <ComboBox.ItemTemplate>
-              <DataTemplate>
-                <TextBlock Text="{Binding Name}" />
-              </DataTemplate>
-            </ComboBox.ItemTemplate>
-          </ComboBox>
-          <ComboBox Grid.Column="1" ItemsSource="{Binding TemplateApplicationModes}" SelectedItem="{Binding SelectedTemplateApplicationMode}" />
-          <Button Grid.Column="2" Content="Apply Template" Command="{Binding ApplyTemplateCommand}" />
-        </Grid>
-      </StackPanel>
-    </Border>
+    <TabControl Classes="authoring-tabs">
+      <TabItem Header="Subject">
+        <Border Classes="surface-card" Padding="16" Margin="0,10,0,0">
+          <StackPanel Spacing="12">
+            <TextBlock Text="Subject" FontSize="18" FontWeight="SemiBold" />
+            <TextBox Text="{Binding DisplayName}" Watermark="Display name" />
+            <TextBox Text="{Binding SubjectName}" Watermark="Distinguished name / subject" />
+            <TextBox Text="{Binding SubjectAlternativeNames}"
+                     AcceptsReturn="True"
+                     Height="96"
+                     TextWrapping="Wrap"
+                     Watermark="Subject Alternative Names, separated by comma or semicolon" />
+          </StackPanel>
+        </Border>
+      </TabItem>
 
-    <Border Classes="surface-card" Padding="12">
-      <StackPanel Spacing="10">
-        <TextBlock Text="Subject" FontWeight="SemiBold" />
-        <TextBox Text="{Binding DisplayName}" Watermark="Display name" />
-        <TextBox Text="{Binding SubjectName}" Watermark="Subject name" />
-        <TextBox Text="{Binding SubjectAlternativeNames}" Watermark="SAN entries separated by comma or semicolon" />
-      </StackPanel>
-    </Border>
+      <TabItem Header="Key" IsVisible="{Binding ShowKeySection}">
+        <Border Classes="surface-card" Padding="16" Margin="0,10,0,0">
+          <StackPanel Spacing="12">
+            <TextBlock Text="Key" FontSize="18" FontWeight="SemiBold" />
+            <Grid ColumnDefinitions="*,180,180" ColumnSpacing="10">
+              <ComboBox ItemsSource="{Binding KeyAlgorithms}" SelectedItem="{Binding KeyAlgorithm}" />
+              <NumericUpDown Grid.Column="1"
+                             Minimum="3072"
+                             Maximum="16384"
+                             Value="{Binding RsaKeySize}"
+                             IsVisible="{Binding IsRsa}" />
+              <ComboBox Grid.Column="2"
+                        ItemsSource="{Binding Curves}"
+                        SelectedItem="{Binding Curve}"
+                        IsVisible="{Binding IsEcdsa}" />
+            </Grid>
+            <Border Classes="surface-subtle" Padding="12">
+              <TextBlock Text="The key section stays explicit for request-oriented workflows so operators can see the requested algorithm before issuing or exporting artifacts."
+                         Classes="secondary-text"
+                         TextWrapping="Wrap" />
+            </Border>
+          </StackPanel>
+        </Border>
+      </TabItem>
 
-    <Border Classes="surface-card" Padding="12" IsVisible="{Binding ShowKeySection}">
-      <StackPanel Spacing="10">
-        <TextBlock Text="Key" FontWeight="SemiBold" />
-        <Grid ColumnDefinitions="*,180,180" ColumnSpacing="10">
-          <ComboBox ItemsSource="{Binding KeyAlgorithms}" SelectedItem="{Binding KeyAlgorithm}" />
-          <NumericUpDown Grid.Column="1" Minimum="3072" Maximum="16384" Value="{Binding RsaKeySize}" IsVisible="{Binding IsRsa}" />
-          <ComboBox Grid.Column="2" ItemsSource="{Binding Curves}" SelectedItem="{Binding Curve}" IsVisible="{Binding IsEcdsa}" />
-        </Grid>
-      </StackPanel>
-    </Border>
+      <TabItem Header="Extensions">
+        <Border Classes="surface-card" Padding="16" Margin="0,10,0,0">
+          <StackPanel Spacing="12">
+            <TextBlock Text="Extensions" FontSize="18" FontWeight="SemiBold" />
+            <Grid ColumnDefinitions="Auto,Auto,120,*" ColumnSpacing="10">
+              <CheckBox Content="Certificate Authority" IsChecked="{Binding IsCertificateAuthority}" />
+              <CheckBox Grid.Column="1" Content="Path length constraint" IsChecked="{Binding HasPathLengthConstraint}" />
+              <NumericUpDown Grid.Column="2"
+                             Minimum="0"
+                             Maximum="16"
+                             Value="{Binding PathLengthConstraint}"
+                             IsEnabled="{Binding HasPathLengthConstraint}" />
+              <TextBox Grid.Column="3"
+                       Text="{Binding SignatureAlgorithm}"
+                       Watermark="Signature algorithm"
+                       IsVisible="{Binding ShowSignatureAlgorithm}" />
+            </Grid>
+            <TextBox Text="{Binding KeyUsages}"
+                     AcceptsReturn="True"
+                     Height="86"
+                     TextWrapping="Wrap"
+                     Watermark="Key usages separated by comma or semicolon" />
+            <TextBox Text="{Binding EnhancedKeyUsages}"
+                     AcceptsReturn="True"
+                     Height="86"
+                     TextWrapping="Wrap"
+                     Watermark="Enhanced key usages separated by comma or semicolon" />
+          </StackPanel>
+        </Border>
+      </TabItem>
 
-    <Border Classes="surface-card" Padding="12">
-      <StackPanel Spacing="10">
-        <TextBlock Text="Extensions" FontWeight="SemiBold" />
-        <Grid ColumnDefinitions="Auto,Auto,120,*" ColumnSpacing="10">
-          <CheckBox Content="CA" IsChecked="{Binding IsCertificateAuthority}" />
-          <CheckBox Grid.Column="1" Content="Path length" IsChecked="{Binding HasPathLengthConstraint}" />
-          <NumericUpDown Grid.Column="2" Minimum="0" Maximum="16" Value="{Binding PathLengthConstraint}" IsEnabled="{Binding HasPathLengthConstraint}" />
-          <TextBox Grid.Column="3" Text="{Binding SignatureAlgorithm}" Watermark="Signature algorithm" IsVisible="{Binding ShowSignatureAlgorithm}" />
-        </Grid>
-        <TextBox Text="{Binding KeyUsages}" Watermark="Key usages separated by comma or semicolon" />
-        <TextBox Text="{Binding EnhancedKeyUsages}" Watermark="Enhanced key usages separated by comma or semicolon" />
-      </StackPanel>
-    </Border>
+      <TabItem Header="Advanced">
+        <Border Classes="surface-card" Padding="16" Margin="0,10,0,0">
+          <StackPanel Spacing="12">
+            <TextBlock Text="Advanced / Raw Extension Area" FontSize="18" FontWeight="SemiBold" />
+            <Border Classes="validation-panel" Padding="12">
+              <TextBlock Text="This surface keeps raw extension text editable for key usage and EKU values without introducing a separate backend path. It is still normalized through the existing application contracts."
+                         Classes="secondary-text"
+                         TextWrapping="Wrap" />
+            </Border>
+            <TextBox Text="{Binding KeyUsages}"
+                     AcceptsReturn="True"
+                     Height="110"
+                     TextWrapping="Wrap"
+                     Watermark="Raw key usage entries" />
+            <TextBox Text="{Binding EnhancedKeyUsages}"
+                     AcceptsReturn="True"
+                     Height="110"
+                     TextWrapping="Wrap"
+                     Watermark="Raw enhanced key usage entries" />
+          </StackPanel>
+        </Border>
+      </TabItem>
 
-    <Border Classes="surface-card" Padding="12" IsVisible="{Binding ShowSigningSection}">
-      <StackPanel Spacing="10">
-        <TextBlock Text="Signing / Issuer Controls" FontWeight="SemiBold" />
-        <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
-          <ComboBox ItemsSource="{Binding IssuerCertificates}" SelectedItem="{Binding SelectedIssuerCertificate}">
-            <ComboBox.ItemTemplate>
-              <DataTemplate>
-                <TextBlock Text="{Binding DisplayName}" />
-              </DataTemplate>
-            </ComboBox.ItemTemplate>
-          </ComboBox>
-          <ComboBox Grid.Column="1" ItemsSource="{Binding IssuerPrivateKeys}" SelectedItem="{Binding SelectedIssuerPrivateKey}">
-            <ComboBox.ItemTemplate>
-              <DataTemplate>
-                <TextBlock Text="{Binding DisplayName}" />
-              </DataTemplate>
-            </ComboBox.ItemTemplate>
-          </ComboBox>
-        </Grid>
-      </StackPanel>
-    </Border>
+      <TabItem Header="Signing" IsVisible="{Binding ShowSigningSection}">
+        <Border Classes="surface-card" Padding="16" Margin="0,10,0,0">
+          <StackPanel Spacing="12">
+            <TextBlock Text="Signing / Issuer" FontSize="18" FontWeight="SemiBold" />
+            <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+              <ComboBox ItemsSource="{Binding IssuerCertificates}" SelectedItem="{Binding SelectedIssuerCertificate}">
+                <ComboBox.ItemTemplate>
+                  <DataTemplate>
+                    <TextBlock Text="{Binding DisplayName}" />
+                  </DataTemplate>
+                </ComboBox.ItemTemplate>
+              </ComboBox>
+              <ComboBox Grid.Column="1" ItemsSource="{Binding IssuerPrivateKeys}" SelectedItem="{Binding SelectedIssuerPrivateKey}">
+                <ComboBox.ItemTemplate>
+                  <DataTemplate>
+                    <TextBlock Text="{Binding DisplayName}" />
+                  </DataTemplate>
+                </ComboBox.ItemTemplate>
+              </ComboBox>
+            </Grid>
+          </StackPanel>
+        </Border>
+      </TabItem>
 
-    <Border Classes="surface-card" Padding="12" IsVisible="{Binding ShowValiditySection}">
-      <StackPanel Spacing="10">
-        <TextBlock Text="Validity" FontWeight="SemiBold" />
-        <NumericUpDown Minimum="1" Maximum="36500" Value="{Binding ValidityDays}" />
-      </StackPanel>
+      <TabItem Header="Validity" IsVisible="{Binding ShowValiditySection}">
+        <Border Classes="surface-card" Padding="16" Margin="0,10,0,0">
+          <StackPanel Spacing="12">
+            <TextBlock Text="Validity" FontSize="18" FontWeight="SemiBold" />
+            <NumericUpDown Minimum="1" Maximum="36500" Value="{Binding ValidityDays}" Width="220" />
+          </StackPanel>
+        </Border>
+      </TabItem>
+    </TabControl>
+
+    <Border Classes="surface-subtle" Padding="14">
+      <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+        <TextBlock Text="{Binding Title}" FontWeight="SemiBold" VerticalAlignment="Center" />
+        <Button Grid.Column="1"
+                Content="{Binding PrimaryActionLabel}"
+                Command="{Binding PrimaryActionCommand}"
+                MinWidth="150" />
+      </Grid>
     </Border>
-  </StackPanel>
+  </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Shared/CertificateAuthoringSurfaceView.axaml.cs
+++ b/src/XcaNet.App/Views/Shared/CertificateAuthoringSurfaceView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace XcaNet.App.Views.Shared;
+
+public partial class CertificateAuthoringSurfaceView : UserControl
+{
+    public CertificateAuthoringSurfaceView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/XcaNet.App/Views/Shared/TemplateAuthoringDialogView.axaml
+++ b/src/XcaNet.App/Views/Shared/TemplateAuthoringDialogView.axaml
@@ -2,50 +2,41 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:shared="using:XcaNet.App.Views.Shared"
              x:Class="XcaNet.App.Views.Shared.TemplateAuthoringDialogView">
-  <Grid RowDefinitions="Auto,*" RowSpacing="12">
-    <StackPanel Spacing="10">
-      <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
-        <TextBox Text="{Binding Name}" Watermark="Template name" />
-        <ComboBox Grid.Column="1" ItemsSource="{Binding IntendedUsages}" SelectedItem="{Binding IntendedUsage}" />
-      </Grid>
-      <TextBox Text="{Binding Description}" Watermark="Description" AcceptsReturn="True" Height="72" TextWrapping="Wrap" />
-      <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnSpacing="10">
-        <CheckBox Content="Enabled" IsChecked="{Binding IsEnabled}" />
-        <CheckBox Grid.Column="1" Content="Favorite" IsChecked="{Binding IsFavorite}" />
-        <Button Grid.Column="2" Content="Save Template" Command="{Binding SaveTemplateCommand}" />
-        <Button Grid.Column="3" Content="Clone" Command="{Binding CloneTemplateCommand}" />
-        <Button Grid.Column="4" Content="Delete" Command="{Binding DeleteTemplateCommand}" />
-      </Grid>
-    </StackPanel>
+  <Grid RowDefinitions="Auto,*,Auto" RowSpacing="8">
+    <Grid ColumnDefinitions="*,220,Auto,Auto" ColumnSpacing="8">
+      <TextBox Text="{Binding Name}" Watermark="Template name" />
+      <ComboBox Grid.Column="1" ItemsSource="{Binding IntendedUsages}" SelectedItem="{Binding IntendedUsage}" />
+      <CheckBox Grid.Column="2" Content="Enabled" IsChecked="{Binding IsEnabled}" VerticalAlignment="Center" />
+      <CheckBox Grid.Column="3" Content="Favorite" IsChecked="{Binding IsFavorite}" VerticalAlignment="Center" />
+    </Grid>
 
-    <Grid Grid.Row="1" ColumnDefinitions="1.4*,0.8*" ColumnSpacing="14">
+    <Grid Grid.Row="1" ColumnDefinitions="*,260" ColumnSpacing="10">
       <shared:CertificateAuthoringSurfaceView DataContext="{Binding Authoring}" />
+      <TabControl Grid.Column="1" Classes="workspace-inspector-tabs">
+        <TabItem Header="Summary">
+          <TextBox Margin="8" Classes="readonly-surface"
+                   Text="{Binding PreviewSummary}"
+                   IsReadOnly="True"
+                   AcceptsReturn="True"
+                   Height="300"
+                   TextWrapping="Wrap" />
+        </TabItem>
+        <TabItem Header="Validation">
+          <TextBox Margin="8" Classes="readonly-surface"
+                   Text="{Binding ValidationSummary}"
+                   IsReadOnly="True"
+                   AcceptsReturn="True"
+                   Height="300"
+                   TextWrapping="Wrap" />
+        </TabItem>
+      </TabControl>
+    </Grid>
 
-      <StackPanel Grid.Column="1" Spacing="14">
-        <Border Classes="surface-card" Padding="16">
-          <StackPanel Spacing="10">
-            <TextBlock Text="Template Summary" FontSize="18" FontWeight="SemiBold" />
-            <TextBox Classes="readonly-surface"
-                     Text="{Binding PreviewSummary}"
-                     IsReadOnly="True"
-                     AcceptsReturn="True"
-                     Height="220"
-                     TextWrapping="Wrap" />
-          </StackPanel>
-        </Border>
-
-        <Border Classes="surface-card" Padding="16">
-          <StackPanel Spacing="10">
-            <TextBlock Text="Validation" FontSize="18" FontWeight="SemiBold" />
-            <TextBox Classes="readonly-surface"
-                     Text="{Binding ValidationSummary}"
-                     IsReadOnly="True"
-                     AcceptsReturn="True"
-                     Height="180"
-                     TextWrapping="Wrap" />
-          </StackPanel>
-        </Border>
-      </StackPanel>
+    <Grid Grid.Row="2" ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="8">
+      <TextBox Text="{Binding Description}" Watermark="Description" />
+      <Button Grid.Column="1" Content="Clone" Command="{Binding CloneTemplateCommand}" />
+      <Button Grid.Column="2" Content="Delete" Command="{Binding DeleteTemplateCommand}" />
+      <Button Grid.Column="3" Content="Save Template" Command="{Binding SaveTemplateCommand}" />
     </Grid>
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Shared/TemplateAuthoringDialogView.axaml
+++ b/src/XcaNet.App/Views/Shared/TemplateAuthoringDialogView.axaml
@@ -1,0 +1,51 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:shared="using:XcaNet.App.Views.Shared"
+             x:Class="XcaNet.App.Views.Shared.TemplateAuthoringDialogView">
+  <Grid RowDefinitions="Auto,*" RowSpacing="12">
+    <StackPanel Spacing="10">
+      <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+        <TextBox Text="{Binding Name}" Watermark="Template name" />
+        <ComboBox Grid.Column="1" ItemsSource="{Binding IntendedUsages}" SelectedItem="{Binding IntendedUsage}" />
+      </Grid>
+      <TextBox Text="{Binding Description}" Watermark="Description" AcceptsReturn="True" Height="72" TextWrapping="Wrap" />
+      <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnSpacing="10">
+        <CheckBox Content="Enabled" IsChecked="{Binding IsEnabled}" />
+        <CheckBox Grid.Column="1" Content="Favorite" IsChecked="{Binding IsFavorite}" />
+        <Button Grid.Column="2" Content="Save Template" Command="{Binding SaveTemplateCommand}" />
+        <Button Grid.Column="3" Content="Clone" Command="{Binding CloneTemplateCommand}" />
+        <Button Grid.Column="4" Content="Delete" Command="{Binding DeleteTemplateCommand}" />
+      </Grid>
+    </StackPanel>
+
+    <Grid Grid.Row="1" ColumnDefinitions="1.4*,0.8*" ColumnSpacing="14">
+      <shared:CertificateAuthoringSurfaceView DataContext="{Binding Authoring}" />
+
+      <StackPanel Grid.Column="1" Spacing="14">
+        <Border Classes="surface-card" Padding="16">
+          <StackPanel Spacing="10">
+            <TextBlock Text="Template Summary" FontSize="18" FontWeight="SemiBold" />
+            <TextBox Classes="readonly-surface"
+                     Text="{Binding PreviewSummary}"
+                     IsReadOnly="True"
+                     AcceptsReturn="True"
+                     Height="220"
+                     TextWrapping="Wrap" />
+          </StackPanel>
+        </Border>
+
+        <Border Classes="surface-card" Padding="16">
+          <StackPanel Spacing="10">
+            <TextBlock Text="Validation" FontSize="18" FontWeight="SemiBold" />
+            <TextBox Classes="readonly-surface"
+                     Text="{Binding ValidationSummary}"
+                     IsReadOnly="True"
+                     AcceptsReturn="True"
+                     Height="180"
+                     TextWrapping="Wrap" />
+          </StackPanel>
+        </Border>
+      </StackPanel>
+    </Grid>
+  </Grid>
+</UserControl>

--- a/src/XcaNet.App/Views/Shared/TemplateAuthoringDialogView.axaml.cs
+++ b/src/XcaNet.App/Views/Shared/TemplateAuthoringDialogView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace XcaNet.App.Views.Shared;
+
+public partial class TemplateAuthoringDialogView : UserControl
+{
+    public TemplateAuthoringDialogView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/XcaNet.Contracts/Browser/CertificateListItem.cs
+++ b/src/XcaNet.Contracts/Browser/CertificateListItem.cs
@@ -17,4 +17,9 @@ public sealed record CertificateListItem(
     DateTimeOffset? RevokedAt,
     Guid? IssuerCertificateId,
     Guid? PrivateKeyId,
-    int ChildCertificateCount);
+    int ChildCertificateCount)
+{
+    public string CertificateKind => IsCertificateAuthority ? "CA" : "Leaf";
+
+    public string PrivateKeyStatus => PrivateKeyId is null ? "No" : "Yes";
+}

--- a/src/XcaNet.Contracts/Browser/CertificateRequestListItem.cs
+++ b/src/XcaNet.Contracts/Browser/CertificateRequestListItem.cs
@@ -8,4 +8,7 @@ public sealed record CertificateRequestListItem(
     NavigationTarget? PrivateKeyTarget,
     string KeyAlgorithm,
     string SubjectAlternativeNames,
-    DateTimeOffset CreatedUtc);
+    DateTimeOffset CreatedUtc)
+{
+    public string PrivateKeySummary => PrivateKeyId is null ? "Imported" : "Stored key";
+}

--- a/src/XcaNet.Contracts/Browser/PrivateKeyListItem.cs
+++ b/src/XcaNet.Contracts/Browser/PrivateKeyListItem.cs
@@ -6,4 +6,9 @@ public sealed record PrivateKeyListItem(
     string Algorithm,
     string PublicKeyFingerprint,
     DateTimeOffset CreatedUtc,
-    int LinkedCertificateCount);
+    int LinkedCertificateCount)
+{
+    public string SizeOrCurve => Algorithm;
+
+    public string RelatedObjectSummary => $"{LinkedCertificateCount} linked";
+}

--- a/src/XcaNet.Contracts/Browser/TemplateListItem.cs
+++ b/src/XcaNet.Contracts/Browser/TemplateListItem.cs
@@ -7,4 +7,9 @@ public sealed record TemplateListItem(
     TemplateIntendedUsage IntendedUsage,
     bool IsFavorite,
     bool IsEnabled,
-    string Summary);
+    string Summary)
+{
+    public string EnabledState => IsEnabled ? "Enabled" : "Disabled";
+
+    public string FavoriteState => IsFavorite ? "Favorite" : "Standard";
+}

--- a/tests/XcaNet.Integration.Tests/PageViewModelTests.cs
+++ b/tests/XcaNet.Integration.Tests/PageViewModelTests.cs
@@ -249,6 +249,23 @@ public sealed class PageViewModelTests
         Assert.Equal(KeyAlgorithmKind.Ecdsa, page.Authoring.KeyAlgorithm);
     }
 
+    [Fact]
+    public void BrowserListItems_ShouldExposeWorkspaceDisplaySummaries()
+    {
+        var privateKey = new PrivateKeyListItem(Guid.NewGuid(), "Issuer Key", "RSA 3072", "fp", DateTimeOffset.UtcNow, 2);
+        var request = new CertificateRequestListItem(Guid.NewGuid(), "Leaf CSR", "CN=leaf.example.test", Guid.NewGuid(), null, "ECDSA P-256", "leaf.example.test", DateTimeOffset.UtcNow);
+        var certificate = CreateCertificateListItem(Guid.NewGuid(), "Leaf");
+        var template = new TemplateListItem(Guid.NewGuid(), "Server", "desc", TemplateIntendedUsage.EndEntityCertificate, true, false, "summary");
+
+        Assert.Equal("RSA 3072", privateKey.SizeOrCurve);
+        Assert.Equal("2 linked", privateKey.RelatedObjectSummary);
+        Assert.Equal("Stored key", request.PrivateKeySummary);
+        Assert.Equal("Leaf", certificate.CertificateKind);
+        Assert.Equal("No", certificate.PrivateKeyStatus);
+        Assert.Equal("Disabled", template.EnabledState);
+        Assert.Equal("Favorite", template.FavoriteState);
+    }
+
     private static CertificateListItem CreateCertificateListItem(Guid id, string displayName, bool isCertificateAuthority = false)
     {
         return new CertificateListItem(

--- a/tests/XcaNet.Integration.Tests/PageViewModelTests.cs
+++ b/tests/XcaNet.Integration.Tests/PageViewModelTests.cs
@@ -132,6 +132,123 @@ public sealed class PageViewModelTests
         Assert.Contains("Server Authentication", saveRequest.EnhancedKeyUsages);
     }
 
+    [Fact]
+    public void CertificateAuthoringViewModel_ApplyTemplateDefaults_ShouldRespectMode()
+    {
+        var page = new CertificateAuthoringViewModel(
+            "CSR Authoring",
+            "Operation: create request",
+            "Source: selected key",
+            "Original Display",
+            "CN=original.example.test",
+            180,
+            false,
+            "DigitalSignature",
+            "Server Authentication",
+            true,
+            true,
+            false,
+            true,
+            true,
+            "Create CSR");
+        var defaults = new AppliedTemplateDefaults(
+            Guid.NewGuid(),
+            "Template Display",
+            TemplateWorkflowKind.CertificateSigningRequest,
+            "CN=template.example.test",
+            ["template.example.test", "api.template.example.test"],
+            KeyAlgorithmKind.Ecdsa,
+            null,
+            EllipticCurveKind.P384,
+            "SHA-384",
+            397,
+            true,
+            2,
+            ["DigitalSignature", "KeyEncipherment"],
+            ["Client Authentication"],
+            new TemplatePreviewSummary("usage", "subject", "san", "key", "validity", "extensions", "state"),
+            new TemplateValidationSummary([], []));
+
+        page.SelectedTemplateApplicationMode = TemplateApplicationModeView.SubjectOnly;
+        page.ApplyTemplateDefaults(defaults);
+
+        Assert.Equal("Original Display", page.DisplayName);
+        Assert.Equal("CN=template.example.test", page.SubjectName);
+        Assert.Equal("template.example.test, api.template.example.test", page.SubjectAlternativeNames);
+        Assert.Equal(180, page.ValidityDays);
+        Assert.False(page.IsCertificateAuthority);
+
+        page.SelectedTemplateApplicationMode = TemplateApplicationModeView.ExtensionsOnly;
+        page.ApplyTemplateDefaults(defaults);
+
+        Assert.True(page.IsCertificateAuthority);
+        Assert.True(page.HasPathLengthConstraint);
+        Assert.Equal(2, page.PathLengthConstraint);
+        Assert.Equal("DigitalSignature, KeyEncipherment", page.KeyUsages);
+        Assert.Equal("Client Authentication", page.EnhancedKeyUsages);
+        Assert.Equal(KeyAlgorithmKind.Rsa, page.KeyAlgorithm);
+
+        page.SelectedTemplateApplicationMode = TemplateApplicationModeView.Full;
+        page.ApplyTemplateDefaults(defaults);
+
+        Assert.Equal("Template Display", page.DisplayName);
+        Assert.Equal(KeyAlgorithmKind.Ecdsa, page.KeyAlgorithm);
+        Assert.Equal(EllipticCurveKind.P384, page.Curve);
+        Assert.Equal("SHA-384", page.SignatureAlgorithm);
+        Assert.Equal(397, page.ValidityDays);
+    }
+
+    [Fact]
+    public void TemplatesPageViewModel_ShouldLoadCertificateAndRequestIntoCentralAuthoringSurface()
+    {
+        var page = new TemplatesPageViewModel();
+        var certificate = CreateCertificateListItem(Guid.NewGuid(), "Leaf");
+        var request = new CertificateRequestListItem(
+            Guid.NewGuid(),
+            "Leaf CSR",
+            "CN=leaf.example.test",
+            Guid.NewGuid(),
+            new NavigationTarget(BrowserEntityType.PrivateKey, Guid.NewGuid(), NavigationFocusSection.Overview),
+            "ECDSA",
+            "leaf.example.test, api.example.test",
+            DateTimeOffset.UtcNow);
+        var inspector = new CertificateInspectorData(
+            certificate.CertificateId,
+            new CertificateDisplayFields(certificate.DisplayName, "range", "Leaf", "Issuer", "Leaf Key"),
+            new CertificateRawFields(
+                certificate.Subject,
+                certificate.Issuer,
+                certificate.SerialNumber,
+                DateTimeOffset.UtcNow.AddDays(-1),
+                DateTimeOffset.UtcNow.AddDays(364),
+                certificate.Sha1Thumbprint,
+                certificate.Sha256Thumbprint,
+                certificate.KeyAlgorithm),
+            new CertificateExtensionFields(
+                false,
+                ["leaf.example.test"],
+                ["DigitalSignature", "KeyEncipherment"],
+                ["Server Authentication"]),
+            new CertificateRevocationInfo(false, "Active", null, null, null),
+            new CertificateNavigationInfo(null, null, []));
+
+        page.PrepareTemplateFromCertificate(certificate, inspector);
+
+        Assert.Equal("Leaf derived template", page.Name);
+        Assert.Equal(TemplateIntendedUsage.EndEntityCertificate, page.IntendedUsage);
+        Assert.Equal("CN=Leaf", page.Authoring.SubjectName);
+        Assert.Equal("leaf.example.test", page.Authoring.SubjectAlternativeNames);
+        Assert.Equal("DigitalSignature, KeyEncipherment", page.Authoring.KeyUsages);
+
+        page.PrepareTemplateFromCertificateRequest(request);
+
+        Assert.Equal("Leaf CSR derived template", page.Name);
+        Assert.Equal(TemplateIntendedUsage.CertificateSigningRequest, page.IntendedUsage);
+        Assert.Equal("CN=leaf.example.test", page.Authoring.SubjectName);
+        Assert.Equal("leaf.example.test, api.example.test", page.Authoring.SubjectAlternativeNames);
+        Assert.Equal(KeyAlgorithmKind.Ecdsa, page.Authoring.KeyAlgorithm);
+    }
+
     private static CertificateListItem CreateCertificateListItem(Guid id, string displayName, bool isCertificateAuthority = false)
     {
         return new CertificateListItem(

--- a/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
+++ b/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
@@ -4,8 +4,10 @@ using Microsoft.Extensions.Logging.Abstractions;
 using XcaNet.App.Services;
 using XcaNet.App.Commands;
 using XcaNet.App.ViewModels;
+using XcaNet.App.ViewModels.Pages;
 using XcaNet.Application.DependencyInjection;
 using XcaNet.Application.Services;
+using XcaNet.Contracts.Browser;
 using XcaNet.Contracts.Crypto;
 using XcaNet.Contracts.Crypto.Workflow;
 using XcaNet.Contracts.Database;
@@ -58,6 +60,79 @@ public sealed class ShellWorkflowTests
         await ((AsyncCommand)shell.CertificateRevocationListsPage.RefreshCommand!).ExecuteAsync();
 
         Assert.NotEmpty(shell.CertificateRevocationListsPage.Items);
+    }
+
+    [Fact]
+    public async Task CentralAuthoringSurface_ShouldSupportTemplateModesAndCoreCreationFlow()
+    {
+        using var provider = BuildServiceProvider();
+        var service = provider.GetRequiredService<IDatabaseSessionService>();
+        var databasePath = GetDatabasePath();
+
+        await service.CreateDatabaseAsync(new CreateDatabaseRequest(databasePath, "correct horse battery staple", "M13 Test"), CancellationToken.None);
+
+        await service.OpenDatabaseAsync(new OpenDatabaseRequest(databasePath), CancellationToken.None);
+        await service.UnlockDatabaseAsync(new UnlockDatabaseRequest("correct horse battery staple"), CancellationToken.None);
+
+        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        while (shell.IsBusy)
+        {
+            await Task.Delay(20);
+        }
+
+        await ((AsyncCommand)shell.PrivateKeysPage.RefreshCommand!).ExecuteAsync();
+        await ((AsyncCommand)shell.CertificateRequestsPage.RefreshCommand!).ExecuteAsync();
+        await ((AsyncCommand)shell.TemplatesPage.RefreshCommand!).ExecuteAsync();
+
+        shell.PrivateKeysPage.NewKeyDisplayName = "Root Key";
+        await shell.PrivateKeysPage.GenerateKeyCommand!.As<AsyncCommand>().ExecuteAsync();
+        shell.PrivateKeysPage.SelectedItem = shell.PrivateKeysPage.Items.Single(x => x.DisplayName == "Root Key");
+        shell.PrivateKeysPage.SelfSignedCaAuthoring.DisplayName = "Root CA";
+        shell.PrivateKeysPage.SelfSignedCaAuthoring.SubjectName = "CN=Root CA";
+        shell.PrivateKeysPage.SelfSignedCaAuthoring.ValidityDays = 3650;
+        await shell.PrivateKeysPage.CreateSelfSignedCaCommand!.As<AsyncCommand>().ExecuteAsync();
+
+        shell.PrivateKeysPage.NewKeyDisplayName = "Leaf Key";
+        shell.PrivateKeysPage.SelectedAlgorithm = KeyAlgorithmView.Ecdsa;
+        shell.PrivateKeysPage.SelectedCurve = EllipticCurveView.P256;
+        await shell.PrivateKeysPage.GenerateKeyCommand!.As<AsyncCommand>().ExecuteAsync();
+        shell.PrivateKeysPage.SelectedItem = shell.PrivateKeysPage.Items.Single(x => x.DisplayName == "Leaf Key");
+        shell.PrivateKeysPage.CertificateSigningRequestAuthoring.DisplayName = "Leaf CSR";
+        shell.PrivateKeysPage.CertificateSigningRequestAuthoring.SubjectName = "CN=leaf.example.test";
+        shell.PrivateKeysPage.CertificateSigningRequestAuthoring.SubjectAlternativeNames = "leaf.example.test, api.example.test";
+        shell.PrivateKeysPage.CertificateSigningRequestAuthoring.KeyUsages = "DigitalSignature, KeyEncipherment";
+        shell.PrivateKeysPage.CertificateSigningRequestAuthoring.EnhancedKeyUsages = "Server Authentication";
+
+        await shell.PrivateKeysPage.CreateCertificateSigningRequestCommand!.As<AsyncCommand>().ExecuteAsync();
+        await shell.CertificateRequestsPage.RefreshCommand!.As<AsyncCommand>().ExecuteAsync();
+
+        shell.CertificateRequestsPage.SelectedItem = shell.CertificateRequestsPage.Items.Single(x => x.DisplayName == "Leaf CSR");
+        shell.CertificateRequestsPage.IssuanceAuthoring.DisplayName = "Issued Leaf";
+        shell.CertificateRequestsPage.IssuanceAuthoring.SelectedIssuerCertificate = shell.CertificateRequestsPage.IssuanceAuthoring.IssuerCertificates.Single(x => x.DisplayName == "Root CA");
+        shell.CertificateRequestsPage.IssuanceAuthoring.SelectedIssuerPrivateKey = shell.CertificateRequestsPage.IssuanceAuthoring.IssuerPrivateKeys.Single(x => x.DisplayName == "Root Key");
+        await shell.CertificateRequestsPage.SignSelectedCommand!.As<AsyncCommand>().ExecuteAsync();
+        await shell.CertificatesPage.RefreshCommand!.As<AsyncCommand>().ExecuteAsync();
+
+        var issuedCertificate = shell.CertificatesPage.Items.Single(x => x.DisplayName == "Issued Leaf");
+        Assert.Equal("CN=Root CA", issuedCertificate.Issuer);
+
+        shell.CertificatesPage.SelectedItem = issuedCertificate;
+        await Task.Delay(50);
+        shell.CertificatesPage.CreateTemplateFromCertificateCommand!.As<DelegateCommand>().Execute(null);
+
+        Assert.Equal("Issued Leaf derived template", shell.TemplatesPage.Name);
+        Assert.Equal(TemplateIntendedUsage.EndEntityCertificate, shell.TemplatesPage.IntendedUsage);
+
+        shell.CertificateRequestsPage.SelectedItem = shell.CertificateRequestsPage.Items.Single(x => x.DisplayName == "Leaf CSR");
+        shell.CertificateRequestsPage.CreateTemplateFromRequestCommand!.As<DelegateCommand>().Execute(null);
+
+        Assert.Equal("Leaf CSR derived template", shell.TemplatesPage.Name);
+        Assert.Equal(TemplateIntendedUsage.CertificateSigningRequest, shell.TemplatesPage.IntendedUsage);
+
+        shell.CertificateRequestsPage.CreateSimilarRequestCommand!.As<DelegateCommand>().Execute(null);
+
+        Assert.Equal("Leaf CSR Copy", shell.PrivateKeysPage.CertificateSigningRequestAuthoring.DisplayName);
+        Assert.Equal("CN=leaf.example.test", shell.PrivateKeysPage.CertificateSigningRequestAuthoring.SubjectName);
     }
 
     private static ServiceProvider BuildServiceProvider()

--- a/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
+++ b/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
@@ -87,16 +87,22 @@ public sealed class ShellWorkflowTests
         shell.PrivateKeysPage.NewKeyDisplayName = "Root Key";
         await shell.PrivateKeysPage.GenerateKeyCommand!.As<AsyncCommand>().ExecuteAsync();
         shell.PrivateKeysPage.SelectedItem = shell.PrivateKeysPage.Items.Single(x => x.DisplayName == "Root Key");
+        shell.PrivateKeysPage.OpenSelfSignedCaAuthoringCommand!.As<DelegateCommand>().Execute(null);
+        Assert.True(shell.IsAuthoringDialogOpen);
+        Assert.True(shell.IsCertificateAuthoringDialogOpen);
         shell.PrivateKeysPage.SelfSignedCaAuthoring.DisplayName = "Root CA";
         shell.PrivateKeysPage.SelfSignedCaAuthoring.SubjectName = "CN=Root CA";
         shell.PrivateKeysPage.SelfSignedCaAuthoring.ValidityDays = 3650;
         await shell.PrivateKeysPage.CreateSelfSignedCaCommand!.As<AsyncCommand>().ExecuteAsync();
+        Assert.False(shell.IsAuthoringDialogOpen);
 
         shell.PrivateKeysPage.NewKeyDisplayName = "Leaf Key";
         shell.PrivateKeysPage.SelectedAlgorithm = KeyAlgorithmView.Ecdsa;
         shell.PrivateKeysPage.SelectedCurve = EllipticCurveView.P256;
         await shell.PrivateKeysPage.GenerateKeyCommand!.As<AsyncCommand>().ExecuteAsync();
         shell.PrivateKeysPage.SelectedItem = shell.PrivateKeysPage.Items.Single(x => x.DisplayName == "Leaf Key");
+        shell.PrivateKeysPage.OpenCertificateSigningRequestAuthoringCommand!.As<DelegateCommand>().Execute(null);
+        Assert.True(shell.IsAuthoringDialogOpen);
         shell.PrivateKeysPage.CertificateSigningRequestAuthoring.DisplayName = "Leaf CSR";
         shell.PrivateKeysPage.CertificateSigningRequestAuthoring.SubjectName = "CN=leaf.example.test";
         shell.PrivateKeysPage.CertificateSigningRequestAuthoring.SubjectAlternativeNames = "leaf.example.test, api.example.test";
@@ -104,13 +110,17 @@ public sealed class ShellWorkflowTests
         shell.PrivateKeysPage.CertificateSigningRequestAuthoring.EnhancedKeyUsages = "Server Authentication";
 
         await shell.PrivateKeysPage.CreateCertificateSigningRequestCommand!.As<AsyncCommand>().ExecuteAsync();
+        Assert.False(shell.IsAuthoringDialogOpen);
         await shell.CertificateRequestsPage.RefreshCommand!.As<AsyncCommand>().ExecuteAsync();
 
         shell.CertificateRequestsPage.SelectedItem = shell.CertificateRequestsPage.Items.Single(x => x.DisplayName == "Leaf CSR");
+        shell.CertificateRequestsPage.OpenIssuanceAuthoringCommand!.As<DelegateCommand>().Execute(null);
+        Assert.True(shell.IsAuthoringDialogOpen);
         shell.CertificateRequestsPage.IssuanceAuthoring.DisplayName = "Issued Leaf";
         shell.CertificateRequestsPage.IssuanceAuthoring.SelectedIssuerCertificate = shell.CertificateRequestsPage.IssuanceAuthoring.IssuerCertificates.Single(x => x.DisplayName == "Root CA");
         shell.CertificateRequestsPage.IssuanceAuthoring.SelectedIssuerPrivateKey = shell.CertificateRequestsPage.IssuanceAuthoring.IssuerPrivateKeys.Single(x => x.DisplayName == "Root Key");
         await shell.CertificateRequestsPage.SignSelectedCommand!.As<AsyncCommand>().ExecuteAsync();
+        Assert.False(shell.IsAuthoringDialogOpen);
         await shell.CertificatesPage.RefreshCommand!.As<AsyncCommand>().ExecuteAsync();
 
         var issuedCertificate = shell.CertificatesPage.Items.Single(x => x.DisplayName == "Issued Leaf");
@@ -120,6 +130,8 @@ public sealed class ShellWorkflowTests
         await Task.Delay(50);
         shell.CertificatesPage.CreateTemplateFromCertificateCommand!.As<DelegateCommand>().Execute(null);
 
+        Assert.True(shell.IsAuthoringDialogOpen);
+        Assert.True(shell.IsTemplateAuthoringDialogOpen);
         Assert.Equal("Issued Leaf derived template", shell.TemplatesPage.Name);
         Assert.Equal(TemplateIntendedUsage.EndEntityCertificate, shell.TemplatesPage.IntendedUsage);
 
@@ -131,8 +143,13 @@ public sealed class ShellWorkflowTests
 
         shell.CertificateRequestsPage.CreateSimilarRequestCommand!.As<DelegateCommand>().Execute(null);
 
+        Assert.True(shell.IsAuthoringDialogOpen);
+        Assert.True(shell.IsCertificateAuthoringDialogOpen);
         Assert.Equal("Leaf CSR Copy", shell.PrivateKeysPage.CertificateSigningRequestAuthoring.DisplayName);
         Assert.Equal("CN=leaf.example.test", shell.PrivateKeysPage.CertificateSigningRequestAuthoring.SubjectName);
+
+        shell.CloseAuthoringDialogCommand.As<DelegateCommand>().Execute(null);
+        Assert.False(shell.IsAuthoringDialogOpen);
     }
 
     private static ServiceProvider BuildServiceProvider()

--- a/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
+++ b/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
@@ -152,6 +152,20 @@ public sealed class ShellWorkflowTests
         Assert.False(shell.IsAuthoringDialogOpen);
     }
 
+    [Fact]
+    public void Shell_ShouldDefaultToObjectWorkspaceTabs()
+    {
+        using var provider = BuildServiceProvider();
+        var service = provider.GetRequiredService<IDatabaseSessionService>();
+        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), NullLogger<ShellViewModel>.Instance);
+
+        Assert.Equal("Certificates", shell.CurrentPage.Title);
+        Assert.Equal(5, shell.WorkspaceNavigationItems.Count);
+        Assert.Equal("Private Keys", shell.WorkspaceNavigationItems[0].Title);
+        Assert.Equal("CRLs", shell.WorkspaceNavigationItems[^1].Title);
+        Assert.Equal(2, shell.UtilityNavigationItems.Count);
+    }
+
     private static ServiceProvider BuildServiceProvider()
     {
         var services = new ServiceCollection();

--- a/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
+++ b/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
@@ -162,7 +162,7 @@ public sealed class ShellWorkflowTests
         Assert.Equal("Certificates", shell.CurrentPage.Title);
         Assert.Equal(5, shell.WorkspaceNavigationItems.Count);
         Assert.Equal("Private Keys", shell.WorkspaceNavigationItems[0].Title);
-        Assert.Equal("CRLs", shell.WorkspaceNavigationItems[^1].Title);
+        Assert.Equal("Revocation lists", shell.WorkspaceNavigationItems[^1].Title);
         Assert.Equal(2, shell.UtilityNavigationItems.Count);
     }
 


### PR DESCRIPTION
## Why this exists

XcaNet's milestones so far (M13, M13.1, M13.2, M13.3) moved the app closer to XCA's
look and feel through incremental UI passes. However, each pass was guided by general
impressions rather than a concrete per-screen inventory of what XCA actually contains.
The result is an app that is structurally similar to XCA but missing dozens of specific
elements: exact column sets, button labels, context menus, modal dialogs, and operator
workflows that XCA users rely on daily.

This PR resets the implementation strategy from "XCA-inspired Avalonia app" to
"XCA screen-by-screen parity port." It does not change any code.

## What was inventoried

`docs/parity/xca-screen-inventory.md` covers all major XCA screens against XCA 2.9.0
source (Qt .ui files and documentation):

- **Main window shell** — menu bar (File / Import / Token / Extra / Help), tab bar,
  status bar; all missing menu items documented
- **Private Keys tab** — columns (Name, Algorithm, Bit length, Use, Token), buttons
  (New, Export, Import, Show Details, Delete), New Key modal dialog, Key Detail dialog
  (4 tabs), context menu items
- **Certificate Signing Requests tab** — columns (Name, Subject, Private key, Signed,
  Algorithm), Sign workflow, CSR detail view, context menu
- **Certificates tab** — hierarchical tree view, Plain View toggle, 8 columns including
  Status/color coding, Certificate Detail dialog (6 tabs), Certificate Renewal dialog,
  Revoke dialog, full context menu
- **Templates tab** — editing surface alignment with NewX509 tabs, context menu
  (Create cert/request from template)
- **Revocation Lists tab** — New CRL dialog (NewCrl.ui), CRL Detail dialog (5 tabs),
  Manage Revocations dialog
- **NewX509 / Certificate input dialog** — all 7 tabs: Source (mode radio buttons,
  signature algorithm, date pickers), Subject (structured DN widget, key selector),
  Extensions (SAN editor, CDP, AIA, key identifiers), Key Usage (checkboxes per flag,
  Critical flags), Netscape (intentional deviation candidate), Advanced, Comment
- **Template input dialog** — aligns with NewX509 gaps
- **CA Properties dialog** — CRL issuance interval, default template
- **Certificate Revocation dialog** — reason dropdown, date picker
- **Manage Revocations dialog** — Add/Delete/Edit revocation entries
- **Database flows** — PwDialog fields, Close Database, Recent databases
- **Import/Export dialogs** — ImportMulti, ExportDialog modal, clipboard import
- **Options/Preferences dialog** — 3 tabs: Settings, DN, PKCS#11 Provider
- **Certificate Renewal dialog** — date pickers, duration shortcut, revoke/replace options
- **OID Resolver dialog**

## How future implementation will work

Each screen section contains:
- **XCA reference** — exact labels, columns, buttons, tab names sourced from XCA
- **XcaNet current** — what exists today
- **Gaps** — checklist; items must be implemented or moved to Intentional Deviations
- **Intentional Deviations** — explicit exceptions with written justification
- **Priority** — which milestone closes this screen

A screen is not parity-complete until every gap is resolved or explicitly deviated.

## Implementation milestone alignment

| Milestone | Focus |
|---|---|
| M13.4 | Main shell menus (Import, Extra, full File menu) |
| M13.5 | Private Keys + CSR tabs (columns, New modal, Show Details, Delete, Import) |
| M13.6 | Certificates tab (hierarchy tree, Plain View, CertDetail modal, color coding) |
| M13.7 | NewX509 dialog (structured DN, key selector, date pickers, Key Usage checkboxes, Comment tab) |
| M14 | CA Properties, Revoke dialog, Manage Revocations, New CRL dialog, context menus, Options |
| M15 | Token menu, remote database, OID Resolver, advanced import/export |

## Next implementation milestone

**M13.4** — Main shell menus. This is the highest leverage next step because the Import
menu and Extra menu affect every tab (import paths, password change, clipboard operations).
It is also the smallest scope change that visibly closes a structural parity gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)