### PR TITLE
M13.4: shell menus and main frame parity

### DIFF
--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -28,6 +28,7 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly AsyncCommand _openDatabaseCommand;
     private readonly AsyncCommand _unlockDatabaseCommand;
     private readonly AsyncCommand _lockDatabaseCommand;
+    private readonly AsyncCommand _closeDatabaseCommand;
     private readonly AsyncCommand _refreshWorkspaceCommand;
     private readonly AsyncCommand _refreshCertificatesCommand;
     private readonly AsyncCommand _importFilesCommand;
@@ -102,6 +103,7 @@ public sealed class ShellViewModel : ViewModelBase
         _openDatabaseCommand = new AsyncCommand(OpenDatabaseAsync, () => !IsBusy);
         _unlockDatabaseCommand = new AsyncCommand(UnlockDatabaseAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Locked);
         _lockDatabaseCommand = new AsyncCommand(LockDatabaseAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked);
+        _closeDatabaseCommand = new AsyncCommand(CloseDatabaseAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed);
         _refreshWorkspaceCommand = new AsyncCommand(RefreshAllAsync, () => !IsBusy);
         _refreshCertificatesCommand = new AsyncCommand(LoadCertificatesAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed);
         _importFilesCommand = new AsyncCommand(ImportFilesFromPickerAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked);
@@ -359,6 +361,8 @@ public sealed class ShellViewModel : ViewModelBase
 
     public ICommand LockDatabaseCommand => _lockDatabaseCommand;
 
+    public ICommand CloseDatabaseCommand => _closeDatabaseCommand;
+
     public ICommand RefreshWorkspaceCommand => _refreshWorkspaceCommand;
 
     public ICommand DashboardCommand => UtilityNavigationItems[0].Command;
@@ -391,6 +395,11 @@ public sealed class ShellViewModel : ViewModelBase
     private async Task LockDatabaseAsync()
     {
         await RunDatabaseActionAsync("Locking database", () => _databaseSessionService.LockDatabaseAsync(CancellationToken.None));
+    }
+
+    private async Task CloseDatabaseAsync()
+    {
+        await RunDatabaseActionAsync("Closing database", () => _databaseSessionService.CloseDatabaseAsync(CancellationToken.None));
     }
 
     private async Task GenerateKeyAsync()
@@ -1615,6 +1624,7 @@ public sealed class ShellViewModel : ViewModelBase
         _openDatabaseCommand.RaiseCanExecuteChanged();
         _unlockDatabaseCommand.RaiseCanExecuteChanged();
         _lockDatabaseCommand.RaiseCanExecuteChanged();
+        _closeDatabaseCommand.RaiseCanExecuteChanged();
         _refreshWorkspaceCommand.RaiseCanExecuteChanged();
         _refreshCertificatesCommand.RaiseCanExecuteChanged();
         _importFilesCommand.RaiseCanExecuteChanged();

--- a/src/XcaNet.App/Views/MainWindow.axaml
+++ b/src/XcaNet.App/Views/MainWindow.axaml
@@ -12,20 +12,45 @@
     <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Background="{DynamicResource SurfaceBrush}">
       <Menu>
         <MenuItem Header="_File">
-          <MenuItem Header="Create Database" Command="{Binding CreateDatabaseCommand}" />
+          <MenuItem Header="New Database" Command="{Binding CreateDatabaseCommand}" />
           <MenuItem Header="Open Database" Command="{Binding OpenDatabaseCommand}" />
+          <MenuItem Header="Close Database" Command="{Binding CloseDatabaseCommand}" />
           <Separator />
           <MenuItem Header="Unlock" Command="{Binding UnlockDatabaseCommand}" />
           <MenuItem Header="Lock" Command="{Binding LockDatabaseCommand}" />
           <Separator />
           <MenuItem Header="Refresh" Command="{Binding RefreshWorkspaceCommand}" />
         </MenuItem>
+        <MenuItem Header="_Import">
+          <MenuItem Header="Private Keys" Command="{Binding ImportFilesCommand}" />
+          <MenuItem Header="Certificate Requests" Command="{Binding ImportFilesCommand}" />
+          <MenuItem Header="Certificates" Command="{Binding ImportFilesCommand}" />
+          <Separator />
+          <MenuItem Header="PKCS#12" Command="{Binding ImportFilesCommand}" />
+          <MenuItem Header="PKCS#7" Command="{Binding ImportFilesCommand}" />
+          <Separator />
+          <MenuItem Header="Revocation list" Command="{Binding ImportFilesCommand}" />
+          <MenuItem Header="PEM file" Command="{Binding ImportFilesCommand}" />
+        </MenuItem>
+        <MenuItem Header="E_xtra">
+          <MenuItem Header="Dump / Show Audit Log" IsEnabled="False" />
+          <MenuItem Header="Options" IsEnabled="False" />
+        </MenuItem>
         <MenuItem Header="_Token">
