### PR TITLE
M13.6: Certificates tab and chain tree parity

### DIFF
--- a/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
@@ -85,6 +85,8 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
 
     public ICommand? DeleteSelectedCommand { get; set; }
 
+    public ICommand? OpenNewRequestAuthoringCommand { get; set; }
+
     public void SetIssuers(IEnumerable<CertificateListItem> certificates, IEnumerable<PrivateKeyListItem> privateKeys)
     {
         IssuanceAuthoring.SetIssuers(certificates, privateKeys);

--- a/src/XcaNet.App/ViewModels/Pages/CertificateTreeNodeViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateTreeNodeViewModel.cs
@@ -1,0 +1,35 @@
+using System.Collections.ObjectModel;
+using XcaNet.Contracts.Browser;
+
+namespace XcaNet.App.ViewModels.Pages;
+
+public sealed class CertificateTreeNodeViewModel
+{
+    public CertificateTreeNodeViewModel(CertificateListItem item)
+    {
+        Item = item;
+        Children = [];
+    }
+
+    public CertificateListItem Item { get; }
+
+    public Guid CertificateId => Item.CertificateId;
+
+    public string DisplayName => Item.DisplayName;
+
+    public string CommonName => Item.CommonName;
+
+    public string StatusDisplay => Item.StatusDisplay;
+
+    public string NotBeforeDisplay => Item.NotBefore?.ToString("yyyy-MM-dd") ?? string.Empty;
+
+    public string NotAfterDisplay => Item.NotAfter?.ToString("yyyy-MM-dd") ?? string.Empty;
+
+    public string SerialNumber => Item.SerialNumber;
+
+    public string Sha1Thumbprint => Item.Sha1Thumbprint;
+
+    public bool IsCertificateAuthority => Item.IsCertificateAuthority;
+
+    public ObservableCollection<CertificateTreeNodeViewModel> Children { get; }
+}

--- a/src/XcaNet.App/ViewModels/Pages/CertificatesPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificatesPageViewModel.cs
@@ -20,8 +20,11 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
     private string _exportPreview = string.Empty;
     private CertificateRevocationReason _selectedRevocationReason = CertificateRevocationReason.Unspecified;
     private DateTimeOffset _selectedRevocationDate = DateTimeOffset.UtcNow;
-    private string _revocationConfirmationText = string.Empty;
     private RelatedNavigationItem? _selectedChildNavigationItem;
+    private CertificateTreeNodeViewModel? _selectedTreeNode;
+    private bool _isPlainView;
+    private bool _isDetailDialogOpen;
+    private bool _isRevokeDialogOpen;
 
     public CertificatesPageViewModel()
         : base("Certificates")
@@ -50,6 +53,46 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
 
     public IReadOnlyList<CertificateRevocationReason> RevocationReasons { get; } =
         Enum.GetValues<CertificateRevocationReason>();
+
+    // --- Tree ---
+
+    public ObservableCollection<CertificateTreeNodeViewModel> CertificateTreeRoots { get; } = [];
+
+    public CertificateTreeNodeViewModel? SelectedTreeNode
+    {
+        get => _selectedTreeNode;
+        set
+        {
+            if (SetProperty(ref _selectedTreeNode, value))
+            {
+                // Sync to the flat SelectedItem so all commands remain source-of-truth agnostic.
+                if (value is not null && !ReferenceEquals(SelectedItem, value.Item))
+                    SelectedItem = value.Item;
+            }
+        }
+    }
+
+    public bool IsPlainView
+    {
+        get => _isPlainView;
+        set => SetProperty(ref _isPlainView, value);
+    }
+
+    // --- Dialogs ---
+
+    public bool IsDetailDialogOpen
+    {
+        get => _isDetailDialogOpen;
+        set => SetProperty(ref _isDetailDialogOpen, value);
+    }
+
+    public bool IsRevokeDialogOpen
+    {
+        get => _isRevokeDialogOpen;
+        set => SetProperty(ref _isRevokeDialogOpen, value);
+    }
+
+    // --- Existing data properties ---
 
     public CertificateFilterState Filter
     {
@@ -129,25 +172,13 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
         set => SetProperty(ref _selectedRevocationDate, value);
     }
 
-    public string RevocationConfirmationText
-    {
-        get => _revocationConfirmationText;
-        set
-        {
-            if (SetProperty(ref _revocationConfirmationText, value))
-            {
-                OnPropertyChanged(nameof(IsRevocationConfirmed));
-            }
-        }
-    }
-
-    public bool IsRevocationConfirmed => string.Equals(RevocationConfirmationText, "REVOKE", StringComparison.Ordinal);
-
     public RelatedNavigationItem? SelectedChildNavigationItem
     {
         get => _selectedChildNavigationItem;
         set => SetProperty(ref _selectedChildNavigationItem, value);
     }
+
+    // --- Commands ---
 
     public ICommand? ImportMaterialCommand { get; set; }
 
@@ -156,6 +187,10 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
     public ICommand? ExportSelectedCommand { get; set; }
 
     public ICommand? RevokeSelectedCommand { get; set; }
+
+    public ICommand? OpenRevokeDialogCommand { get; set; }
+
+    public ICommand? CloseRevokeDialogCommand { get; set; }
 
     public ICommand? GenerateCertificateRevocationListCommand { get; set; }
 
@@ -166,6 +201,43 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
     public ICommand? OpenChildCertificateCommand { get; set; }
 
     public ICommand? CreateTemplateFromCertificateCommand { get; set; }
+
+    public ICommand? ShowDetailsCommand { get; set; }
+
+    public ICommand? CloseDetailCommand { get; set; }
+
+    public ICommand? TogglePlainViewCommand { get; set; }
+
+    // --- Tree building ---
+
+    public void RebuildTree(IReadOnlyList<CertificateListItem> items)
+    {
+        CertificateTreeRoots.Clear();
+
+        // Index all items by their CertificateId.
+        var nodeById = new Dictionary<Guid, CertificateTreeNodeViewModel>(items.Count);
+        foreach (var item in items)
+            nodeById[item.CertificateId] = new CertificateTreeNodeViewModel(item);
+
+        // Place each node under its parent, or at root if the issuer is not in the set.
+        foreach (var item in items)
+        {
+            var node = nodeById[item.CertificateId];
+            var isSelfSigned = item.IssuerCertificateId is null
+                || item.IssuerCertificateId == item.CertificateId;
+
+            if (!isSelfSigned
+                && item.IssuerCertificateId is Guid parentId
+                && nodeById.TryGetValue(parentId, out var parent))
+            {
+                parent.Children.Add(node);
+            }
+            else
+            {
+                CertificateTreeRoots.Add(node);
+            }
+        }
+    }
 
     protected override Guid GetItemId(CertificateListItem item) => item.CertificateId;
 }

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -73,6 +73,11 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly DelegateCommand _createTemplateFromRequestCommand;
     private readonly DelegateCommand _createSimilarRequestCommand;
     private readonly DelegateCommand _closeAuthoringDialogCommand;
