### PR TITLE
M13.5: Private Keys and CSR tab parity

### DIFF
--- a/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
@@ -1,4 +1,5 @@
 using System.Windows.Input;
+using XcaNet.App.Commands;
 using XcaNet.Contracts.Browser;
 
 namespace XcaNet.App.ViewModels.Pages;
@@ -7,12 +8,16 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
 {
     private CryptoFormatView _selectedExportFormat = CryptoFormatView.Pem;
     private string _exportPreview = string.Empty;
+    private bool _isDetailDialogOpen;
 
     public CertificateRequestsPageViewModel()
         : base("Certificate signing requests")
     {
         EmptyStateTitle = "No certificate signing requests";
         EmptyStateMessage = "Create a CSR from the Private Keys page or import request files to review and sign them.";
+
+        ShowDetailsCommand = new DelegateCommand(() => { if (SelectedItem is not null) IsDetailDialogOpen = true; });
+        CloseDetailCommand = new DelegateCommand(() => IsDetailDialogOpen = false);
     }
 
     public CertificateAuthoringViewModel IssuanceAuthoring { get; } = new(
@@ -37,6 +42,16 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
     public IReadOnlyList<PrivateKeyListItem> IssuerPrivateKeys => IssuanceAuthoring.IssuerPrivateKeys;
 
     public IReadOnlyList<CryptoFormatView> ExportFormats { get; } = [CryptoFormatView.Pem, CryptoFormatView.Der, CryptoFormatView.Pkcs10];
+
+    public DelegateCommand ShowDetailsCommand { get; }
+
+    public DelegateCommand CloseDetailCommand { get; }
+
+    public bool IsDetailDialogOpen
+    {
+        get => _isDetailDialogOpen;
+        set => SetProperty(ref _isDetailDialogOpen, value);
+    }
 
     public CryptoFormatView SelectedExportFormat
     {
@@ -65,6 +80,10 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
     public ICommand? CreateTemplateFromRequestCommand { get; set; }
 
     public ICommand? CreateSimilarRequestCommand { get; set; }
+
+    public ICommand? ImportCommand { get; set; }
+
+    public ICommand? DeleteSelectedCommand { get; set; }
 
     public void SetIssuers(IEnumerable<CertificateListItem> certificates, IEnumerable<PrivateKeyListItem> privateKeys)
     {

--- a/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
@@ -1,30 +1,49 @@
 using System.Collections.ObjectModel;
 using System.Windows.Input;
+using XcaNet.App.Commands;
 using XcaNet.Contracts.Browser;
 
 namespace XcaNet.App.ViewModels.Pages;
 
 public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<PrivateKeyListItem, Guid>
 {
-    private string _newKeyDisplayName = "Managed Key";
+    private string _newKeyDisplayName = "New Key";
     private KeyAlgorithmView _selectedAlgorithm = KeyAlgorithmView.Rsa;
     private EllipticCurveView _selectedCurve = EllipticCurveView.P256;
+    private int _selectedKeySize = 3072;
     private CryptoFormatView _selectedExportFormat = CryptoFormatView.Pem;
     private string _selectedExportPassword = string.Empty;
     private string _exportPreview = string.Empty;
+    private bool _isNewKeyDialogOpen;
+    private bool _isKeyDetailDialogOpen;
 
     public PrivateKeysPageViewModel()
         : base("Private Keys")
     {
         EmptyStateTitle = "No private keys stored";
         EmptyStateMessage = "Generate a key or import existing key material to begin issuing certificates and CSRs.";
+
+        OpenNewKeyDialogCommand = new DelegateCommand(() => IsNewKeyDialogOpen = true);
+        CloseNewKeyDialogCommand = new DelegateCommand(() => IsNewKeyDialogOpen = false);
+        ShowDetailsCommand = new DelegateCommand(() => { if (SelectedItem is not null) IsKeyDetailDialogOpen = true; });
+        CloseKeyDetailCommand = new DelegateCommand(() => IsKeyDetailDialogOpen = false);
     }
 
     public IReadOnlyList<KeyAlgorithmView> Algorithms { get; } = [KeyAlgorithmView.Rsa, KeyAlgorithmView.Ecdsa];
 
     public IReadOnlyList<EllipticCurveView> Curves { get; } = [EllipticCurveView.P256, EllipticCurveView.P384];
 
+    public IReadOnlyList<int> KeySizes { get; } = [2048, 3072, 4096];
+
     public IReadOnlyList<CryptoFormatView> ExportFormats { get; } = [CryptoFormatView.Pem, CryptoFormatView.Der, CryptoFormatView.Pkcs8];
+
+    public DelegateCommand OpenNewKeyDialogCommand { get; }
+
+    public DelegateCommand CloseNewKeyDialogCommand { get; }
+
+    public DelegateCommand ShowDetailsCommand { get; }
+
+    public DelegateCommand CloseKeyDetailCommand { get; }
 
     public CertificateAuthoringViewModel SelfSignedCaAuthoring { get; } = new(
         "Certificate Input",
@@ -60,6 +79,18 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
         true,
         "Create CSR");
 
+    public bool IsNewKeyDialogOpen
+    {
+        get => _isNewKeyDialogOpen;
+        set => SetProperty(ref _isNewKeyDialogOpen, value);
+    }
+
+    public bool IsKeyDetailDialogOpen
+    {
+        get => _isKeyDetailDialogOpen;
+        set => SetProperty(ref _isKeyDetailDialogOpen, value);
+    }
+
     public string NewKeyDisplayName
     {
         get => _newKeyDisplayName;
@@ -69,7 +100,24 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
     public KeyAlgorithmView SelectedAlgorithm
     {
         get => _selectedAlgorithm;
-        set => SetProperty(ref _selectedAlgorithm, value);
+        set
+        {
+            if (SetProperty(ref _selectedAlgorithm, value))
+            {
+                OnPropertyChanged(nameof(IsRsaAlgorithmSelected));
+                OnPropertyChanged(nameof(IsEcdsaAlgorithmSelected));
+            }
+        }
+    }
+
+    public bool IsRsaAlgorithmSelected => _selectedAlgorithm == KeyAlgorithmView.Rsa;
+
+    public bool IsEcdsaAlgorithmSelected => _selectedAlgorithm == KeyAlgorithmView.Ecdsa;
+
+    public int SelectedKeySize
+    {
+        get => _selectedKeySize;
+        set => SetProperty(ref _selectedKeySize, value);
     }
 
     public EllipticCurveView SelectedCurve
@@ -113,6 +161,10 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
     public ICommand? ExportSelectedCommand { get; set; }
 
     public ICommand? ExportSelectedToFileCommand { get; set; }
+
+    public ICommand? ImportCommand { get; set; }
+
+    public ICommand? DeleteSelectedCommand { get; set; }
 
     public void SetTemplates(IEnumerable<TemplateListItem> templates)
     {

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -411,7 +411,7 @@ public sealed class ShellViewModel : ViewModelBase
 
         using var scope = BeginBusy("Generating managed private key");
         var result = await _databaseSessionService.GenerateStoredKeyAsync(
-            new GenerateStoredKeyRequest(PrivateKeysPage.NewKeyDisplayName, algorithm, algorithm == KeyAlgorithmKind.Rsa ? 3072 : null, curve),
+            new GenerateStoredKeyRequest(PrivateKeysPage.NewKeyDisplayName, algorithm, algorithm == KeyAlgorithmKind.Rsa ? PrivateKeysPage.SelectedKeySize : null, curve),
             CancellationToken.None);
 
         if (!result.IsSuccess || result.Value is null)
@@ -420,6 +420,7 @@ public sealed class ShellViewModel : ViewModelBase
             return;
         }
 
+        PrivateKeysPage.IsNewKeyDialogOpen = false;
         await RefreshAllAsync();
         NavigateTo(new NavigationTarget(BrowserEntityType.PrivateKey, result.Value.PrivateKeyId, NavigationFocusSection.Overview));
         NotifySuccess($"Generated {result.Value.Algorithm} key.");

--- a/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
@@ -1,11 +1,13 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Pages.CertificateRequestsPageView">
-  <Grid ColumnDefinitions="*,150" RowDefinitions="*,170" ColumnSpacing="8" RowSpacing="8">
+  <Grid ColumnDefinitions="*,150" RowDefinitions="*,140" ColumnSpacing="8" RowSpacing="8">
+
+    <!-- Main table -->
     <Border Grid.Row="0" Classes="workspace-pane">
       <Grid RowDefinitions="Auto,*">
         <Border Classes="table-header" Padding="8,6">
-          <Grid ColumnDefinitions="1.2*,2.2*,1.0*,0.9*,1.0*" ColumnSpacing="10">
+          <Grid ColumnDefinitions="1.2*,2.0*,0.9*,0.9*,1.0*" ColumnSpacing="8">
             <TextBlock Text="Certificate signing requests" FontWeight="SemiBold" />
             <TextBlock Grid.Column="1" Text="Subject" Classes="table-header-text" />
             <TextBlock Grid.Column="2" Text="Key" Classes="table-header-text" />
@@ -18,10 +20,24 @@
             <TextBlock Text="{Binding EmptyStateMessage}" TextWrapping="Wrap" />
           </Border>
           <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+            <ListBox.ContextMenu>
+              <ContextMenu>
+                <MenuItem Header="Show Details" Command="{Binding ShowDetailsCommand}" />
+                <MenuItem Header="Sign" Command="{Binding OpenIssuanceAuthoringCommand}" />
+                <MenuItem Header="Export" Command="{Binding ExportSelectedToFileCommand}" />
+                <Separator />
+                <MenuItem Header="Similar Request" Command="{Binding CreateSimilarRequestCommand}" />
+                <MenuItem Header="To Template" Command="{Binding CreateTemplateFromRequestCommand}" />
+                <MenuItem Header="Open Key" Command="{Binding OpenSelectedPrivateKeyCommand}" />
+                <Separator />
+                <MenuItem Header="Import" IsEnabled="False" />
+                <MenuItem Header="Delete" IsEnabled="False" />
+              </ContextMenu>
+            </ListBox.ContextMenu>
             <ListBox.ItemTemplate>
               <DataTemplate>
                 <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
-                  <Grid ColumnDefinitions="1.2*,2.2*,1.0*,0.9*,1.0*" ColumnSpacing="10">
+                  <Grid ColumnDefinitions="1.2*,2.0*,0.9*,0.9*,1.0*" ColumnSpacing="8">
                     <TextBlock Text="{Binding DisplayName}" />
                     <TextBlock Grid.Column="1" Text="{Binding Subject}" TextWrapping="Wrap" />
                     <TextBlock Grid.Column="2" Text="{Binding PrivateKeySummary}" />
@@ -36,13 +52,14 @@
       </Grid>
     </Border>
 
+    <!-- Side action panel -->
     <Border Grid.Column="1" Classes="classic-side-panel" Padding="8">
       <StackPanel>
         <Button Classes="side-action" Content="New Request" IsEnabled="False" />
         <Button Classes="side-action" Content="Sign" Command="{Binding OpenIssuanceAuthoringCommand}" />
         <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedToFileCommand}" />
         <Button Classes="side-action" Content="Import" IsEnabled="False" />
-        <Button Classes="side-action" Content="Show Details" IsEnabled="False" />
+        <Button Classes="side-action" Content="Show Details" Command="{Binding ShowDetailsCommand}" IsEnabled="{Binding HasSelection}" />
         <Button Classes="side-action" Content="Delete" IsEnabled="False" />
         <Button Classes="side-action" Content="Similar Request" Command="{Binding CreateSimilarRequestCommand}" />
         <Button Classes="side-action" Content="To Template" Command="{Binding CreateTemplateFromRequestCommand}" />
@@ -51,6 +68,7 @@
       </StackPanel>
     </Border>
 
+    <!-- Inspector panel -->
     <Border Grid.Row="1" Grid.ColumnSpan="2" Classes="workspace-pane" Padding="8">
       <TabControl Classes="workspace-inspector-tabs">
         <TabItem Header="Details">
@@ -74,5 +92,37 @@
         </TabItem>
       </TabControl>
     </Border>
+
+    <!-- CSR Detail dialog overlay -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsDetailDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="560"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="Request Details" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Close" Command="{Binding CloseDetailCommand}" />
+          </Grid>
+          <Grid Grid.Row="1" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+            <TextBlock Text="Internal name" />
+            <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" />
+            <TextBlock Grid.Row="1" Text="Subject" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.Subject}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="2" Text="Alternative names" />
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedItem.SubjectAlternativeNames}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="3" Text="Algorithm" />
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.KeyAlgorithm}" />
+            <TextBlock Grid.Row="4" Text="Private key" />
+            <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding SelectedItem.PrivateKeySummary}" />
+          </Grid>
+          <Button Grid.Row="2" Content="OK" Command="{Binding CloseDetailCommand}" HorizontalAlignment="Right" MinWidth="80" />
+        </Grid>
+      </Border>
+    </Grid>
+
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
@@ -1,16 +1,18 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="XcaNet.App.Views.Pages.PrivateKeysPageView">
-  <Grid ColumnDefinitions="*,150" RowDefinitions="*,170" ColumnSpacing="8" RowSpacing="8">
+  <Grid ColumnDefinitions="*,150" RowDefinitions="*,140" ColumnSpacing="8" RowSpacing="8">
+
+    <!-- Main table -->
     <Border Grid.Row="0" Grid.Column="0" Classes="workspace-pane">
       <Grid RowDefinitions="Auto,*">
         <Border Classes="table-header" Padding="8,6">
-          <Grid ColumnDefinitions="2.0*,1.0*,1.0*,1.0*,0.9*" ColumnSpacing="10">
+          <Grid ColumnDefinitions="1.8*,1.4*,0.7*,0.9*,0.6*" ColumnSpacing="8">
             <TextBlock Text="Private Keys" FontWeight="SemiBold" />
             <TextBlock Grid.Column="1" Text="Algorithm" Classes="table-header-text" />
-            <TextBlock Grid.Column="2" Text="Size / Curve" Classes="table-header-text" />
+            <TextBlock Grid.Column="2" Text="Use" Classes="table-header-text" />
             <TextBlock Grid.Column="3" Text="Created" Classes="table-header-text" />
-            <TextBlock Grid.Column="4" Text="Related" Classes="table-header-text" />
+            <TextBlock Grid.Column="4" Text="Source" Classes="table-header-text" />
           </Grid>
         </Border>
         <Grid Grid.Row="1">
@@ -18,15 +20,27 @@
             <TextBlock Text="{Binding EmptyStateMessage}" TextWrapping="Wrap" />
           </Border>
           <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+            <ListBox.ContextMenu>
+              <ContextMenu>
+                <MenuItem Header="Show Details" Command="{Binding ShowDetailsCommand}" />
+                <MenuItem Header="Export" Command="{Binding ExportSelectedToFileCommand}" />
+                <Separator />
+                <MenuItem Header="Create CSR" Command="{Binding OpenCertificateSigningRequestAuthoringCommand}" />
+                <MenuItem Header="Create Certificate" Command="{Binding OpenSelfSignedCaAuthoringCommand}" />
+                <Separator />
+                <MenuItem Header="Import" IsEnabled="False" />
+                <MenuItem Header="Delete" IsEnabled="False" />
+              </ContextMenu>
+            </ListBox.ContextMenu>
             <ListBox.ItemTemplate>
               <DataTemplate>
                 <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
-                  <Grid ColumnDefinitions="2.0*,1.0*,1.0*,1.0*,0.9*" ColumnSpacing="10">
+                  <Grid ColumnDefinitions="1.8*,1.4*,0.7*,0.9*,0.6*" ColumnSpacing="8">
                     <TextBlock Text="{Binding DisplayName}" />
                     <TextBlock Grid.Column="1" Text="{Binding Algorithm}" />
-                    <TextBlock Grid.Column="2" Text="{Binding SizeOrCurve}" />
+                    <TextBlock Grid.Column="2" Text="{Binding LinkedCertificateCount}" />
                     <TextBlock Grid.Column="3" Text="{Binding CreatedUtc, StringFormat='{}{0:yyyy-MM-dd}'}" />
-                    <TextBlock Grid.Column="4" Text="{Binding RelatedObjectSummary}" />
+                    <TextBlock Grid.Column="4" Text="SW" />
                   </Grid>
                 </Border>
               </DataTemplate>
@@ -36,20 +50,21 @@
       </Grid>
     </Border>
 
+    <!-- Side action panel -->
     <Border Grid.Row="0" Grid.Column="1" Classes="classic-side-panel" Padding="8">
       <StackPanel>
-        <Button Classes="side-action" Content="New Key" Command="{Binding GenerateKeyCommand}" />
+        <Button Classes="side-action" Content="New Key" Command="{Binding OpenNewKeyDialogCommand}" />
         <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedToFileCommand}" />
         <Button Classes="side-action" Content="Import" IsEnabled="False" />
