### PR TITLE
M13.5.1: CSR New Request parity

### DIFF
--- a/src/XcaNet.App/ViewModels/Pages/CertificateAuthoringViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateAuthoringViewModel.cs
@@ -28,11 +28,13 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
     private bool _showSigningSection;
     private bool _showValiditySection;
     private bool _showSignatureAlgorithm;
+    private bool _showSourceKeyPicker;
     private string _primaryActionLabel;
     private TemplateListItem? _selectedTemplate;
     private TemplateApplicationModeView _selectedTemplateApplicationMode;
     private CertificateListItem? _selectedIssuerCertificate;
     private PrivateKeyListItem? _selectedIssuerPrivateKey;
+    private PrivateKeyListItem? _selectedSourceKey;
     private ICommand? _applyTemplateCommand;
     private ICommand? _primaryActionCommand;
 
@@ -51,7 +53,8 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
         bool showSigningSection,
         bool showValiditySection,
         bool showSignatureAlgorithm,
-        string primaryActionLabel)
+        string primaryActionLabel,
+        bool showSourceKeyPicker = false)
     {
         _title = title;
         _operationModeSummary = operationModeSummary;
@@ -67,6 +70,7 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
         _showSigningSection = showSigningSection;
         _showValiditySection = showValiditySection;
         _showSignatureAlgorithm = showSignatureAlgorithm;
+        _showSourceKeyPicker = showSourceKeyPicker;
         _primaryActionLabel = primaryActionLabel;
         _subjectAlternativeNames = string.Empty;
         _keyAlgorithm = KeyAlgorithmKind.Rsa;
@@ -88,6 +92,8 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
     public ObservableCollection<CertificateListItem> IssuerCertificates { get; } = [];
 
     public ObservableCollection<PrivateKeyListItem> IssuerPrivateKeys { get; } = [];
+
+    public ObservableCollection<PrivateKeyListItem> AvailableSourceKeys { get; } = [];
 
     public string Title
     {
@@ -226,6 +232,12 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
         set => SetProperty(ref _showSignatureAlgorithm, value);
     }
 
+    public bool ShowSourceKeyPicker
+    {
+        get => _showSourceKeyPicker;
+        set => SetProperty(ref _showSourceKeyPicker, value);
+    }
+
     public string PrimaryActionLabel
     {
         get => _primaryActionLabel;
@@ -256,6 +268,12 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
         set => SetProperty(ref _selectedIssuerPrivateKey, value);
     }
 
+    public PrivateKeyListItem? SelectedSourceKey
+    {
+        get => _selectedSourceKey;
+        set => SetProperty(ref _selectedSourceKey, value);
+    }
+
     public ICommand? ApplyTemplateCommand
     {
         get => _applyTemplateCommand;
@@ -278,6 +296,18 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
 
         SelectedTemplate = Templates.FirstOrDefault(x => SelectedTemplate is not null && x.TemplateId == SelectedTemplate.TemplateId)
             ?? Templates.FirstOrDefault();
+    }
+
+    public void SetSourceKeys(IEnumerable<PrivateKeyListItem> keys)
+    {
+        AvailableSourceKeys.Clear();
+        foreach (var key in keys)
+        {
+            AvailableSourceKeys.Add(key);
+        }
+
+        SelectedSourceKey = AvailableSourceKeys.FirstOrDefault(x => SelectedSourceKey is not null && x.PrivateKeyId == SelectedSourceKey.PrivateKeyId)
+            ?? SelectedSourceKey;
     }
 
     public void SetIssuers(IEnumerable<CertificateListItem> certificates, IEnumerable<PrivateKeyListItem> privateKeys)

--- a/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
@@ -65,6 +65,8 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
         set => SetProperty(ref _exportPreview, value);
     }
 
+    public ICommand? OpenNewRequestAuthoringCommand { get; set; }
+
     public ICommand? SignSelectedCommand { get; set; }
 
     public ICommand? OpenIssuanceAuthoringCommand { get; set; }

--- a/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
@@ -77,7 +77,8 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
         false,
         false,
         true,