+    private readonly DelegateCommand _showCertificateDetailsCommand;
+    private readonly DelegateCommand _closeCertificateDetailCommand;
+    private readonly DelegateCommand _openRevokeDialogCommand;
+    private readonly DelegateCommand _closeRevokeDialogCommand;
+    private readonly DelegateCommand _togglePlainViewCommand;
 
     private PageViewModelBase _currentPage;
     private string _subtitle = "Core UI workflows";
@@ -149,6 +154,11 @@ public sealed class ShellViewModel : ViewModelBase
         _createTemplateFromRequestCommand = new DelegateCommand(CreateTemplateFromRequest, () => CertificateRequestsPage.SelectedItem is not null);
         _createSimilarRequestCommand = new DelegateCommand(CreateSimilarRequest, () => CertificateRequestsPage.SelectedItem is not null);
         _closeAuthoringDialogCommand = new DelegateCommand(CloseAuthoringDialog, () => IsAuthoringDialogOpen && !IsBusy);
+        _showCertificateDetailsCommand = new DelegateCommand(ShowCertificateDetails, () => CertificatesPage.HasSelection && CertificatesPage.Inspector is not null);
+        _closeCertificateDetailCommand = new DelegateCommand(() => CertificatesPage.IsDetailDialogOpen = false);
+        _openRevokeDialogCommand = new DelegateCommand(OpenRevokeDialog, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificatesPage.SelectedItem is { } cert && !string.Equals(cert.RevocationStatus, "Revoked", StringComparison.OrdinalIgnoreCase));
+        _closeRevokeDialogCommand = new DelegateCommand(() => CertificatesPage.IsRevokeDialogOpen = false);
+        _togglePlainViewCommand = new DelegateCommand(() => CertificatesPage.IsPlainView = !CertificatesPage.IsPlainView);
 
         SettingsSecurityPage.CreateDatabaseCommand = _createDatabaseCommand;
         SettingsSecurityPage.OpenDatabaseCommand = _openDatabaseCommand;
@@ -165,6 +175,11 @@ public sealed class ShellViewModel : ViewModelBase
         CertificatesPage.OpenPrivateKeyCommand = _navigatePrivateKeyCommand;
         CertificatesPage.OpenChildCertificateCommand = _navigateChildCertificateCommand;
         CertificatesPage.CreateTemplateFromCertificateCommand = _createTemplateFromCertificateCommand;
+        CertificatesPage.ShowDetailsCommand = _showCertificateDetailsCommand;
+        CertificatesPage.CloseDetailCommand = _closeCertificateDetailCommand;
+        CertificatesPage.OpenRevokeDialogCommand = _openRevokeDialogCommand;
+        CertificatesPage.CloseRevokeDialogCommand = _closeRevokeDialogCommand;
+        CertificatesPage.TogglePlainViewCommand = _togglePlainViewCommand;
 
         PrivateKeysPage.RefreshCommand = _refreshPrivateKeysCommand;
         PrivateKeysPage.GenerateKeyCommand = _generateKeyCommand;
@@ -596,7 +611,7 @@ public sealed class ShellViewModel : ViewModelBase
             return;
         }
 
-        CertificatesPage.RevocationConfirmationText = string.Empty;
+        CertificatesPage.IsRevokeDialogOpen = false;
         await RefreshAllAsync();
         NavigateTo(new NavigationTarget(BrowserEntityType.Certificate, result.Value.CertificateId, NavigationFocusSection.Revocation));
         NotifySuccess("Certificate revoked.");
@@ -1000,7 +1015,9 @@ public sealed class ShellViewModel : ViewModelBase
         }
 
         var result = await _databaseSessionService.ListCertificatesAsync(CertificatesPage.Filter, CancellationToken.None);
-        CertificatesPage.SetItems(result.IsSuccess && result.Value is not null ? result.Value : []);
+        var certItems = result.IsSuccess && result.Value is not null ? result.Value : [];
+        CertificatesPage.SetItems(certItems);
+        CertificatesPage.RebuildTree(certItems);
         await LoadSelectedCertificateInspectorAsync();
         CertificateRequestsPage.SetIssuers(CertificatesPage.Items, PrivateKeysPage.Items);
     }
@@ -1278,6 +1295,27 @@ public sealed class ShellViewModel : ViewModelBase
         NotifySuccess("Issuance template applied.");
     }
 