-        <Button Classes="side-action" Content="Show Details" IsEnabled="False" />
+        <Button Classes="side-action" Content="Show Details" Command="{Binding ShowDetailsCommand}" IsEnabled="{Binding HasSelection}" />
         <Button Classes="side-action" Content="Delete" IsEnabled="False" />
         <Button Classes="side-action" Content="Create CSR" Command="{Binding OpenCertificateSigningRequestAuthoringCommand}" />
         <Button Classes="side-action" Content="Create Certificate" Command="{Binding OpenSelfSignedCaAuthoringCommand}" />
-        <Button Classes="side-action" Content="Preview Export" Command="{Binding ExportSelectedCommand}" />
         <Button Classes="side-action" Content="Refresh" Command="{Binding RefreshCommand}" />
       </StackPanel>
     </Border>
 
+    <!-- Inspector panel -->
     <Border Grid.Row="1" Grid.ColumnSpan="2" Classes="workspace-pane" Padding="8">
       <TabControl Classes="workspace-inspector-tabs">
         <TabItem Header="Details">
@@ -64,14 +79,6 @@
             <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.CreatedUtc, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" />
           </Grid>
         </TabItem>
-        <TabItem Header="New Key">
-          <Grid Margin="6" ColumnDefinitions="220,180,180,Auto" ColumnSpacing="10">
-            <TextBox Text="{Binding NewKeyDisplayName}" Watermark="Key name" />
-            <ComboBox Grid.Column="1" ItemsSource="{Binding Algorithms}" SelectedItem="{Binding SelectedAlgorithm}" />
-            <ComboBox Grid.Column="2" ItemsSource="{Binding Curves}" SelectedItem="{Binding SelectedCurve}" />
-            <Button Grid.Column="3" Content="Generate" Command="{Binding GenerateKeyCommand}" />
-          </Grid>
-        </TabItem>
         <TabItem Header="Export">
           <Grid Margin="6" ColumnDefinitions="180,*" RowDefinitions="Auto,*" ColumnSpacing="10" RowSpacing="8">
             <ComboBox ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
