### PR TITLE
feat: M13.5 - Private Keys and CSR Tab Parity

### DIFF
--- a/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
@@ -9,6 +9,7 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
     private CryptoFormatView _selectedExportFormat = CryptoFormatView.Pem;
     private string _exportPreview = string.Empty;
     private bool _isDetailDialogOpen;
+    private bool _isDeleteConfirmDialogOpen;
 
     public CertificateRequestsPageViewModel()
         : base("Certificate signing requests")
@@ -18,6 +19,8 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
 
         ShowDetailsCommand = new DelegateCommand(() => { if (SelectedItem is not null) IsDetailDialogOpen = true; });
         CloseDetailCommand = new DelegateCommand(() => IsDetailDialogOpen = false);
+        OpenDeleteConfirmCommand = new DelegateCommand(() => { if (SelectedItem is not null) IsDeleteConfirmDialogOpen = true; });
+        CloseDeleteConfirmCommand = new DelegateCommand(() => IsDeleteConfirmDialogOpen = false);
     }
 
     public CertificateAuthoringViewModel IssuanceAuthoring { get; } = new(
@@ -46,6 +49,16 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
     public DelegateCommand ShowDetailsCommand { get; }
 
     public DelegateCommand CloseDetailCommand { get; }
+
+    public DelegateCommand OpenDeleteConfirmCommand { get; }
+
+    public DelegateCommand CloseDeleteConfirmCommand { get; }
+
+    public bool IsDeleteConfirmDialogOpen
+    {
+        get => _isDeleteConfirmDialogOpen;
+        set => SetProperty(ref _isDeleteConfirmDialogOpen, value);
+    }
 
     public bool IsDetailDialogOpen
     {

--- a/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
@@ -16,6 +16,7 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
     private string _exportPreview = string.Empty;
     private bool _isNewKeyDialogOpen;
     private bool _isKeyDetailDialogOpen;
+    private bool _isDeleteConfirmDialogOpen;
 
     public PrivateKeysPageViewModel()
         : base("Private Keys")
@@ -27,6 +28,8 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
         CloseNewKeyDialogCommand = new DelegateCommand(() => IsNewKeyDialogOpen = false);
         ShowDetailsCommand = new DelegateCommand(() => { if (SelectedItem is not null) IsKeyDetailDialogOpen = true; });
         CloseKeyDetailCommand = new DelegateCommand(() => IsKeyDetailDialogOpen = false);
+        OpenDeleteConfirmCommand = new DelegateCommand(() => { if (SelectedItem is not null) IsDeleteConfirmDialogOpen = true; });
+        CloseDeleteConfirmCommand = new DelegateCommand(() => IsDeleteConfirmDialogOpen = false);
     }
 
     public IReadOnlyList<KeyAlgorithmView> Algorithms { get; } = [KeyAlgorithmView.Rsa, KeyAlgorithmView.Ecdsa];
@@ -44,6 +47,16 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
     public DelegateCommand ShowDetailsCommand { get; }
 
     public DelegateCommand CloseKeyDetailCommand { get; }
+
+    public DelegateCommand OpenDeleteConfirmCommand { get; }
+
+    public DelegateCommand CloseDeleteConfirmCommand { get; }
+
+    public bool IsDeleteConfirmDialogOpen
+    {
+        get => _isDeleteConfirmDialogOpen;
+        set => SetProperty(ref _isDeleteConfirmDialogOpen, value);
+    }
 
     public CertificateAuthoringViewModel SelfSignedCaAuthoring { get; } = new(
         "Certificate Input",

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -65,6 +65,8 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly AsyncCommand _cloneTemplateCommand;
     private readonly AsyncCommand _toggleTemplateFavoriteCommand;
     private readonly AsyncCommand _toggleTemplateEnabledCommand;
+    private readonly AsyncCommand _deletePrivateKeyCommand;
+    private readonly AsyncCommand _deleteCsrCommand;
     private readonly AsyncCommand _deleteTemplateCommand;
     private readonly AsyncCommand _applySelfSignedCaTemplateCommand;
     private readonly AsyncCommand _applyCertificateSigningRequestTemplateCommand;
@@ -146,6 +148,8 @@ public sealed class ShellViewModel : ViewModelBase
         _cloneTemplateCommand = new AsyncCommand(CloneTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
         _toggleTemplateFavoriteCommand = new AsyncCommand(ToggleTemplateFavoriteAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
         _toggleTemplateEnabledCommand = new AsyncCommand(ToggleTemplateEnabledAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
+        _deletePrivateKeyCommand = new AsyncCommand(DeletePrivateKeyAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
+        _deleteCsrCommand = new AsyncCommand(DeleteCsrAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificateRequestsPage.HasSelection);
         _deleteTemplateCommand = new AsyncCommand(DeleteTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
         _applySelfSignedCaTemplateCommand = new AsyncCommand(ApplySelfSignedCaTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && PrivateKeysPage.SelfSignedCaAuthoring.SelectedTemplate is not null);
         _applyCertificateSigningRequestTemplateCommand = new AsyncCommand(ApplyCertificateSigningRequestTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && PrivateKeysPage.CertificateSigningRequestAuthoring.SelectedTemplate is not null);
@@ -191,6 +195,8 @@ public sealed class ShellViewModel : ViewModelBase
         PrivateKeysPage.ApplyCertificateSigningRequestTemplateCommand = _applyCertificateSigningRequestTemplateCommand;
         PrivateKeysPage.ExportSelectedCommand = _exportPrivateKeyCommand;
         PrivateKeysPage.ExportSelectedToFileCommand = _exportPrivateKeyToFileCommand;
+        PrivateKeysPage.ImportCommand = _importFilesCommand;
+        PrivateKeysPage.DeleteSelectedCommand = _deletePrivateKeyCommand;
         PrivateKeysPage.SelfSignedCaAuthoring.ApplyTemplateCommand = _applySelfSignedCaTemplateCommand;
         PrivateKeysPage.SelfSignedCaAuthoring.PrimaryActionCommand = _createSelfSignedCaCommand;
         PrivateKeysPage.CertificateSigningRequestAuthoring.ApplyTemplateCommand = _applyCertificateSigningRequestTemplateCommand;
@@ -205,6 +211,9 @@ public sealed class ShellViewModel : ViewModelBase
         CertificateRequestsPage.OpenSelectedPrivateKeyCommand = _navigateRequestPrivateKeyCommand;
         CertificateRequestsPage.CreateTemplateFromRequestCommand = _createTemplateFromRequestCommand;
         CertificateRequestsPage.CreateSimilarRequestCommand = _createSimilarRequestCommand;
+        CertificateRequestsPage.ImportCommand = _importFilesCommand;
+        CertificateRequestsPage.DeleteSelectedCommand = _deleteCsrCommand;
+        CertificateRequestsPage.OpenNewRequestAuthoringCommand = _openCertificateSigningRequestAuthoringCommand;
         CertificateRequestsPage.IssuanceAuthoring.ApplyTemplateCommand = _applyIssuanceTemplateCommand;
         CertificateRequestsPage.IssuanceAuthoring.PrimaryActionCommand = _signCertificateSigningRequestCommand;
 
@@ -1204,6 +1213,42 @@ public sealed class ShellViewModel : ViewModelBase
         NotifySuccess("Template enabled state updated.");
     }
 
+    private async Task DeletePrivateKeyAsync()
+    {
+        if (PrivateKeysPage.SelectedItem is null)
+            return;
+
+        PrivateKeysPage.IsDeleteConfirmDialogOpen = false;
+        using var scope = BeginBusy("Deleting private key");
+        var result = await _databaseSessionService.DeletePrivateKeyAsync(PrivateKeysPage.SelectedItem.PrivateKeyId, CancellationToken.None);
+        if (!result.IsSuccess)
+        {
+            NotifyFailure(result.Message);
+            return;
+        }
+
+        await LoadPrivateKeysAsync();
+        NotifySuccess("Private key deleted.");
+    }
+
+    private async Task DeleteCsrAsync()
+    {
+        if (CertificateRequestsPage.SelectedItem is null)
+            return;
+
+        CertificateRequestsPage.IsDeleteConfirmDialogOpen = false;
+        using var scope = BeginBusy("Deleting certificate signing request");
+        var result = await _databaseSessionService.DeleteCertificateSigningRequestAsync(CertificateRequestsPage.SelectedItem.CertificateSigningRequestId, CancellationToken.None);
+        if (!result.IsSuccess)
+        {
+            NotifyFailure(result.Message);
+            return;
+        }
+
+        await LoadCertificateRequestsAsync();
+        NotifySuccess("Certificate signing request deleted.");
+    }
+
     private async Task DeleteTemplateAsync()
     {
         if (TemplatesPage.SelectedItem is null)
@@ -1711,6 +1756,8 @@ public sealed class ShellViewModel : ViewModelBase
         _cloneTemplateCommand.RaiseCanExecuteChanged();
         _toggleTemplateFavoriteCommand.RaiseCanExecuteChanged();
         _toggleTemplateEnabledCommand.RaiseCanExecuteChanged();
+        _deletePrivateKeyCommand.RaiseCanExecuteChanged();
+        _deleteCsrCommand.RaiseCanExecuteChanged();
         _deleteTemplateCommand.RaiseCanExecuteChanged();
         _applySelfSignedCaTemplateCommand.RaiseCanExecuteChanged();
         _applyCertificateSigningRequestTemplateCommand.RaiseCanExecuteChanged();

--- a/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
@@ -7,12 +7,13 @@
     <Border Grid.Row="0" Classes="workspace-pane">
       <Grid RowDefinitions="Auto,*">
         <Border Classes="table-header" Padding="8,6">
-          <Grid ColumnDefinitions="1.2*,2.0*,0.9*,0.9*,1.0*" ColumnSpacing="8">
+          <Grid ColumnDefinitions="1.2*,2.0*,0.7*,0.7*,0.9*,0.6*" ColumnSpacing="8">
             <TextBlock Text="Certificate signing requests" FontWeight="SemiBold" />
             <TextBlock Grid.Column="1" Text="Subject" Classes="table-header-text" />
             <TextBlock Grid.Column="2" Text="Key" Classes="table-header-text" />
             <TextBlock Grid.Column="3" Text="Created" Classes="table-header-text" />
             <TextBlock Grid.Column="4" Text="Algorithm" Classes="table-header-text" />
+            <TextBlock Grid.Column="5" Text="Signed" Classes="table-header-text" />
           </Grid>
         </Border>
         <Grid Grid.Row="1">
@@ -30,19 +31,20 @@
                 <MenuItem Header="To Template" Command="{Binding CreateTemplateFromRequestCommand}" />
                 <MenuItem Header="Open Key" Command="{Binding OpenSelectedPrivateKeyCommand}" />
                 <Separator />
-                <MenuItem Header="Import" IsEnabled="False" />
-                <MenuItem Header="Delete" IsEnabled="False" />
+                <MenuItem Header="Import" Command="{Binding ImportCommand}" />
+                <MenuItem Header="Delete" Command="{Binding OpenDeleteConfirmCommand}" />
               </ContextMenu>
             </ListBox.ContextMenu>
             <ListBox.ItemTemplate>
               <DataTemplate>
                 <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
-                  <Grid ColumnDefinitions="1.2*,2.0*,0.9*,0.9*,1.0*" ColumnSpacing="8">
+                  <Grid ColumnDefinitions="1.2*,2.0*,0.7*,0.7*,0.9*,0.6*" ColumnSpacing="8">
                     <TextBlock Text="{Binding DisplayName}" />
                     <TextBlock Grid.Column="1" Text="{Binding Subject}" TextWrapping="Wrap" />
                     <TextBlock Grid.Column="2" Text="{Binding PrivateKeySummary}" />
                     <TextBlock Grid.Column="3" Text="{Binding CreatedUtc, StringFormat='{}{0:yyyy-MM-dd}'}" />
                     <TextBlock Grid.Column="4" Text="{Binding KeyAlgorithm}" />
+                    <TextBlock Grid.Column="5" Text="{Binding IsSigned}" />
                   </Grid>
                 </Border>
               </DataTemplate>
@@ -55,12 +57,12 @@
     <!-- Side action panel -->
     <Border Grid.Column="1" Classes="classic-side-panel" Padding="8">
       <StackPanel>
-        <Button Classes="side-action" Content="New Request" IsEnabled="False" />
+        <Button Classes="side-action" Content="New Request" Command="{Binding OpenNewRequestAuthoringCommand}" IsEnabled="{Binding OpenNewRequestAuthoringCommand, Converter={x:Static ObjectConverters.IsNotNull}}" />
         <Button Classes="side-action" Content="Sign" Command="{Binding OpenIssuanceAuthoringCommand}" />
         <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedToFileCommand}" />
-        <Button Classes="side-action" Content="Import" IsEnabled="False" />
+        <Button Classes="side-action" Content="Import" Command="{Binding ImportCommand}" />
         <Button Classes="side-action" Content="Show Details" Command="{Binding ShowDetailsCommand}" IsEnabled="{Binding HasSelection}" />
-        <Button Classes="side-action" Content="Delete" IsEnabled="False" />
+        <Button Classes="side-action" Content="Delete" Command="{Binding OpenDeleteConfirmCommand}" IsEnabled="{Binding HasSelection}" />
         <Button Classes="side-action" Content="Similar Request" Command="{Binding CreateSimilarRequestCommand}" />
         <Button Classes="side-action" Content="To Template" Command="{Binding CreateTemplateFromRequestCommand}" />
         <Button Classes="side-action" Content="Open Key" Command="{Binding OpenSelectedPrivateKeyCommand}" />
@@ -107,7 +109,7 @@
             <TextBlock Text="Request Details" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
             <Button Grid.Column="1" Content="Close" Command="{Binding CloseDetailCommand}" />
           </Grid>
-          <Grid Grid.Row="1" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+          <Grid Grid.Row="1" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
             <TextBlock Text="Internal name" />
             <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" />
             <TextBlock Grid.Row="1" Text="Subject" />
@@ -118,8 +120,30 @@
             <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.KeyAlgorithm}" />
             <TextBlock Grid.Row="4" Text="Private key" />
             <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding SelectedItem.PrivateKeySummary}" />
+            <TextBlock Grid.Row="5" Text="Signed" />
+            <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding SelectedItem.IsSigned}" />
           </Grid>
           <Button Grid.Row="2" Content="OK" Command="{Binding CloseDetailCommand}" HorizontalAlignment="Right" MinWidth="80" />
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- Delete confirmation dialog overlay -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsDeleteConfirmDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="400"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+          <TextBlock Text="Delete Certificate Signing Request" FontSize="16" FontWeight="SemiBold" />
+          <TextBlock Grid.Row="1" Text="{Binding SelectedItem.DisplayName, StringFormat='Delete &quot;{0}&quot;? This action cannot be undone.'}" TextWrapping="Wrap" />
+          <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+            <Button Content="Cancel" Command="{Binding CloseDeleteConfirmCommand}" />
+            <Button Content="Delete" Command="{Binding DeleteSelectedCommand}" Classes="danger" />
+          </StackPanel>
         </Grid>
       </Border>
     </Grid>

--- a/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
@@ -28,8 +28,8 @@
                 <MenuItem Header="Create CSR" Command="{Binding OpenCertificateSigningRequestAuthoringCommand}" />
                 <MenuItem Header="Create Certificate" Command="{Binding OpenSelfSignedCaAuthoringCommand}" />
                 <Separator />
-                <MenuItem Header="Import" IsEnabled="False" />
-                <MenuItem Header="Delete" IsEnabled="False" />
+                <MenuItem Header="Import" Command="{Binding ImportCommand}" />
+                <MenuItem Header="Delete" Command="{Binding OpenDeleteConfirmCommand}" />
               </ContextMenu>
             </ListBox.ContextMenu>
             <ListBox.ItemTemplate>
@@ -55,9 +55,9 @@
       <StackPanel>
         <Button Classes="side-action" Content="New Key" Command="{Binding OpenNewKeyDialogCommand}" />
         <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedToFileCommand}" />
-        <Button Classes="side-action" Content="Import" IsEnabled="False" />
+        <Button Classes="side-action" Content="Import" Command="{Binding ImportCommand}" />
         <Button Classes="side-action" Content="Show Details" Command="{Binding ShowDetailsCommand}" IsEnabled="{Binding HasSelection}" />
-        <Button Classes="side-action" Content="Delete" IsEnabled="False" />
+        <Button Classes="side-action" Content="Delete" Command="{Binding OpenDeleteConfirmCommand}" IsEnabled="{Binding HasSelection}" />
         <Button Classes="side-action" Content="Create CSR" Command="{Binding OpenCertificateSigningRequestAuthoringCommand}" />
         <Button Classes="side-action" Content="Create Certificate" Command="{Binding OpenSelfSignedCaAuthoringCommand}" />
         <Button Classes="side-action" Content="Refresh" Command="{Binding RefreshCommand}" />
@@ -165,6 +165,26 @@
             <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding SelectedItem.PublicKeyFingerprint}" TextWrapping="Wrap" />
           </Grid>
           <Button Grid.Row="2" Content="OK" Command="{Binding CloseKeyDetailCommand}" HorizontalAlignment="Right" MinWidth="80" />
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- Delete confirmation dialog overlay -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsDeleteConfirmDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="400"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+          <TextBlock Text="Delete Private Key" FontSize="16" FontWeight="SemiBold" />
+          <TextBlock Grid.Row="1" Text="{Binding SelectedItem.DisplayName, StringFormat='Delete &quot;{0}&quot;? This action cannot be undone.'}" TextWrapping="Wrap" />
+          <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+            <Button Content="Cancel" Command="{Binding CloseDeleteConfirmCommand}" />
+            <Button Content="Delete" Command="{Binding DeleteSelectedCommand}" Classes="danger" />
+          </StackPanel>
         </Grid>
       </Border>
     </Grid>

--- a/src/XcaNet.Application/Services/DatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/DatabaseSessionService.cs
@@ -537,6 +537,7 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
                     request.IssuerCertificateId),
                 cancellationToken);
 