+    private void ShowCertificateDetails()
+    {
+        if (CertificatesPage.SelectedItem is null || CertificatesPage.Inspector is null)
+        {
+            return;
+        }
+
+        CertificatesPage.IsDetailDialogOpen = true;
+    }
+
+    private void OpenRevokeDialog()
+    {
+        if (CertificatesPage.SelectedItem is null)
+        {
+            return;
+        }
+
+        CertificatesPage.SelectedRevocationDate = DateTimeOffset.UtcNow;
+        CertificatesPage.IsRevokeDialogOpen = true;
+    }
+
     private void CreateTemplateFromCertificate()
     {
         if (CertificatesPage.SelectedItem is null)
@@ -1453,7 +1491,7 @@ public sealed class ShellViewModel : ViewModelBase
     {
         if (e.PropertyName is nameof(CertificatesPageViewModel.SelectedItem)
             or nameof(CertificatesPageViewModel.Filter)
-            or nameof(CertificatesPageViewModel.RevocationConfirmationText)
+            or nameof(CertificatesPageViewModel.IsRevokeDialogOpen)
             or nameof(CertificatesPageViewModel.SelectedChildNavigationItem))
         {
             if (e.PropertyName == nameof(CertificatesPageViewModel.SelectedItem))
@@ -1557,8 +1595,11 @@ public sealed class ShellViewModel : ViewModelBase
         DashboardPage.CertificateRevocationListCount = 0;
         DashboardPage.TemplateCount = 0;
         CertificatesPage.SetItems([]);
+        CertificatesPage.RebuildTree([]);
         CertificatesPage.Inspector = null;
         CertificatesPage.SelectedChildNavigationItem = null;
+        CertificatesPage.IsDetailDialogOpen = false;
+        CertificatesPage.IsRevokeDialogOpen = false;
         PrivateKeysPage.SetItems([]);
         CertificateRequestsPage.SetItems([]);
         CertificateRequestsPage.SetIssuers([], []);
@@ -1600,7 +1641,7 @@ public sealed class ShellViewModel : ViewModelBase
             && Snapshot.State == DatabaseSessionState.Unlocked
             && CertificatesPage.SelectedItem is { } certificate
             && !string.Equals(certificate.RevocationStatus, "Revoked", StringComparison.OrdinalIgnoreCase)
-            && CertificatesPage.IsRevocationConfirmed;
+            && CertificatesPage.IsRevokeDialogOpen;
     }
 
     private bool CanGenerateCertificateRevocationList()
@@ -1675,6 +1716,11 @@ public sealed class ShellViewModel : ViewModelBase
         _applyCertificateSigningRequestTemplateCommand.RaiseCanExecuteChanged();
         _applyIssuanceTemplateCommand.RaiseCanExecuteChanged();
         _closeAuthoringDialogCommand.RaiseCanExecuteChanged();
+        _showCertificateDetailsCommand.RaiseCanExecuteChanged();
+        _closeCertificateDetailCommand.RaiseCanExecuteChanged();
+        _openRevokeDialogCommand.RaiseCanExecuteChanged();
+        _closeRevokeDialogCommand.RaiseCanExecuteChanged();
+        _togglePlainViewCommand.RaiseCanExecuteChanged();
     }
 
     private static IReadOnlyList<SanEntry> ParseSubjectAlternativeNames(string value)

--- a/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
@@ -1,49 +1,111 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:XcaNet.App.ViewModels.Pages"
              x:Class="XcaNet.App.Views.Pages.CertificatesPageView">
   <Grid ColumnDefinitions="*,160" RowDefinitions="*,210" ColumnSpacing="8" RowSpacing="8">
-    <Border Classes="workspace-pane">
+
+    <!-- Main pane: tree view (hierarchy) OR flat list (plain view) -->
+    <Border Grid.Row="0" Classes="workspace-pane">
       <Grid RowDefinitions="Auto,Auto,*">
-        <Grid Margin="8,6,8,0" ColumnDefinitions="*,*,*,*,Auto" ColumnSpacing="8">
+
+        <!-- Filter row -->
+        <Grid Margin="8,6,8,0" ColumnDefinitions="*,*,*,*,Auto,Auto" ColumnSpacing="8">
           <TextBox Watermark="Name" Text="{Binding Filter.DisplayName}" />
           <TextBox Grid.Column="1" Watermark="Subject" Text="{Binding Filter.Subject}" />
           <TextBox Grid.Column="2" Watermark="Issuer" Text="{Binding Filter.Issuer}" />
           <TextBox Grid.Column="3" Watermark="Serial" Text="{Binding Filter.SerialNumber}" />
           <Button Grid.Column="4" Content="Refresh" Command="{Binding RefreshCommand}" />
+          <ToggleButton Grid.Column="5" Content="Plain View"
+                        IsChecked="{Binding IsPlainView}"
+                        Command="{Binding TogglePlainViewCommand}" />
         </Grid>
 
+        <!-- Table column headers -->
         <Border Grid.Row="1" Classes="table-header" Padding="8,6" Margin="0,6,0,0">
-          <Grid ColumnDefinitions="1.2*,1.5*,1.3*,0.9*,0.9*,0.9*,0.6*,0.8*,0.7*" ColumnSpacing="8">
+          <Grid ColumnDefinitions="1.4*,1.0*,0.8*,0.85*,0.85*,0.9*,1.0*" ColumnSpacing="8">
             <TextBlock Text="Certificates" FontWeight="SemiBold" />
-            <TextBlock Grid.Column="1" Text="Subject" Classes="table-header-text" />
-            <TextBlock Grid.Column="2" Text="Issuer" Classes="table-header-text" />
-            <TextBlock Grid.Column="3" Text="Serial" Classes="table-header-text" />
-            <TextBlock Grid.Column="4" Text="Valid From" Classes="table-header-text" />
-            <TextBlock Grid.Column="5" Text="Valid To" Classes="table-header-text" />
-            <TextBlock Grid.Column="6" Text="CA" Classes="table-header-text" />
-            <TextBlock Grid.Column="7" Text="Revoked" Classes="table-header-text" />
-            <TextBlock Grid.Column="8" Text="Key" Classes="table-header-text" />
+            <TextBlock Grid.Column="1" Text="Common Name" Classes="table-header-text" />
+            <TextBlock Grid.Column="2" Text="Status" Classes="table-header-text" />
+            <TextBlock Grid.Column="3" Text="Not Before" Classes="table-header-text" />
+            <TextBlock Grid.Column="4" Text="Not After" Classes="table-header-text" />
+            <TextBlock Grid.Column="5" Text="Serial" Classes="table-header-text" />
+            <TextBlock Grid.Column="6" Text="SHA-1" Classes="table-header-text" />
           </Grid>
         </Border>
 
+        <!-- Content: hierarchy tree OR flat list -->
         <Grid Grid.Row="2">
           <Border Classes="empty-state" Margin="8" Padding="12" IsVisible="{Binding IsEmpty}">
             <TextBlock Text="{Binding EmptyStateMessage}" TextWrapping="Wrap" />
           </Border>
-          <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+
+          <!-- Hierarchy tree view (default) -->
+          <TreeView ItemsSource="{Binding CertificateTreeRoots}"
+                    SelectedItem="{Binding SelectedTreeNode}"
+                    IsVisible="{Binding !IsPlainView}">
+            <TreeView.ContextMenu>
+              <ContextMenu>
+                <MenuItem Header="Show Details" Command="{Binding ShowDetailsCommand}" />
+                <MenuItem Header="Export" Command="{Binding ExportSelectedCommand}" />
+                <Separator />
+                <MenuItem Header="Revoke" Command="{Binding OpenRevokeDialogCommand}" />
+                <MenuItem Header="Generate CRL" Command="{Binding GenerateCertificateRevocationListCommand}" />
+                <Separator />
+                <MenuItem Header="To Template" Command="{Binding CreateTemplateFromCertificateCommand}" />
+                <MenuItem Header="Renew" IsEnabled="False" />
+                <Separator />
+                <MenuItem Header="Open Issuer" Command="{Binding OpenIssuerCommand}" />
+                <MenuItem Header="Delete" IsEnabled="False" />
+              </ContextMenu>
+            </TreeView.ContextMenu>
+            <TreeView.ItemTemplate>
+              <TreeDataTemplate DataType="{x:Type vm:CertificateTreeNodeViewModel}"
+                                ItemsSource="{Binding Children}">
+                <Border Padding="4,5" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                  <Grid ColumnDefinitions="1.4*,1.0*,0.8*,0.85*,0.85*,0.9*,1.0*" ColumnSpacing="8">
+                    <TextBlock Text="{Binding DisplayName}" />
+                    <TextBlock Grid.Column="1" Text="{Binding CommonName}" />
+                    <TextBlock Grid.Column="2" Text="{Binding StatusDisplay}" />
+                    <TextBlock Grid.Column="3" Text="{Binding NotBeforeDisplay}" />
+                    <TextBlock Grid.Column="4" Text="{Binding NotAfterDisplay}" />
+                    <TextBlock Grid.Column="5" Text="{Binding SerialNumber}" />
+                    <TextBlock Grid.Column="6" Text="{Binding Sha1Thumbprint}" TextWrapping="NoWrap" />
+                  </Grid>
+                </Border>
+              </TreeDataTemplate>
+            </TreeView.ItemTemplate>
+          </TreeView>
+
+          <!-- Plain (flat) list view -->
+          <ListBox ItemsSource="{Binding Items}"
+                   SelectedItem="{Binding SelectedItem}"
+                   IsVisible="{Binding IsPlainView}">
+            <ListBox.ContextMenu>
+              <ContextMenu>
+                <MenuItem Header="Show Details" Command="{Binding ShowDetailsCommand}" />
+                <MenuItem Header="Export" Command="{Binding ExportSelectedCommand}" />
+                <Separator />
+                <MenuItem Header="Revoke" Command="{Binding OpenRevokeDialogCommand}" />
+                <MenuItem Header="Generate CRL" Command="{Binding GenerateCertificateRevocationListCommand}" />
+                <Separator />
+                <MenuItem Header="To Template" Command="{Binding CreateTemplateFromCertificateCommand}" />
+                <MenuItem Header="Renew" IsEnabled="False" />
+                <Separator />
+                <MenuItem Header="Open Issuer" Command="{Binding OpenIssuerCommand}" />
+                <MenuItem Header="Delete" IsEnabled="False" />
+              </ContextMenu>
+            </ListBox.ContextMenu>
             <ListBox.ItemTemplate>
               <DataTemplate>
                 <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
-                  <Grid ColumnDefinitions="1.2*,1.5*,1.3*,0.9*,0.9*,0.9*,0.6*,0.8*,0.7*" ColumnSpacing="8">
+                  <Grid ColumnDefinitions="1.4*,1.0*,0.8*,0.85*,0.85*,0.9*,1.0*" ColumnSpacing="8">
                     <TextBlock Text="{Binding DisplayName}" />
-                    <TextBlock Grid.Column="1" Text="{Binding Subject}" TextWrapping="Wrap" />
-                    <TextBlock Grid.Column="2" Text="{Binding Issuer}" TextWrapping="Wrap" />
-                    <TextBlock Grid.Column="3" Text="{Binding SerialNumber}" />
-                    <TextBlock Grid.Column="4" Text="{Binding NotBefore, StringFormat='{}{0:yyyy-MM-dd}'}" />
-                    <TextBlock Grid.Column="5" Text="{Binding NotAfter, StringFormat='{}{0:yyyy-MM-dd}'}" />
-                    <TextBlock Grid.Column="6" Text="{Binding CertificateKind}" />
-                    <TextBlock Grid.Column="7" Text="{Binding RevocationStatus}" />
-                    <TextBlock Grid.Column="8" Text="{Binding PrivateKeyStatus}" />
+                    <TextBlock Grid.Column="1" Text="{Binding CommonName}" />
+                    <TextBlock Grid.Column="2" Text="{Binding StatusDisplay}" />
+                    <TextBlock Grid.Column="3" Text="{Binding NotBefore, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                    <TextBlock Grid.Column="4" Text="{Binding NotAfter, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                    <TextBlock Grid.Column="5" Text="{Binding SerialNumber}" />
+                    <TextBlock Grid.Column="6" Text="{Binding Sha1Thumbprint}" TextWrapping="NoWrap" />
                   </Grid>
                 </Border>
               </DataTemplate>
@@ -53,21 +115,24 @@
       </Grid>
     </Border>
 
+    <!-- Right-side action buttons -->
     <Border Grid.Column="1" Classes="classic-side-panel" Padding="8">
       <StackPanel>
         <Button Classes="side-action" Content="New Certificate" IsEnabled="False" />
         <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedCommand}" />
         <Button Classes="side-action" Content="Import" Command="{Binding ImportFilesCommand}" />
-        <Button Classes="side-action" Content="Show Details" IsEnabled="False" />
+        <Button Classes="side-action" Content="Show Details" Command="{Binding ShowDetailsCommand}" />
         <Button Classes="side-action" Content="Delete" IsEnabled="False" />
-        <Button Classes="side-action" Content="Revoke" Command="{Binding RevokeSelectedCommand}" />
+        <Button Classes="side-action" Content="Revoke" Command="{Binding OpenRevokeDialogCommand}" />
         <Button Classes="side-action" Content="Generate CRL" Command="{Binding GenerateCertificateRevocationListCommand}" />
+        <Button Classes="side-action" Content="Renew" IsEnabled="False" />
         <Button Classes="side-action" Content="To Template" Command="{Binding CreateTemplateFromCertificateCommand}" />
-        <Button Classes="side-action" Content="Plain View" IsEnabled="False" />
         <Button Classes="side-action" Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
+        <Button Classes="side-action" Content="Refresh" Command="{Binding RefreshCommand}" />
       </StackPanel>
     </Border>
 
+    <!-- Inspector panel (bottom) -->
     <Border Grid.Row="1" Grid.ColumnSpan="2" Classes="workspace-pane" Padding="8">
       <TabControl Classes="workspace-inspector-tabs">
         <TabItem Header="General">
@@ -85,7 +150,7 @@
           </Grid>
         </TabItem>
         <TabItem Header="Details">
-          <Grid Margin="6" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="6">
+          <Grid Margin="6" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="6">
             <TextBlock Text="Serial" />
             <TextBlock Grid.Column="1" Text="{Binding Inspector.Raw.SerialNumber}" />
             <TextBlock Grid.Row="1" Text="SHA-1" />
@@ -94,6 +159,8 @@
             <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.Raw.Sha256Thumbprint}" TextWrapping="Wrap" />
             <TextBlock Grid.Row="3" Text="Key algorithm" />
             <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Inspector.Raw.KeyAlgorithm}" />