@@ -81,5 +88,86 @@
         </TabItem>
       </TabControl>
     </Border>
+
+    <!-- New Key dialog overlay -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsNewKeyDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="460"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto" RowSpacing="12">
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="New Private Key" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Close" Command="{Binding CloseNewKeyDialogCommand}" />
+          </Grid>
+          <Grid Grid.Row="1" ColumnDefinitions="120,*" ColumnSpacing="10">
+            <TextBlock Text="Key Name" VerticalAlignment="Center" />
+            <TextBox Grid.Column="1" Text="{Binding NewKeyDisplayName}" Watermark="Key name" />
+          </Grid>
+          <Grid Grid.Row="2" ColumnDefinitions="120,*" ColumnSpacing="10">
+            <TextBlock Text="Algorithm" VerticalAlignment="Center" />
+            <ComboBox Grid.Column="1"
+                      ItemsSource="{Binding Algorithms}"
+                      SelectedItem="{Binding SelectedAlgorithm}"
+                      HorizontalAlignment="Stretch" />
+          </Grid>
+          <Grid Grid.Row="3" ColumnDefinitions="120,*" ColumnSpacing="10">
+            <TextBlock Text="Key Size / Curve" VerticalAlignment="Center" />
+            <Grid Grid.Column="1">
+              <ComboBox ItemsSource="{Binding KeySizes}"
+                        SelectedItem="{Binding SelectedKeySize}"
+                        IsVisible="{Binding IsRsaAlgorithmSelected}"
+                        HorizontalAlignment="Stretch" />
+              <ComboBox ItemsSource="{Binding Curves}"
+                        SelectedItem="{Binding SelectedCurve}"
+                        IsVisible="{Binding IsEcdsaAlgorithmSelected}"
+                        HorizontalAlignment="Stretch" />
+            </Grid>
+          </Grid>
+          <Grid Grid.Row="4" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+            <TextBlock />
+            <Button Grid.Column="1" Content="Cancel" Command="{Binding CloseNewKeyDialogCommand}" MinWidth="80" />
+            <Button Grid.Column="2" Content="Generate" Command="{Binding GenerateKeyCommand}" MinWidth="80" />
+          </Grid>
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- Key Detail dialog overlay -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsKeyDetailDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="560"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="Key Details" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Close" Command="{Binding CloseKeyDetailCommand}" />
+          </Grid>
+          <Grid Grid.Row="1" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+            <TextBlock Text="Internal name" />
+            <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" />
+            <TextBlock Grid.Row="1" Text="Algorithm" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.Algorithm}" />
+            <TextBlock Grid.Row="2" Text="Linked certificates" />
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SelectedItem.LinkedCertificateCount}" />
+            <TextBlock Grid.Row="3" Text="Created" />
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.CreatedUtc, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" />
+            <TextBlock Grid.Row="4" Text="Source" />
+            <TextBlock Grid.Row="4" Grid.Column="1" Text="Software (managed)" />
+            <TextBlock Grid.Row="5" Text="Fingerprint" />
+            <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding SelectedItem.PublicKeyFingerprint}" TextWrapping="Wrap" />
+          </Grid>
+          <Button Grid.Row="2" Content="OK" Command="{Binding CloseKeyDetailCommand}" HorizontalAlignment="Right" MinWidth="80" />
+        </Grid>
+      </Border>
+    </Grid>
+
   </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary

### Private Keys tab

- **New Key dialog**: replaced the inline inspector "New Key" tab with an XCA-style modal overlay. Fields: internal name, algorithm (RSA / ECDSA), key size (RSA: 2048/3072/4096) or curve (ECDSA: P-256/P-384), with Generate and Cancel buttons. Dialog closes automatically on successful generation.
- **RSA key size**: now user-selectable (2048 / 3072 / 4096 bits). Was hard-coded to 3072.
- **Show Details dialog**: new modal overlay showing internal name, algorithm, linked certificate count, created date, source (software), and public key fingerprint. Replaces the disabled placeholder.
- **Columns** (aligned to XCA): Name, Algorithm, Use (linked cert count), Created, Source ("SW" placeholder). Removed the redundant "Size / Curve" column and "Preview Export" side button.
- **Context menu**: Show Details, Export, Create CSR, Create Certificate, Import (disabled), Delete (disabled).

### CSR tab

- **Show Details dialog**: new modal overlay showing internal name, subject, SANs, algorithm, and private key info. Replaces the disabled placeholder.
- **Context menu**: Show Details, Sign, Export, Similar Request, To Template, Open Key, Import (disabled), Delete (disabled).
- **Show Details button**: now active when a CSR is selected (was always disabled).
- All existing workflows (Sign, Similar Request, To Template, Open Key, Export, Refresh) unchanged.

### Disabled placeholders documented as remaining gaps

| Gap | Tab | Target milestone |
|---|---|---|
| New Request button | CSR | M14 (requires key-picker flow) |
| Delete action | Keys + CSR | M14 (backend delete not yet implemented) |
| Import action | Keys + CSR | M14 |
| Signed column | CSR | Requires `IsSigned` on `CertificateRequestListItem` |
| Context menu password / token ops | Keys | M15 |

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings (25 projects, debug)
- [x] `dotnet build -c Release` — 0 errors, 0 warnings
- [x] `dotnet test -c Release --no-build` — 70/70 passing
- [ ] Smoke: open a database, go to Private Keys, click "New Key" → modal appears with correct fields
- [ ] Select RSA: key size dropdown shows 2048/3072/4096; select ECDSA: curve dropdown appears
- [ ] Generate a key → dialog closes, key appears in list with correct Use count (0)
- [ ] Click "Show Details" on a key → detail dialog shows correct data
- [ ] Right-click a key row → context menu appears with expected items
- [ ] Go to CSR tab, select a CSR, click "Show Details" → dialog shows correct data
- [ ] Right-click CSR row → context menu appears