+            await _certificateRequestRepository.MarkSignedAsync(databasePath, request.CertificateSigningRequestId, cancellationToken);
             await _auditEventRepository.AddAsync(databasePath, CreateAuditEvent(AuditEventKind.CertificateSigningRequestSigned, "Certificate signing request signed."), cancellationToken);
 
             return OperationResult<StoredCertificateResult>.Success(
@@ -1192,7 +1193,8 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
                     x.PrivateKeyId == Guid.Empty ? null : new NavigationTarget(BrowserEntityType.PrivateKey, x.PrivateKeyId, NavigationFocusSection.Overview),
                     x.KeyAlgorithm,
                     x.SubjectAlternativeNames,
-                    DateTime.SpecifyKind(x.CreatedUtc, DateTimeKind.Utc)))
+                    DateTime.SpecifyKind(x.CreatedUtc, DateTimeKind.Utc),
+                    x.IsSigned))
                 .ToList();
 
             return OperationResult<IReadOnlyList<CertificateRequestListItem>>.Success(items, "Certificate signing requests loaded.");
@@ -1410,6 +1412,42 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
 
             var template = await _templateRepository.GetAsync(databasePath, request.TemplateId, cancellationToken);
             return OperationResult<TemplateDetails>.Success(TemplateModelMapper.ToDetails(template!), "Template enabled state updated.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<OperationResult> DeletePrivateKeyAsync(Guid privateKeyId, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (!TryGetOpenDatabasePath<object>(out var databasePath, out var failure))
+                return OperationResult.Failure(failure!.ErrorCode, failure.Message);
+
+            return await _privateKeyRepository.DeleteAsync(databasePath, privateKeyId, cancellationToken)
+                ? OperationResult.Success("Private key deleted.")
+                : OperationResult.Failure(OperationErrorCode.DatabaseNotFound, "Private key not found.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<OperationResult> DeleteCertificateSigningRequestAsync(Guid csrId, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (!TryGetOpenDatabasePath<object>(out var databasePath, out var failure))
+                return OperationResult.Failure(failure!.ErrorCode, failure.Message);
+
+            return await _certificateRequestRepository.DeleteAsync(databasePath, csrId, cancellationToken)
+                ? OperationResult.Success("Certificate signing request deleted.")
+                : OperationResult.Failure(OperationErrorCode.DatabaseNotFound, "Certificate signing request not found.");
         }
         finally
         {

--- a/src/XcaNet.Application/Services/IDatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/IDatabaseSessionService.cs
@@ -70,6 +70,10 @@ public interface IDatabaseSessionService
 
     Task<OperationResult<TemplateDetails>> SetTemplateEnabledAsync(SetTemplateEnabledRequest request, CancellationToken cancellationToken);
 
+    Task<OperationResult> DeletePrivateKeyAsync(Guid privateKeyId, CancellationToken cancellationToken);
+
+    Task<OperationResult> DeleteCertificateSigningRequestAsync(Guid csrId, CancellationToken cancellationToken);
+
     Task<OperationResult> DeleteTemplateAsync(Guid templateId, CancellationToken cancellationToken);
 
     Task<OperationResult<AppliedTemplateDefaults>> ApplyTemplateAsync(ApplyTemplateRequest request, CancellationToken cancellationToken);

--- a/src/XcaNet.Contracts/Browser/CertificateRequestListItem.cs
+++ b/src/XcaNet.Contracts/Browser/CertificateRequestListItem.cs
@@ -8,7 +8,8 @@ public sealed record CertificateRequestListItem(
     NavigationTarget? PrivateKeyTarget,
     string KeyAlgorithm,
     string SubjectAlternativeNames,
-    DateTimeOffset CreatedUtc)
+    DateTimeOffset CreatedUtc,
+    bool IsSigned)
 {
     public string PrivateKeySummary => PrivateKeyId is null ? "Imported" : "Stored key";
 }

--- a/src/XcaNet.Storage/Persistence/Entities/CertificateRequestEntity.cs
+++ b/src/XcaNet.Storage/Persistence/Entities/CertificateRequestEntity.cs
@@ -11,4 +11,5 @@ public sealed class CertificateRequestEntity
     public string KeyAlgorithm { get; set; } = string.Empty;
     public string SubjectAlternativeNames { get; set; } = string.Empty;
     public DateTime CreatedUtc { get; set; }
+    public bool IsSigned { get; set; }
 }