+            <TextBlock Grid.Row="4" Text="Type" />
+            <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Inspector.Display.CertificateKind}" />
           </Grid>
         </TabItem>
         <TabItem Header="Extensions">
@@ -112,13 +179,13 @@
         </TabItem>
         <TabItem Header="Relationships">
           <Grid Margin="6" ColumnDefinitions="140,*,220" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="6">
-            <TextBlock Text="Type" />
-            <TextBlock Grid.Column="1" Text="{Binding Inspector.Display.CertificateKind}" />
-            <TextBlock Grid.Row="1" Text="Issuer" />
-            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.Display.IssuerDisplayName}" TextWrapping="Wrap" />
-            <TextBlock Grid.Row="2" Text="Children" />
-            <ComboBox Grid.Row="2" Grid.Column="1" ItemsSource="{Binding Inspector.Navigation.Children}" SelectedItem="{Binding SelectedChildNavigationItem}" />
-            <Button Grid.Row="2" Grid.Column="2" Content="Open Child" HorizontalAlignment="Left" Command="{Binding OpenChildCertificateCommand}" />
+            <TextBlock Text="Issuer" />
+            <TextBlock Grid.Column="1" Text="{Binding Inspector.Display.IssuerDisplayName}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="1" Text="Children" />
+            <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding Inspector.Navigation.Children}" SelectedItem="{Binding SelectedChildNavigationItem}" />
+            <Button Grid.Row="1" Grid.Column="2" Content="Open Child" HorizontalAlignment="Left" Command="{Binding OpenChildCertificateCommand}" />
+            <TextBlock Grid.Row="2" Text="Private key" />
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.Display.PrivateKeyDisplayName}" />
           </Grid>
         </TabItem>
         <TabItem Header="Raw / PEM">