-          <MenuItem Header="No token actions yet" IsEnabled="False" />
+          <MenuItem Header="Generate Request" IsEnabled="False" />
+          <MenuItem Header="Import from Request" IsEnabled="False" />
+          <Separator />
+          <MenuItem Header="Init Token" IsEnabled="False" />
+          <MenuItem Header="Change PIN" IsEnabled="False" />
+          <MenuItem Header="Change SO-PIN" IsEnabled="False" />
+          <Separator />
+          <MenuItem Header="Show token info" IsEnabled="False" />
         </MenuItem>
         <MenuItem Header="_Help">
           <MenuItem Header="Overview" Command="{Binding DashboardCommand}" />
           <MenuItem Header="Settings / Security" Command="{Binding SettingsSecurityCommand}" />
+          <Separator />
+          <MenuItem Header="About" IsEnabled="False" />
         </MenuItem>
       </Menu>
       <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,8,0" Spacing="10">

--- a/src/XcaNet.Application/Services/DatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/DatabaseSessionService.cs
@@ -225,6 +225,31 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
         }
     }
 
+    public async Task<OperationResult<DatabaseSessionSnapshot>> CloseDatabaseAsync(CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (string.IsNullOrWhiteSpace(_currentDatabasePath))
+            {
+                return OperationResult<DatabaseSessionSnapshot>.Failure(OperationErrorCode.DatabaseNotOpen, "No database is currently open.");
+            }
+
+            var databasePath = _currentDatabasePath;
+            ClearUnlockedKey();
+            _state = DatabaseSessionState.Closed;
+            _currentDatabasePath = null;
+            _currentDisplayName = null;
+            _lastOpenedUtc = null;
+            await _auditEventRepository.AddAsync(databasePath, CreateAuditEvent(AuditEventKind.DatabaseClosed, "Database closed."), cancellationToken);
+            return OperationResult<DatabaseSessionSnapshot>.Success(GetSnapshot(), "Database closed.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     public async Task<OperationResult<StorePrivateKeyResult>> StorePrivateKeyAsync(StorePrivateKeyRequest request, CancellationToken cancellationToken)
     {
         await _gate.WaitAsync(cancellationToken);

--- a/src/XcaNet.Application/Services/IDatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/IDatabaseSessionService.cs
@@ -16,6 +16,8 @@ public interface IDatabaseSessionService
 
     Task<OperationResult<DatabaseSessionSnapshot>> LockDatabaseAsync(CancellationToken cancellationToken);
 
+    Task<OperationResult<DatabaseSessionSnapshot>> CloseDatabaseAsync(CancellationToken cancellationToken);
+
     Task<OperationResult<StorePrivateKeyResult>> StorePrivateKeyAsync(StorePrivateKeyRequest request, CancellationToken cancellationToken);
 
     Task<OperationResult<StoredKeyResult>> GenerateStoredKeyAsync(GenerateStoredKeyRequest request, CancellationToken cancellationToken);

--- a/src/XcaNet.Core/Enums/AuditEventKind.cs
+++ b/src/XcaNet.Core/Enums/AuditEventKind.cs
@@ -6,6 +6,7 @@ public static class AuditEventKind
     public const string DatabaseOpened = "database_opened";
     public const string DatabaseUnlocked = "database_unlocked";
     public const string DatabaseLocked = "database_locked";
+    public const string DatabaseClosed = "database_closed";
     public const string PrivateKeyGenerated = "private_key_generated";
     public const string PrivateKeyImported = "private_key_imported";
     public const string PrivateKeyStored = "private_key_stored";


### PR DESCRIPTION
## Summary

- **File menu**: renamed "Create Database" → "New Database", added **Close Database** command that resets session to Closed state (clears path, key, display name) with audit trail
- **Import menu** (new): seven per-type entries (Private Keys, Certificate Requests, Certificates, PKCS#12, PKCS#7, Revocation list, PEM file) — all route to the existing generic file-picker import; template import stays disabled until M13.5
- **Extra menu** (new): Dump / Show Audit Log and Options — both disabled (placeholders for M14/M15)
- **Token menu**: full XCA token action set (Generate Request, Import from Request, Init Token, Change PIN, Change SO-PIN, Show token info) — all disabled pending M15 hardware token support
- **Help menu**: added About (disabled)

Backend additions:
- `AuditEventKind.DatabaseClosed` constant
- `CloseDatabaseAsync` on `IDatabaseSessionService` and `DatabaseSessionService`
- `CloseDatabaseCommand` exposed on `ShellViewModel`

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings (25 projects)
- [x] `dotnet test` — 70/70 passing
- [ ] Smoke: launch app, open a DB, verify **File → Close Database** is enabled; close DB, verify it becomes disabled and session resets to Closed state
- [ ] Verify **Import** submenu appears and all items trigger file picker when a DB is unlocked
- [ ] Verify **Extra** and **Token** stubs are visible but greyed out