--- a/src/XcaNet.Storage/Persistence/Migrations/20260425000000_CsrSignedFlag.Designer.cs
+++ b/src/XcaNet.Storage/Persistence/Migrations/20260425000000_CsrSignedFlag.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using XcaNet.Storage.Persistence;
 
@@ -10,9 +11,11 @@ using XcaNet.Storage.Persistence;
 namespace XcaNet.Storage.Persistence.Migrations
 {
     [DbContext(typeof(XcaNetDbContext))]
-    partial class XcaNetDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425000000_CsrSignedFlag")]
+    partial class CsrSignedFlag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.0");

--- a/src/XcaNet.Storage/Persistence/Migrations/20260425000000_CsrSignedFlag.cs
+++ b/src/XcaNet.Storage/Persistence/Migrations/20260425000000_CsrSignedFlag.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XcaNet.Storage.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class CsrSignedFlag : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsSigned",
+                table: "CertificateRequests",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsSigned",
+                table: "CertificateRequests");
+        }
+    }
+}

--- a/src/XcaNet.Storage/Repositories/CertificateRequestRepository.cs
+++ b/src/XcaNet.Storage/Repositories/CertificateRequestRepository.cs
@@ -34,4 +34,28 @@ public sealed class CertificateRequestRepository : ICertificateRequestRepository
             .OrderByDescending(x => x.CreatedUtc)
             .ToListAsync(cancellationToken);
     }