@@ -126,10 +193,130 @@
             <ComboBox ItemsSource="{Binding ExportTargets}" SelectedItem="{Binding SelectedExportTarget}" />
             <ComboBox Grid.Column="1" ItemsSource="{Binding ExportFormats}" SelectedItem="{Binding SelectedExportFormat}" />
             <TextBox Grid.Row="1" Grid.ColumnSpan="2" Text="{Binding SelectedExportPassword}" PasswordChar="*" Watermark="Optional password for PEM bundle or PKCS#12" />
-            <TextBox Grid.Row="2" Grid.ColumnSpan="2" Text="{Binding ImportPayload}" AcceptsReturn="True" TextWrapping="Wrap" />
+            <TextBox Grid.Row="2" Grid.ColumnSpan="2" Classes="readonly-surface" Text="{Binding ExportPreview}" AcceptsReturn="True" TextWrapping="Wrap" />
           </Grid>
         </TabItem>
       </TabControl>
     </Border>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- Certificate Detail dialog overlay                                  -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsDetailDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="700"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,*,Auto" RowSpacing="12">
+
+          <!-- Dialog header -->
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="{Binding SelectedItem.DisplayName}" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Close" Command="{Binding CloseDetailCommand}" />
+          </Grid>
+
+          <!-- Detail tabs -->
+          <TabControl Grid.Row="1">
+            <TabItem Header="Status">
+              <Grid Margin="6" ColumnDefinitions="160,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+                <TextBlock Text="Type" />
+                <TextBlock Grid.Column="1" Text="{Binding Inspector.Display.CertificateKind}" />
+                <TextBlock Grid.Row="1" Text="Status" />
+                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.StatusDisplay}" />
+                <TextBlock Grid.Row="2" Text="Serial" />
+                <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.Raw.SerialNumber}" />
+                <TextBlock Grid.Row="3" Text="Validity" />
+                <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Inspector.Display.ValidityRange}" />
+                <TextBlock Grid.Row="4" Text="SHA-1" />
+                <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Inspector.Raw.Sha1Thumbprint}" TextWrapping="Wrap" />
+                <TextBlock Grid.Row="5" Text="SHA-256" />
+                <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding Inspector.Raw.Sha256Thumbprint}" TextWrapping="Wrap" />
+              </Grid>
+            </TabItem>
+            <TabItem Header="Subject">
+              <Grid Margin="6" ColumnDefinitions="160,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+                <TextBlock Text="Subject DN" />
+                <TextBlock Grid.Column="1" Text="{Binding Inspector.Raw.Subject}" TextWrapping="Wrap" />
+                <TextBlock Grid.Row="1" Text="Common Name" />
+                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.CommonName}" />
+              </Grid>
+            </TabItem>
+            <TabItem Header="Issuer">
+              <Grid Margin="6" ColumnDefinitions="160,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+                <TextBlock Text="Issuer DN" />
+                <TextBlock Grid.Column="1" Text="{Binding Inspector.Raw.Issuer}" TextWrapping="Wrap" />
+                <TextBlock Grid.Row="1" Text="Issuer name" />
+                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.Display.IssuerDisplayName}" TextWrapping="Wrap" />
+              </Grid>
+            </TabItem>
+            <TabItem Header="Extensions">
+              <Grid Margin="6" ColumnDefinitions="1*,1*" RowDefinitions="Auto,*" RowSpacing="8">
+                <TextBlock Text="Key algorithm" />
+                <TextBlock Grid.Column="1" Text="{Binding Inspector.Raw.KeyAlgorithm}" />
+                <StackPanel Grid.Row="1">
+                  <TextBlock Text="Subject Alternative Names" FontWeight="SemiBold" />
+                  <ItemsControl ItemsSource="{Binding Inspector.Extensions.SubjectAlternativeNames}" />
+                  <TextBlock Text="Key Usage" FontWeight="SemiBold" Margin="0,8,0,0" />
+                  <ItemsControl ItemsSource="{Binding Inspector.Extensions.KeyUsages}" />
+                </StackPanel>
+                <StackPanel Grid.Row="1" Grid.Column="1">
+                  <TextBlock Text="Enhanced Key Usage" FontWeight="SemiBold" />
+                  <ItemsControl ItemsSource="{Binding Inspector.Extensions.EnhancedKeyUsages}" />
+                </StackPanel>
+              </Grid>
+            </TabItem>
+          </TabControl>
+
+          <!-- OK button -->
+          <Button Grid.Row="2" Content="OK" Command="{Binding CloseDetailCommand}" HorizontalAlignment="Right" MinWidth="80" />
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- Revoke dialog overlay                                              -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsRevokeDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="480"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="12">
+
+          <!-- Dialog header -->
+          <TextBlock Text="Certificate revocation" FontSize="16" FontWeight="SemiBold" />
+
+          <!-- Fields -->
+          <Grid Grid.Row="1" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="10">
+            <TextBlock Text="Certificate" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="1" Text="Serial number" VerticalAlignment="Center" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.SerialNumber}" />
+            <TextBlock Grid.Row="2" Text="Revocation reason" VerticalAlignment="Center" />
+            <ComboBox Grid.Row="2" Grid.Column="1"
+                      ItemsSource="{Binding RevocationReasons}"
+                      SelectedItem="{Binding SelectedRevocationReason}"
+                      HorizontalAlignment="Stretch" />
+          </Grid>
+
+          <!-- Revocation date note -->
+          <TextBlock Grid.Row="2" Text="Revocation date will be recorded as the current UTC time." Classes="secondary-text" TextWrapping="Wrap" />
+
+          <!-- Action buttons -->
+          <Grid Grid.Row="3" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+            <TextBlock Text="This action cannot be undone." Classes="secondary-text" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Revoke" Command="{Binding RevokeSelectedCommand}" />
+            <Button Grid.Column="2" Content="Cancel" Command="{Binding CloseRevokeDialogCommand}" />
+          </Grid>
+        </Grid>
+      </Border>
+    </Grid>
+
   </Grid>
 </UserControl>