-        "Create CSR");
+        "Create CSR",
+        true);
 
     public bool IsNewKeyDialogOpen
     {

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -44,6 +44,7 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly AsyncCommand _generateKeyCommand;
     private readonly DelegateCommand _openSelfSignedCaAuthoringCommand;
     private readonly DelegateCommand _openCertificateSigningRequestAuthoringCommand;
+    private readonly DelegateCommand _openNewCertificateSigningRequestAuthoringCommand;
     private readonly AsyncCommand _createSelfSignedCaCommand;
     private readonly AsyncCommand _createCertificateSigningRequestCommand;
     private readonly AsyncCommand _exportPrivateKeyCommand;
@@ -119,8 +120,9 @@ public sealed class ShellViewModel : ViewModelBase
         _generateKeyCommand = new AsyncCommand(GenerateKeyAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked);
         _openSelfSignedCaAuthoringCommand = new DelegateCommand(OpenSelfSignedCaAuthoring, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
         _openCertificateSigningRequestAuthoringCommand = new DelegateCommand(OpenCertificateSigningRequestAuthoring, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
+        _openNewCertificateSigningRequestAuthoringCommand = new DelegateCommand(OpenNewCertificateSigningRequestAuthoring, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked);
         _createSelfSignedCaCommand = new AsyncCommand(CreateSelfSignedCaAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
-        _createCertificateSigningRequestCommand = new AsyncCommand(CreateCertificateSigningRequestAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
+        _createCertificateSigningRequestCommand = new AsyncCommand(CreateCertificateSigningRequestAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.CertificateSigningRequestAuthoring.SelectedSourceKey is not null);
         _exportPrivateKeyCommand = new AsyncCommand(ExportSelectedPrivateKeyAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
         _exportPrivateKeyToFileCommand = new AsyncCommand(ExportSelectedPrivateKeyToFileAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
         _refreshCertificateRequestsCommand = new AsyncCommand(LoadCertificateRequestsAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed);
@@ -180,6 +182,7 @@ public sealed class ShellViewModel : ViewModelBase
         PrivateKeysPage.CertificateSigningRequestAuthoring.PrimaryActionCommand = _createCertificateSigningRequestCommand;
 
         CertificateRequestsPage.RefreshCommand = _refreshCertificateRequestsCommand;
+        CertificateRequestsPage.OpenNewRequestAuthoringCommand = _openNewCertificateSigningRequestAuthoringCommand;
         CertificateRequestsPage.OpenIssuanceAuthoringCommand = _openIssuanceAuthoringCommand;
         CertificateRequestsPage.SignSelectedCommand = _signCertificateSigningRequestCommand;
         CertificateRequestsPage.ApplyIssuanceTemplateCommand = _applyIssuanceTemplateCommand;
@@ -449,7 +452,19 @@ public sealed class ShellViewModel : ViewModelBase
             return;
         }
 
+        PrivateKeysPage.CertificateSigningRequestAuthoring.SelectedSourceKey = PrivateKeysPage.SelectedItem;
         PrivateKeysPage.CertificateSigningRequestAuthoring.SourceSummary = $"Source: private key {PrivateKeysPage.SelectedItem.DisplayName}";
+        OpenCertificateAuthoringDialog(
+            PrivateKeysPage.CertificateSigningRequestAuthoring,
+            "Certificate Input",
+            "Certificate request authoring");
+    }
+
+    private void OpenNewCertificateSigningRequestAuthoring()
+    {
+        PrivateKeysPage.CertificateSigningRequestAuthoring.SelectedSourceKey = null;
+        PrivateKeysPage.CertificateSigningRequestAuthoring.SourceSummary = "Source: no private key selected";
+        SelectPage(PrivateKeysPage);
         OpenCertificateAuthoringDialog(
             PrivateKeysPage.CertificateSigningRequestAuthoring,
             "Certificate Input",
@@ -503,7 +518,7 @@ public sealed class ShellViewModel : ViewModelBase
 
     private async Task CreateCertificateSigningRequestAsync()
     {
-        if (PrivateKeysPage.SelectedItem is null)
+        if (PrivateKeysPage.CertificateSigningRequestAuthoring.SelectedSourceKey is null)
         {
             NotifyFailure("Select a private key first.");
             return;
@@ -512,7 +527,7 @@ public sealed class ShellViewModel : ViewModelBase
         using var scope = BeginBusy("Creating certificate signing request");
         var result = await _databaseSessionService.CreateCertificateSigningRequestAsync(
             new CreateCertificateSigningRequestWorkflowRequest(
-                PrivateKeysPage.SelectedItem.PrivateKeyId,
+                PrivateKeysPage.CertificateSigningRequestAuthoring.SelectedSourceKey.PrivateKeyId,
                 PrivateKeysPage.CertificateSigningRequestAuthoring.DisplayName,
                 PrivateKeysPage.CertificateSigningRequestAuthoring.SubjectName,
                 ParseSubjectAlternativeNames(PrivateKeysPage.CertificateSigningRequestAuthoring.SubjectAlternativeNames),
@@ -1009,6 +1024,7 @@ public sealed class ShellViewModel : ViewModelBase
 
         var result = await _databaseSessionService.ListPrivateKeysAsync(CancellationToken.None);
         PrivateKeysPage.SetItems(result.IsSuccess && result.Value is not null ? result.Value : []);
+        PrivateKeysPage.CertificateSigningRequestAuthoring.SetSourceKeys(PrivateKeysPage.Items);
         CertificateRequestsPage.SetIssuers(CertificatesPage.Items, PrivateKeysPage.Items);
     }
 
@@ -1312,6 +1328,7 @@ public sealed class ShellViewModel : ViewModelBase
             PrivateKeysPage.SelectedItem = PrivateKeysPage.Items.FirstOrDefault(x => x.PrivateKeyId == privateKeyId) ?? PrivateKeysPage.SelectedItem;
         }
 
+        PrivateKeysPage.CertificateSigningRequestAuthoring.SelectedSourceKey = PrivateKeysPage.SelectedItem;
         SelectPage(PrivateKeysPage);
         OpenCertificateAuthoringDialog(
             PrivateKeysPage.CertificateSigningRequestAuthoring,
@@ -1499,7 +1516,8 @@ public sealed class ShellViewModel : ViewModelBase
     {
         if (e.PropertyName is nameof(CertificateAuthoringViewModel.SelectedTemplate)
             or nameof(CertificateAuthoringViewModel.SelectedIssuerCertificate)
-            or nameof(CertificateAuthoringViewModel.SelectedIssuerPrivateKey))
+            or nameof(CertificateAuthoringViewModel.SelectedIssuerPrivateKey)
+            or nameof(CertificateAuthoringViewModel.SelectedSourceKey))
         {
             RefreshCommandStates();
         }
@@ -1554,6 +1572,7 @@ public sealed class ShellViewModel : ViewModelBase
         CertificatesPage.Inspector = null;
         CertificatesPage.SelectedChildNavigationItem = null;
         PrivateKeysPage.SetItems([]);
+        PrivateKeysPage.CertificateSigningRequestAuthoring.SetSourceKeys([]);
         CertificateRequestsPage.SetItems([]);
         CertificateRequestsPage.SetIssuers([], []);
         CertificateRevocationListsPage.SetItems([]);
@@ -1641,6 +1660,7 @@ public sealed class ShellViewModel : ViewModelBase
         _generateKeyCommand.RaiseCanExecuteChanged();
         _openSelfSignedCaAuthoringCommand.RaiseCanExecuteChanged();
         _openCertificateSigningRequestAuthoringCommand.RaiseCanExecuteChanged();
+        _openNewCertificateSigningRequestAuthoringCommand.RaiseCanExecuteChanged();
         _createSelfSignedCaCommand.RaiseCanExecuteChanged();
         _createCertificateSigningRequestCommand.RaiseCanExecuteChanged();
         _exportPrivateKeyCommand.RaiseCanExecuteChanged();

--- a/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
@@ -22,6 +22,7 @@
           <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
             <ListBox.ContextMenu>
               <ContextMenu>
+                <MenuItem Header="New Request" Command="{Binding OpenNewRequestAuthoringCommand}" />
                 <MenuItem Header="Show Details" Command="{Binding ShowDetailsCommand}" />
                 <MenuItem Header="Sign" Command="{Binding OpenIssuanceAuthoringCommand}" />
                 <MenuItem Header="Export" Command="{Binding ExportSelectedToFileCommand}" />
@@ -55,7 +56,7 @@
     <!-- Side action panel -->
     <Border Grid.Column="1" Classes="classic-side-panel" Padding="8">
       <StackPanel>
-        <Button Classes="side-action" Content="New Request" IsEnabled="False" />
+        <Button Classes="side-action" Content="New Request" Command="{Binding OpenNewRequestAuthoringCommand}" />
         <Button Classes="side-action" Content="Sign" Command="{Binding OpenIssuanceAuthoringCommand}" />
         <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedToFileCommand}" />
         <Button Classes="side-action" Content="Import" IsEnabled="False" />

--- a/src/XcaNet.App/Views/Shared/CertificateAuthoringSurfaceView.axaml
+++ b/src/XcaNet.App/Views/Shared/CertificateAuthoringSurfaceView.axaml
@@ -4,7 +4,7 @@
   <Grid RowDefinitions="*,Auto" RowSpacing="10">
     <TabControl Classes="authoring-tabs">
       <TabItem Header="Source">
-        <Grid Margin="10" RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="8">
+        <Grid Margin="10" RowDefinitions="Auto,Auto,Auto,Auto,Auto" RowSpacing="8">
           <Grid ColumnDefinitions="150,*" ColumnSpacing="10">
             <TextBlock Text="Operation" VerticalAlignment="Center" />
             <TextBlock Grid.Column="1" Text="{Binding OperationModeSummary}" TextWrapping="Wrap" />
@@ -13,7 +13,20 @@
             <TextBlock Text="Source" VerticalAlignment="Center" />
             <TextBlock Grid.Column="1" Text="{Binding SourceSummary}" TextWrapping="Wrap" />
           </Grid>
-          <Grid Grid.Row="2" ColumnDefinitions="150,*,170,Auto" ColumnSpacing="10" IsVisible="{Binding ShowTemplateApplication}">
+          <Grid Grid.Row="2" ColumnDefinitions="150,*" ColumnSpacing="10" IsVisible="{Binding ShowSourceKeyPicker}">
+            <TextBlock Text="Private key" VerticalAlignment="Center" />
+            <ComboBox Grid.Column="1"
+                      ItemsSource="{Binding AvailableSourceKeys}"
+                      SelectedItem="{Binding SelectedSourceKey}"
+                      HorizontalAlignment="Stretch">
+              <ComboBox.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Text="{Binding DisplayName}" />
+                </DataTemplate>
+              </ComboBox.ItemTemplate>
+            </ComboBox>
+          </Grid>
+          <Grid Grid.Row="3" ColumnDefinitions="150,*,170,Auto" ColumnSpacing="10" IsVisible="{Binding ShowTemplateApplication}">
             <TextBlock Text="Template" VerticalAlignment="Center" />
             <ComboBox Grid.Column="1" ItemsSource="{Binding Templates}" SelectedItem="{Binding SelectedTemplate}">
               <ComboBox.ItemTemplate>
@@ -25,7 +38,7 @@
             <ComboBox Grid.Column="2" ItemsSource="{Binding TemplateApplicationModes}" SelectedItem="{Binding SelectedTemplateApplicationMode}" />
             <Button Grid.Column="3" Content="Apply" Command="{Binding ApplyTemplateCommand}" />
           </Grid>
-          <Grid Grid.Row="3" ColumnDefinitions="150,220" ColumnSpacing="10" IsVisible="{Binding ShowValiditySection}">
+          <Grid Grid.Row="4" ColumnDefinitions="150,220" ColumnSpacing="10" IsVisible="{Binding ShowValiditySection}">
             <TextBlock Text="Validity days" VerticalAlignment="Center" />
             <NumericUpDown Grid.Column="1" Minimum="1" Maximum="36500" Value="{Binding ValidityDays}" />
           </Grid>

--- a/tests/XcaNet.Application.Tests/CsrWorkflowTests.cs
+++ b/tests/XcaNet.Application.Tests/CsrWorkflowTests.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using XcaNet.Application.DependencyInjection;
+using XcaNet.Application.Services;
+using XcaNet.Contracts.Crypto;
+using XcaNet.Contracts.Crypto.Workflow;
+using XcaNet.Contracts.Database;
+using XcaNet.Crypto.DotNet.DependencyInjection;
+
+namespace XcaNet.Application.Tests;
+
+public sealed class CsrWorkflowTests
+{
+    [Fact]
+    public async Task CreateCertificateSigningRequestAsync_WithAnyStoredKey_ShouldSucceed()
+    {
+        // Arrange
+        using var provider = BuildServiceProvider();
+        var service = provider.GetRequiredService<IDatabaseSessionService>();
+        var databasePath = GetDatabasePath();
+
+        await service.CreateDatabaseAsync(new CreateDatabaseRequest(databasePath, "correct horse battery staple", "CSR Test"), CancellationToken.None);
+        var keyResult = await service.GenerateStoredKeyAsync(
+            new GenerateStoredKeyRequest("Service Key", KeyAlgorithmKind.Rsa, 3072, null),
+            CancellationToken.None);
+
+        // Act — create CSR directly from key ID without pre-navigating the Private Keys tab
+        var result = await service.CreateCertificateSigningRequestAsync(
+            new CreateCertificateSigningRequestWorkflowRequest(
+                keyResult.Value!.PrivateKeyId,
+                "Service CSR",
+                "CN=service.example.test",
+                []),
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(keyResult.Value.PrivateKeyId, result.Value.PrivateKeyId);
+        Assert.NotEqual(Guid.Empty, result.Value.CertificateSigningRequestId);
+    }
+
+    [Fact]
+    public async Task CreateCertificateSigningRequestAsync_WithSecondKeyInStore_ShouldSucceed()
+    {
+        // Arrange — two keys stored; CSR targets the non-first key
+        using var provider = BuildServiceProvider();
+        var service = provider.GetRequiredService<IDatabaseSessionService>();
+        var databasePath = GetDatabasePath();
+
+        await service.CreateDatabaseAsync(new CreateDatabaseRequest(databasePath, "correct horse battery staple", "CSR Test"), CancellationToken.None);
+        await service.GenerateStoredKeyAsync(new GenerateStoredKeyRequest("First Key", KeyAlgorithmKind.Rsa, 3072, null), CancellationToken.None);
+        var secondKeyResult = await service.GenerateStoredKeyAsync(
+            new GenerateStoredKeyRequest("Second Key", KeyAlgorithmKind.Ecdsa, null, EllipticCurveKind.P256),
+            CancellationToken.None);
+
+        // Act
+        var result = await service.CreateCertificateSigningRequestAsync(
+            new CreateCertificateSigningRequestWorkflowRequest(
+                secondKeyResult.Value!.PrivateKeyId,
+                "Second Key CSR",
+                "CN=second.example.test",
+                []),
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(secondKeyResult.Value.PrivateKeyId, result.Value.PrivateKeyId);
+        Assert.NotEqual(Guid.Empty, result.Value.CertificateSigningRequestId);
+    }
+
+    private static ServiceProvider BuildServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddManagedCryptoServices();
+        services.AddApplication(new ConfigurationBuilder().Build());
+        return services.BuildServiceProvider();
+    }
+
+    private static string GetDatabasePath() => Path.Combine(Path.GetTempPath(), $"xcanet-csr-{Guid.NewGuid():N}.db");
+}


### PR DESCRIPTION
## Summary

- **New Request from CSR tab**: The \"New Request\" button and context menu item on the Certificate Requests page are now active. They open the CSR authoring dialog without requiring a pre-selected key in the Private Keys tab.
- **Key picker in authoring surface**: A \"Private key\" ComboBox row appears in the Source tab of the authoring dialog when creating a CSR (not shown for CA or issuance flows). The user selects the signing key directly inside the dialog.
- **Key-started flow preserved**: Opening \"Create CSR\" from a selected private key pre-selects that key in the picker, so the existing workflow is unchanged.
- **Similar Request carries key**: `CreateSimilarRequest` now also sets `SelectedSourceKey` so the picker shows the original request's key.
- **Source key list lifecycle**: Keys are populated when `LoadPrivateKeysAsync` runs and cleared when `ClearBrowseState` resets the workspace.

## Test plan

- [ ] Open app, unlock database, go to **Requests** tab → click **New Request** → dialog opens with empty key picker
- [ ] Select a key from the picker, fill subject, click **Create CSR** → CSR appears in list
- [ ] Go to **Private Keys** tab, select a key, right-click → **Create CSR** → dialog opens with that key pre-selected
- [ ] On Requests tab, select a CSR, right-click → **Similar Request** → dialog opens with the original key pre-selected
- [ ] `CsrWorkflowTests` (2 tests) pass: `dotnet test --filter CsrWorkflowTests`
- [ ] Full test suite: `dotnet test --filter "FullyQualifiedName!~OpenSsl"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)