+
+    public async Task<bool> DeleteAsync(string databasePath, Guid certificateRequestId, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var existing = await dbContext.CertificateRequests.SingleOrDefaultAsync(x => x.Id == certificateRequestId, cancellationToken);
+        if (existing is null)
+            return false;
+
+        dbContext.CertificateRequests.Remove(existing);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    public async Task<bool> MarkSignedAsync(string databasePath, Guid certificateRequestId, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var existing = await dbContext.CertificateRequests.SingleOrDefaultAsync(x => x.Id == certificateRequestId, cancellationToken);
+        if (existing is null)
+            return false;
+
+        existing.IsSigned = true;
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return true;
+    }
 }

--- a/src/XcaNet.Storage/Repositories/ICertificateRequestRepository.cs
+++ b/src/XcaNet.Storage/Repositories/ICertificateRequestRepository.cs
@@ -9,4 +9,8 @@ public interface ICertificateRequestRepository
     Task<CertificateRequestEntity?> GetAsync(string databasePath, Guid certificateRequestId, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<CertificateRequestEntity>> ListAsync(string databasePath, CancellationToken cancellationToken);
+
+    Task<bool> DeleteAsync(string databasePath, Guid certificateRequestId, CancellationToken cancellationToken);
+
+    Task<bool> MarkSignedAsync(string databasePath, Guid certificateRequestId, CancellationToken cancellationToken);
 }