--- a/src/XcaNet.Contracts/Browser/CertificateListItem.cs
+++ b/src/XcaNet.Contracts/Browser/CertificateListItem.cs
@@ -22,4 +22,31 @@ public sealed record CertificateListItem(
     public string CertificateKind => IsCertificateAuthority ? "CA" : "Leaf";
 
     public string PrivateKeyStatus => PrivateKeyId is null ? "No" : "Yes";
+
+    public string CommonName => ExtractCommonName(Subject);
+
+    public string StatusDisplay
+    {
+        get
+        {
+            if (string.Equals(RevocationStatus, "Revoked", StringComparison.OrdinalIgnoreCase))
+                return "Revoked";
+            var now = DateTimeOffset.UtcNow;
+            if (NotBefore is { } nb && nb > now)
+                return "Not yet valid";
+            if (NotAfter is { } na && na < now)
+                return "Expired";
+            return "Valid";
+        }
+    }
+
+    private static string ExtractCommonName(string subject)
+    {
+        foreach (var part in subject.Split(',', StringSplitOptions.TrimEntries))
+        {
+            if (part.StartsWith("CN=", StringComparison.OrdinalIgnoreCase))
+                return part[3..];
+        }
+        return subject;
+    }
 }

--- a/tests/XcaNet.Integration.Tests/CertificatesTabTests.cs
+++ b/tests/XcaNet.Integration.Tests/CertificatesTabTests.cs
@@ -1,0 +1,338 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using XcaNet.App.Commands;
+using XcaNet.App.Services;
+using XcaNet.App.ViewModels;
+using XcaNet.App.ViewModels.Pages;
+using XcaNet.Application.DependencyInjection;
+using XcaNet.Application.Services;
+using XcaNet.Contracts.Browser;
+using XcaNet.Contracts.Crypto;
+using XcaNet.Contracts.Crypto.Workflow;
+using XcaNet.Contracts.Database;
+using XcaNet.Crypto.DotNet.DependencyInjection;
+
+namespace XcaNet.Integration.Tests;
+
+public sealed class CertificatesTabTests
+{
+    // ---------------------------------------------------------------------------
+    // CertificateListItem computed properties
+    // ---------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("CN=Root CA, O=Test", "Root CA")]
+    [InlineData("O=Test, CN=leaf.example.test", "leaf.example.test")]
+    [InlineData("O=NoCn", "O=NoCn")]
+    [InlineData("cn=case.insensitive", "case.insensitive")]
+    public void CertificateListItem_CommonName_ShouldExtractCnPart(string subject, string expected)
+    {
+        var item = MakeCertItem(subject: subject);
+        Assert.Equal(expected, item.CommonName);
+    }
+
+    [Fact]
+    public void CertificateListItem_StatusDisplay_ShouldReturnRevoked_WhenRevocationStatusIsRevoked()
+    {
+        var item = MakeCertItem(revocationStatus: "Revoked");
+        Assert.Equal("Revoked", item.StatusDisplay);
+    }
+
+    [Fact]
+    public void CertificateListItem_StatusDisplay_ShouldReturnExpired_WhenNotAfterInPast()
+    {
+        var item = MakeCertItem(notBefore: DateTimeOffset.UtcNow.AddDays(-365), notAfter: DateTimeOffset.UtcNow.AddDays(-1));
+        Assert.Equal("Expired", item.StatusDisplay);
+    }
+
+    [Fact]
+    public void CertificateListItem_StatusDisplay_ShouldReturnNotYetValid_WhenNotBeforeInFuture()
+    {
+        var item = MakeCertItem(notBefore: DateTimeOffset.UtcNow.AddDays(1), notAfter: DateTimeOffset.UtcNow.AddDays(365));
+        Assert.Equal("Not yet valid", item.StatusDisplay);
+    }
+
+    [Fact]
+    public void CertificateListItem_StatusDisplay_ShouldReturnValid_WhenWithinValidity()
+    {
+        var item = MakeCertItem(notBefore: DateTimeOffset.UtcNow.AddDays(-1), notAfter: DateTimeOffset.UtcNow.AddDays(365));
+        Assert.Equal("Valid", item.StatusDisplay);
+    }
+
+    // ---------------------------------------------------------------------------
+    // CertificatesPageViewModel.RebuildTree
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void RebuildTree_ShouldPlaceSelfSignedCertificatesAtRoot()
+    {
+        var vm = new CertificatesPageViewModel();
+        var rootId = Guid.NewGuid();
+        var root = MakeCertItem(id: rootId, issuerCertificateId: rootId, isCa: true); // self-signed
+
+        vm.RebuildTree([root]);
+
+        Assert.Single(vm.CertificateTreeRoots);
+        Assert.Equal(rootId, vm.CertificateTreeRoots[0].CertificateId);
+        Assert.Empty(vm.CertificateTreeRoots[0].Children);
+    }
+
+    [Fact]
+    public void RebuildTree_ShouldNestLeafUnderIssuer()
+    {
+        var vm = new CertificatesPageViewModel();
+        var rootId = Guid.NewGuid();
+        var leafId = Guid.NewGuid();
+        var root = MakeCertItem(id: rootId, issuerCertificateId: rootId, isCa: true);
+        var leaf = MakeCertItem(id: leafId, issuerCertificateId: rootId);
+
+        vm.RebuildTree([root, leaf]);
+
+        Assert.Single(vm.CertificateTreeRoots);
+        var rootNode = vm.CertificateTreeRoots[0];
+        Assert.Single(rootNode.Children);
+        Assert.Equal(leafId, rootNode.Children[0].CertificateId);
+    }
+
+    [Fact]
+    public void RebuildTree_ShouldPlaceOrphanCertificatesAtRoot_WhenIssuerNotInSet()
+    {
+        var vm = new CertificatesPageViewModel();
+        var unknownIssuerId = Guid.NewGuid();
+        var leafId = Guid.NewGuid();
+        var leaf = MakeCertItem(id: leafId, issuerCertificateId: unknownIssuerId);
+
+        vm.RebuildTree([leaf]);
+
+        Assert.Single(vm.CertificateTreeRoots);
+        Assert.Equal(leafId, vm.CertificateTreeRoots[0].CertificateId);
+    }
+
+    [Fact]
+    public void RebuildTree_ShouldHandleNullIssuerCertificateId_AsRoot()
+    {
+        var vm = new CertificatesPageViewModel();
+        var id = Guid.NewGuid();
+        var cert = MakeCertItem(id: id, issuerCertificateId: null);
+
+        vm.RebuildTree([cert]);
+
+        Assert.Single(vm.CertificateTreeRoots);
+        Assert.Equal(id, vm.CertificateTreeRoots[0].CertificateId);
+    }
+
+    [Fact]
+    public void RebuildTree_ShouldClearExistingTreeBeforeRebuilding()
+    {
+        var vm = new CertificatesPageViewModel();
+        var id1 = Guid.NewGuid();
+        vm.RebuildTree([MakeCertItem(id: id1)]);
+        Assert.Single(vm.CertificateTreeRoots);
+
+        vm.RebuildTree([]);
+        Assert.Empty(vm.CertificateTreeRoots);
+    }
+
+    [Fact]
+    public void RebuildTree_ShouldSupportMultiLevelHierarchy()
+    {
+        var vm = new CertificatesPageViewModel();
+        var rootId = Guid.NewGuid();
+        var intId = Guid.NewGuid();
+        var leafId = Guid.NewGuid();
+
+        var root = MakeCertItem(id: rootId, issuerCertificateId: rootId, isCa: true);
+        var intermediate = MakeCertItem(id: intId, issuerCertificateId: rootId, isCa: true);
+        var leaf = MakeCertItem(id: leafId, issuerCertificateId: intId);
+
+        vm.RebuildTree([root, intermediate, leaf]);
+
+        Assert.Single(vm.CertificateTreeRoots);
+        var rootNode = vm.CertificateTreeRoots[0];
+        Assert.Single(rootNode.Children);
+        var intNode = rootNode.Children[0];
+        Assert.Equal(intId, intNode.CertificateId);
+        Assert.Single(intNode.Children);
+        Assert.Equal(leafId, intNode.Children[0].CertificateId);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Dialog state commands
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void IsPlainView_ShouldDefaultToFalse()
+    {
+        var vm = new CertificatesPageViewModel();
+        Assert.False(vm.IsPlainView);
+    }
+
+    [Fact]
+    public void IsDetailDialogOpen_ShouldDefaultToFalse()
+    {
+        var vm = new CertificatesPageViewModel();
+        Assert.False(vm.IsDetailDialogOpen);
+    }
+
+    [Fact]
+    public void IsRevokeDialogOpen_ShouldDefaultToFalse()
+    {
+        var vm = new CertificatesPageViewModel();
+        Assert.False(vm.IsRevokeDialogOpen);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Shell command wiring — revoke dialog flow
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RevokeDialogFlow_ShouldOpenAndGateRevokeCommand()
+    {
+        using var provider = BuildServiceProvider();
+        var service = provider.GetRequiredService<IDatabaseSessionService>();
+        var databasePath = GetDatabasePath();
+
+        await service.CreateDatabaseAsync(new CreateDatabaseRequest(databasePath, "correct horse battery staple", "M13.6 Test"), CancellationToken.None);
+        await service.OpenDatabaseAsync(new OpenDatabaseRequest(databasePath), CancellationToken.None);
+        await service.UnlockDatabaseAsync(new UnlockDatabaseRequest("correct horse battery staple"), CancellationToken.None);
+
+        var issuerKey = await service.GenerateStoredKeyAsync(new GenerateStoredKeyRequest("CA Key", KeyAlgorithmKind.Rsa, 3072, null), CancellationToken.None);
+        var issuerCert = await service.CreateSelfSignedCaAsync(new CreateSelfSignedCaWorkflowRequest(issuerKey.Value!.PrivateKeyId, "CA", "CN=CA", 365), CancellationToken.None);
+        var leafKey = await service.GenerateStoredKeyAsync(new GenerateStoredKeyRequest("Leaf Key", KeyAlgorithmKind.Ecdsa, null, EllipticCurveKind.P256), CancellationToken.None);
+        var csr = await service.CreateCertificateSigningRequestAsync(
+            new CreateCertificateSigningRequestWorkflowRequest(leafKey.Value!.PrivateKeyId, "Leaf CSR", "CN=leaf", []),
+            CancellationToken.None);
+        var leafCert = await service.SignCertificateSigningRequestAsync(
+            new SignStoredCertificateSigningRequestRequest(csr.Value!.CertificateSigningRequestId, issuerCert.Value!.CertificateId, issuerKey.Value.PrivateKeyId, "Leaf", 90),
+            CancellationToken.None);
+
+        var shell = new ShellViewModel(service, new TestFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        await ((AsyncCommand)shell.CertificatesPage.RefreshCommand!).ExecuteAsync();
+        shell.CertificatesPage.SelectedItem = shell.CertificatesPage.Items.Single(x => x.CertificateId == leafCert.Value!.CertificateId);
+        await Task.Delay(50);
+
+        // Revoke command disabled before dialog open
+        Assert.False(shell.CertificatesPage.RevokeSelectedCommand!.CanExecute(null));
+
+        // Open revoke dialog
+        shell.CertificatesPage.OpenRevokeDialogCommand!.Execute(null);
+        Assert.True(shell.CertificatesPage.IsRevokeDialogOpen);
+        Assert.True(shell.CertificatesPage.RevokeSelectedCommand.CanExecute(null));
+
+        // Close dialog via cancel
+        shell.CertificatesPage.CloseRevokeDialogCommand!.Execute(null);
+        Assert.False(shell.CertificatesPage.IsRevokeDialogOpen);
+        Assert.False(shell.CertificatesPage.RevokeSelectedCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task TogglePlainViewCommand_ShouldToggleIsPlainView()
+    {
+        using var provider = BuildServiceProvider();
+        var service = provider.GetRequiredService<IDatabaseSessionService>();
+        var shell = new ShellViewModel(service, new TestFileDialogService(), NullLogger<ShellViewModel>.Instance);
+
+        Assert.False(shell.CertificatesPage.IsPlainView);
+        shell.CertificatesPage.TogglePlainViewCommand!.Execute(null);
+        Assert.True(shell.CertificatesPage.IsPlainView);
+        shell.CertificatesPage.TogglePlainViewCommand.Execute(null);
+        Assert.False(shell.CertificatesPage.IsPlainView);
+    }
+
+    [Fact]
+    public async Task TreeRebuild_ShouldReflectIssuerHierarchyAfterRefresh()
+    {
+        using var provider = BuildServiceProvider();
+        var service = provider.GetRequiredService<IDatabaseSessionService>();
+        var databasePath = GetDatabasePath();
+
+        await service.CreateDatabaseAsync(new CreateDatabaseRequest(databasePath, "correct horse battery staple", "Tree Test"), CancellationToken.None);
+        await service.OpenDatabaseAsync(new OpenDatabaseRequest(databasePath), CancellationToken.None);
+        await service.UnlockDatabaseAsync(new UnlockDatabaseRequest("correct horse battery staple"), CancellationToken.None);
+
+        var caKey = await service.GenerateStoredKeyAsync(new GenerateStoredKeyRequest("CA Key", KeyAlgorithmKind.Rsa, 3072, null), CancellationToken.None);
+        var caCert = await service.CreateSelfSignedCaAsync(new CreateSelfSignedCaWorkflowRequest(caKey.Value!.PrivateKeyId, "Root CA", "CN=Root CA", 365), CancellationToken.None);
+        var leafKey = await service.GenerateStoredKeyAsync(new GenerateStoredKeyRequest("Leaf Key", KeyAlgorithmKind.Ecdsa, null, EllipticCurveKind.P256), CancellationToken.None);
+        var csr = await service.CreateCertificateSigningRequestAsync(
+            new CreateCertificateSigningRequestWorkflowRequest(leafKey.Value!.PrivateKeyId, "Leaf CSR", "CN=leaf", []),
+            CancellationToken.None);
+        await service.SignCertificateSigningRequestAsync(
+            new SignStoredCertificateSigningRequestRequest(csr.Value!.CertificateSigningRequestId, caCert.Value!.CertificateId, caKey.Value.PrivateKeyId, "Leaf", 90),
+            CancellationToken.None);
+
+        var shell = new ShellViewModel(service, new TestFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        await ((AsyncCommand)shell.CertificatesPage.RefreshCommand!).ExecuteAsync();
+
+        // In tree view: exactly 1 root (the CA) with 1 child (leaf)
+        Assert.Single(shell.CertificatesPage.CertificateTreeRoots);
+        var caNode = shell.CertificatesPage.CertificateTreeRoots[0];
+        Assert.True(caNode.IsCertificateAuthority);
+        Assert.Single(caNode.Children);
+        Assert.False(caNode.Children[0].IsCertificateAuthority);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static CertificateListItem MakeCertItem(
+        Guid? id = null,
+        string displayName = "Test",
+        string subject = "CN=Test",
+        string issuer = "CN=Test",
+        string serialNumber = "00",
+        string sha1 = "AA",
+        string sha256 = "BB",
+        DateTimeOffset? notBefore = null,
+        DateTimeOffset? notAfter = null,
+        string keyAlgorithm = "RSA",
+        bool isCa = false,
+        string revocationStatus = "Good",
+        string? revocationReason = null,
+        DateTimeOffset? revokedAt = null,
+        Guid? issuerCertificateId = null,
+        Guid? privateKeyId = null,
+        int childCount = 0)
+    {
+        return new CertificateListItem(
+            id ?? Guid.NewGuid(),
+            displayName,
+            subject,
+            issuer,
+            serialNumber,
+            sha1,
+            sha256,
+            notBefore ?? DateTimeOffset.UtcNow.AddDays(-1),
+            notAfter ?? DateTimeOffset.UtcNow.AddDays(365),
+            keyAlgorithm,
+            isCa,
+            revocationStatus,
+            revocationReason,
+            revokedAt,
+            issuerCertificateId,
+            privateKeyId,
+            childCount);
+    }
+
+    private static ServiceProvider BuildServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddManagedCryptoServices();
+        services.AddApplication(new ConfigurationBuilder().Build());
+        return services.BuildServiceProvider();
+    }
+
+    private static string GetDatabasePath()
+        => Path.Combine(Path.GetTempPath(), $"xcanet-certs-m13-6-{Guid.NewGuid():N}.db");
+}
+
+file sealed class TestFileDialogService : IDesktopFileDialogService
+{
+    public void SetOwner(Avalonia.Controls.Window? window) { }
+    public Task<IReadOnlyList<string>> PickImportFilesAsync(CancellationToken cancellationToken)
+        => Task.FromResult<IReadOnlyList<string>>([]);
+    public Task<string?> PickSavePathAsync(string suggestedFileName, CancellationToken cancellationToken)
+        => Task.FromResult<string?>(null);
+}

--- a/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
+++ b/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
@@ -46,7 +46,9 @@ public sealed class ShellWorkflowTests
         Assert.False(shell.CertificatesPage.GenerateCertificateRevocationListCommand!.CanExecute(null));
         Assert.False(shell.CertificatesPage.RevokeSelectedCommand!.CanExecute(null));
 
-        shell.CertificatesPage.RevocationConfirmationText = "REVOKE";
+        // Open the revoke dialog — this is now the confirmation gate.
+        shell.CertificatesPage.OpenRevokeDialogCommand!.Execute(null);
+        Assert.True(shell.CertificatesPage.IsRevokeDialogOpen);
         Assert.True(shell.CertificatesPage.RevokeSelectedCommand.CanExecute(null));
 
         await shell.CertificatesPage.RevokeSelectedCommand.As<AsyncCommand>().ExecuteAsync();


### PR DESCRIPTION
## Summary

- Hierarchical **tree view** groups issued certificates under their issuing CA; orphans (issuer not in set) promoted to root
- **Plain View toggle** switches to a flat `ListBox` (same layout, no nesting)
- **7-column table**: Name, Common Name, Status, Not Before, Not After, Serial, SHA-1 Fingerprint
- `CommonName` and `StatusDisplay` computed properties added to `CertificateListItem` (Valid / Expired / Not yet valid / Revoked)
- `CertificateTreeNodeViewModel` wraps `CertificateListItem` and exposes `Children` for `TreeView` binding
- **Certificate Details overlay dialog**: 4 tabs (Status, Subject, Issuer, Extensions)
- **Revoke dialog**: replaces the old "type REVOKE" inline text guard — `IsRevokeDialogOpen` gates `RevokeSelectedCommand`; Cancel closes without revoking
- Right-side action buttons aligned to XCA: Export, Import, Show Details, Revoke, Generate CRL, To Template, Open Issuer, Refresh; New/Delete/Renew are disabled placeholders
- Context menus on both tree and flat list with the same actions
- 20 new tests in `CertificatesTabTests.cs` covering: `CommonName`/`StatusDisplay` logic, tree construction (self-signed root, nested children, orphan promotion, multi-level hierarchy, clear/rebuild), dialog default state, revoke dialog gate flow, plain view toggle, tree rebuild after refresh

## Test plan

- [ ] All 90 tests pass (`dotnet test XcaNet.sln`)
- [ ] Debug and Release builds clean (`dotnet build XcaNet.sln` + `-c Release`)
- [ ] Tree shows CA as root with issued certs nested beneath
- [ ] Plain View toggle flattens to list and back
- [ ] Revoke button disabled until dialog opened; dialog Cancel leaves cert unrevoked
- [ ] Show Details opens overlay; OK closes it
- [ ] Generate CRL enabled only when a CA is selected
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)