--- a/src/XcaNet.Storage/Repositories/IPrivateKeyRepository.cs
+++ b/src/XcaNet.Storage/Repositories/IPrivateKeyRepository.cs
@@ -9,4 +9,6 @@ public interface IPrivateKeyRepository
     Task<PrivateKeyEntity?> GetAsync(string databasePath, Guid privateKeyId, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<PrivateKeyEntity>> ListAsync(string databasePath, CancellationToken cancellationToken);
+
+    Task<bool> DeleteAsync(string databasePath, Guid privateKeyId, CancellationToken cancellationToken);
 }

--- a/src/XcaNet.Storage/Repositories/PrivateKeyRepository.cs
+++ b/src/XcaNet.Storage/Repositories/PrivateKeyRepository.cs
@@ -34,4 +34,16 @@ public sealed class PrivateKeyRepository : IPrivateKeyRepository
             .OrderByDescending(x => x.CreatedUtc)
             .ToListAsync(cancellationToken);
     }
+
+    public async Task<bool> DeleteAsync(string databasePath, Guid privateKeyId, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var existing = await dbContext.PrivateKeys.SingleOrDefaultAsync(x => x.Id == privateKeyId, cancellationToken);
+        if (existing is null)
+            return false;
+
+        dbContext.PrivateKeys.Remove(existing);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `IsSigned` column to CSR list (DB migration + EF snapshot)
- Enables Delete with confirmation dialog for both Private Keys and CSR tabs
- Enables Import button for both tabs (reuses existing file picker flow)
- Wires "New Request" button on CSR tab to the existing CSR authoring dialog
- Marks CSR as signed automatically when a certificate is issued from it

## Changes
- `XcaNet.Storage`: `IsSigned` DB migration, `DeleteAsync` + `MarkSignedAsync` on CSR repo, `DeleteAsync` on key repo
- `XcaNet.Application`: `DeletePrivateKeyAsync` + `DeleteCertificateSigningRequestAsync` on `IDatabaseSessionService`
- `XcaNet.App`: delete confirmation dialog state on both page VMs, full command wiring in `ShellViewModel`, `Signed` column in CSR view, enabled buttons/context menus

## Test plan
- [ ] Open a database, go to Private Keys tab — Import and Delete buttons should now be enabled
- [ ] Select a key, click Delete — confirm dialog appears; clicking Cancel dismisses, clicking Delete removes the key and refreshes the list
- [ ] Go to CSR tab — Signed column visible, Import/Delete/New Request buttons enabled
- [ ] Select a CSR, click Delete — confirm dialog appears, delete removes it
- [ ] Sign a CSR into a certificate — Signed column should show True for that CSR after refresh
- [ ] Verify all existing tests still pass: `dotnet test tests/XcaNet.Storage.Tests tests/XcaNet.Application.Tests --no-build`

Closes #38, #42, #43, #44
Milestone: M13.5