### PR TITLE
feat: implement central input dialog parity (M13.7)

### DIFF
--- a/src/XcaNet.App/ViewModels/Pages/CertificateAuthoringViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateAuthoringViewModel.cs
@@ -18,11 +18,14 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
     private EllipticCurveKind _curve;
     private string _signatureAlgorithm;
     private int _validityDays;
+    private DateTime? _notBeforeDate;
+    private DateTime? _notAfterDate;
     private bool _isCertificateAuthority;
     private bool _hasPathLengthConstraint;
     private int _pathLengthConstraint;
     private string _keyUsages;
     private string _enhancedKeyUsages;
+    private string _comment;
     private bool _showTemplateApplication;
     private bool _showKeySection;
     private bool _showSigningSection;
@@ -35,6 +38,37 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
     private PrivateKeyListItem? _selectedIssuerPrivateKey;
     private ICommand? _applyTemplateCommand;
     private ICommand? _primaryActionCommand;
+
+    // Structured DN backing fields
+    private string _dnCommonName = string.Empty;
+    private string _dnOrganization = string.Empty;
+    private string _dnOrganizationalUnit = string.Empty;
+    private string _dnCountry = string.Empty;
+    private string _dnState = string.Empty;
+    private string _dnLocality = string.Empty;
+    private string _dnEmail = string.Empty;
+    private bool _syncingSubject;
+
+    // KU backing fields
+    private bool _kuDigitalSignature;
+    private bool _kuNonRepudiation;
+    private bool _kuKeyEncipherment;
+    private bool _kuDataEncipherment;
+    private bool _kuKeyAgreement;
+    private bool _kuKeyCertSign;
+    private bool _kuCrlSign;
+    private bool _kuEncipherOnly;
+    private bool _kuDecipherOnly;
+    private bool _syncingKu;
+
+    // EKU backing fields
+    private bool _ekuServerAuth;
+    private bool _ekuClientAuth;
+    private bool _ekuCodeSigning;
+    private bool _ekuEmailProtection;
+    private bool _ekuTimeStamping;
+    private bool _ekuOcspSigning;
+    private bool _syncingEku;
 
     public CertificateAuthoringViewModel(
         string title,
@@ -69,25 +103,38 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
         _showSignatureAlgorithm = showSignatureAlgorithm;
         _primaryActionLabel = primaryActionLabel;
         _subjectAlternativeNames = string.Empty;
+        _comment = string.Empty;
         _keyAlgorithm = KeyAlgorithmKind.Rsa;
         _rsaKeySize = 3072;
         _curve = EllipticCurveKind.P256;
         _signatureAlgorithm = "SHA-256";
         _selectedTemplateApplicationMode = TemplateApplicationModeView.Full;
+
+        var today = DateTime.Today;
+        _notBeforeDate = today;
+        _notAfterDate = today.AddDays(validityDays);
+
+        ParseSubjectNameToDn(subjectName);
+        ParseKeyUsagesToBools(keyUsages);
+        ParseEnhancedKeyUsagesToBools(enhancedKeyUsages);
     }
+
+    // ── Static option lists ────────────────────────────────────────────────
 
     public IReadOnlyList<KeyAlgorithmKind> KeyAlgorithms { get; } = [KeyAlgorithmKind.Rsa, KeyAlgorithmKind.Ecdsa];
 
     public IReadOnlyList<EllipticCurveKind> Curves { get; } = [EllipticCurveKind.P256, EllipticCurveKind.P384];
 
+    public IReadOnlyList<string> SignatureAlgorithms { get; } = ["SHA-256", "SHA-384", "SHA-512"];
+
     public IReadOnlyList<TemplateApplicationModeView> TemplateApplicationModes { get; } =
         [TemplateApplicationModeView.Full, TemplateApplicationModeView.SubjectOnly, TemplateApplicationModeView.ExtensionsOnly];
 
     public ObservableCollection<TemplateListItem> Templates { get; } = [];
-
     public ObservableCollection<CertificateListItem> IssuerCertificates { get; } = [];
-
     public ObservableCollection<PrivateKeyListItem> IssuerPrivateKeys { get; } = [];
+
+    // ── Metadata ──────────────────────────────────────────────────────────
 
     public string Title
     {
@@ -113,10 +160,96 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
         set => SetProperty(ref _displayName, value);
     }
 
+    public string Comment
+    {
+        get => _comment;
+        set => SetProperty(ref _comment, value);
+    }
+
+    // ── Subject / DN ──────────────────────────────────────────────────────
+
     public string SubjectName
     {
         get => _subjectName;
-        set => SetProperty(ref _subjectName, value);
+        set
+        {
+            if (SetProperty(ref _subjectName, value) && !_syncingSubject)
+            {
+                _syncingSubject = true;
+                ParseSubjectNameToDn(value);
+                _syncingSubject = false;
+            }
+        }
+    }
+
+    public string DnCommonName
+    {
+        get => _dnCommonName;
+        set
+        {
+            if (SetProperty(ref _dnCommonName, value) && !_syncingSubject)
+                RebuildSubjectName();
+        }
+    }
+
+    public string DnOrganization
+    {
+        get => _dnOrganization;
+        set
+        {
+            if (SetProperty(ref _dnOrganization, value) && !_syncingSubject)
+                RebuildSubjectName();
+        }
+    }
+
+    public string DnOrganizationalUnit
+    {
+        get => _dnOrganizationalUnit;
+        set
+        {
+            if (SetProperty(ref _dnOrganizationalUnit, value) && !_syncingSubject)
+                RebuildSubjectName();
+        }
+    }
+
+    public string DnCountry
+    {
+        get => _dnCountry;
+        set
+        {
+            if (SetProperty(ref _dnCountry, value) && !_syncingSubject)
+                RebuildSubjectName();
+        }
+    }
+
+    public string DnState
+    {
+        get => _dnState;
+        set
+        {
+            if (SetProperty(ref _dnState, value) && !_syncingSubject)
+                RebuildSubjectName();
+        }
+    }
+
+    public string DnLocality
+    {
+        get => _dnLocality;
+        set
+        {
+            if (SetProperty(ref _dnLocality, value) && !_syncingSubject)
+                RebuildSubjectName();
+        }
+    }
+
+    public string DnEmail
+    {
+        get => _dnEmail;
+        set
+        {
+            if (SetProperty(ref _dnEmail, value) && !_syncingSubject)
+                RebuildSubjectName();
+        }
     }
 
     public string SubjectAlternativeNames
@@ -124,6 +257,52 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
         get => _subjectAlternativeNames;
         set => SetProperty(ref _subjectAlternativeNames, value);
     }
+
+    // ── Validity / Dates ──────────────────────────────────────────────────
+
+    public int ValidityDays
+    {
+        get => _validityDays;
+        set
+        {
+            if (SetProperty(ref _validityDays, value))
+            {
+                _notAfterDate = _notBeforeDate?.AddDays(value);
+                OnPropertyChanged(nameof(NotAfterDate));
+            }
+        }
+    }
+
+    public DateTime? NotBeforeDate
+    {
+        get => _notBeforeDate;
+        set
+        {
+            if (SetProperty(ref _notBeforeDate, value))
+            {
+                _notAfterDate = value?.AddDays(_validityDays);
+                OnPropertyChanged(nameof(NotAfterDate));
+            }
+        }
+    }
+
+    public DateTime? NotAfterDate
+    {
+        get => _notAfterDate;
+        set
+        {
+            if (SetProperty(ref _notAfterDate, value))
+            {
+                if (_notBeforeDate is { } nb && value is { } na)
+                {
+                    _validityDays = Math.Max(1, (int)Math.Round((na - nb).TotalDays, MidpointRounding.AwayFromZero));
+                    OnPropertyChanged(nameof(ValidityDays));
+                }
+            }
+        }
+    }
+
+    // ── Key / Algorithm ───────────────────────────────────────────────────
 
     public KeyAlgorithmKind KeyAlgorithm
     {
@@ -160,11 +339,7 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
         set => SetProperty(ref _signatureAlgorithm, value);
     }
 
-    public int ValidityDays
-    {
-        get => _validityDays;
-        set => SetProperty(ref _validityDays, value);
-    }
+    // ── CA / Extensions ───────────────────────────────────────────────────
 
     public bool IsCertificateAuthority
     {
@@ -184,17 +359,56 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
         set => SetProperty(ref _pathLengthConstraint, value);
     }
 
+    // ── Key Usage ─────────────────────────────────────────────────────────
+
     public string KeyUsages
     {
         get => _keyUsages;
-        set => SetProperty(ref _keyUsages, value);
+        set
+        {
+            if (SetProperty(ref _keyUsages, value) && !_syncingKu)
+            {
+                _syncingKu = true;
+                ParseKeyUsagesToBools(value);
+                _syncingKu = false;
+            }
+        }
     }
+
+    public bool KuDigitalSignature { get => _kuDigitalSignature; set { if (SetProperty(ref _kuDigitalSignature, value) && !_syncingKu) RebuildKeyUsages(); } }
+    public bool KuNonRepudiation { get => _kuNonRepudiation; set { if (SetProperty(ref _kuNonRepudiation, value) && !_syncingKu) RebuildKeyUsages(); } }
+    public bool KuKeyEncipherment { get => _kuKeyEncipherment; set { if (SetProperty(ref _kuKeyEncipherment, value) && !_syncingKu) RebuildKeyUsages(); } }
+    public bool KuDataEncipherment { get => _kuDataEncipherment; set { if (SetProperty(ref _kuDataEncipherment, value) && !_syncingKu) RebuildKeyUsages(); } }
+    public bool KuKeyAgreement { get => _kuKeyAgreement; set { if (SetProperty(ref _kuKeyAgreement, value) && !_syncingKu) RebuildKeyUsages(); } }
+    public bool KuKeyCertSign { get => _kuKeyCertSign; set { if (SetProperty(ref _kuKeyCertSign, value) && !_syncingKu) RebuildKeyUsages(); } }
+    public bool KuCrlSign { get => _kuCrlSign; set { if (SetProperty(ref _kuCrlSign, value) && !_syncingKu) RebuildKeyUsages(); } }
+    public bool KuEncipherOnly { get => _kuEncipherOnly; set { if (SetProperty(ref _kuEncipherOnly, value) && !_syncingKu) RebuildKeyUsages(); } }
+    public bool KuDecipherOnly { get => _kuDecipherOnly; set { if (SetProperty(ref _kuDecipherOnly, value) && !_syncingKu) RebuildKeyUsages(); } }
+
+    // ── Enhanced Key Usage ────────────────────────────────────────────────
 
     public string EnhancedKeyUsages
     {
         get => _enhancedKeyUsages;
-        set => SetProperty(ref _enhancedKeyUsages, value);
+        set
+        {
+            if (SetProperty(ref _enhancedKeyUsages, value) && !_syncingEku)
+            {
+                _syncingEku = true;
+                ParseEnhancedKeyUsagesToBools(value);
+                _syncingEku = false;
+            }
+        }
     }
+
+    public bool EkuServerAuth { get => _ekuServerAuth; set { if (SetProperty(ref _ekuServerAuth, value) && !_syncingEku) RebuildEnhancedKeyUsages(); } }
+    public bool EkuClientAuth { get => _ekuClientAuth; set { if (SetProperty(ref _ekuClientAuth, value) && !_syncingEku) RebuildEnhancedKeyUsages(); } }
+    public bool EkuCodeSigning { get => _ekuCodeSigning; set { if (SetProperty(ref _ekuCodeSigning, value) && !_syncingEku) RebuildEnhancedKeyUsages(); } }
+    public bool EkuEmailProtection { get => _ekuEmailProtection; set { if (SetProperty(ref _ekuEmailProtection, value) && !_syncingEku) RebuildEnhancedKeyUsages(); } }
+    public bool EkuTimeStamping { get => _ekuTimeStamping; set { if (SetProperty(ref _ekuTimeStamping, value) && !_syncingEku) RebuildEnhancedKeyUsages(); } }
+    public bool EkuOcspSigning { get => _ekuOcspSigning; set { if (SetProperty(ref _ekuOcspSigning, value) && !_syncingEku) RebuildEnhancedKeyUsages(); } }
+
+    // ── Visibility flags ──────────────────────────────────────────────────
 
     public bool ShowTemplateApplication
     {
@@ -225,6 +439,8 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
         get => _showSignatureAlgorithm;
         set => SetProperty(ref _showSignatureAlgorithm, value);
     }
+
+    // ── Commands / Actions ────────────────────────────────────────────────
 
     public string PrimaryActionLabel
     {
@@ -268,13 +484,13 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
         set => SetProperty(ref _primaryActionCommand, value);
     }
 
+    // ── Public mutators ───────────────────────────────────────────────────
+
     public void SetTemplates(IEnumerable<TemplateListItem> templates)
     {
         Templates.Clear();
         foreach (var template in templates)
-        {
             Templates.Add(template);
-        }
 
         SelectedTemplate = Templates.FirstOrDefault(x => SelectedTemplate is not null && x.TemplateId == SelectedTemplate.TemplateId)
             ?? Templates.FirstOrDefault();
@@ -284,15 +500,11 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
     {
         IssuerCertificates.Clear();
         foreach (var certificate in certificates.Where(x => x.IsCertificateAuthority))
-        {
             IssuerCertificates.Add(certificate);
-        }
 
         IssuerPrivateKeys.Clear();
         foreach (var privateKey in privateKeys)
-        {
             IssuerPrivateKeys.Add(privateKey);
-        }
 
         SelectedIssuerCertificate = IssuerCertificates.FirstOrDefault(x => SelectedIssuerCertificate is not null && x.CertificateId == SelectedIssuerCertificate.CertificateId)
             ?? IssuerCertificates.FirstOrDefault();
@@ -380,6 +592,7 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
         DisplayName = "Template";
         SubjectName = string.Empty;
         SubjectAlternativeNames = string.Empty;
+        Comment = string.Empty;
         KeyAlgorithm = KeyAlgorithmKind.Rsa;
         RsaKeySize = 3072;
         Curve = EllipticCurveKind.P256;
@@ -392,13 +605,138 @@ public sealed class CertificateAuthoringViewModel : ViewModelBase
         EnhancedKeyUsages = "Server Authentication";
     }
 
+    // ── Private helpers ───────────────────────────────────────────────────
+
+    private void RebuildSubjectName()
+    {
+        _syncingSubject = true;
+        var parts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(_dnCommonName)) parts.Add($"CN={_dnCommonName}");
+        if (!string.IsNullOrWhiteSpace(_dnOrganization)) parts.Add($"O={_dnOrganization}");
+        if (!string.IsNullOrWhiteSpace(_dnOrganizationalUnit)) parts.Add($"OU={_dnOrganizationalUnit}");
+        if (!string.IsNullOrWhiteSpace(_dnCountry)) parts.Add($"C={_dnCountry}");
+        if (!string.IsNullOrWhiteSpace(_dnState)) parts.Add($"ST={_dnState}");
+        if (!string.IsNullOrWhiteSpace(_dnLocality)) parts.Add($"L={_dnLocality}");
+        if (!string.IsNullOrWhiteSpace(_dnEmail)) parts.Add($"E={_dnEmail}");
+        _subjectName = string.Join(", ", parts);
+        OnPropertyChanged(nameof(SubjectName));
+        _syncingSubject = false;
+    }
+
+    private void ParseSubjectNameToDn(string subjectName)
+    {
+        var components = ParseDnComponents(subjectName);
+        _dnCommonName = components.GetValueOrDefault("CN", string.Empty);
+        _dnOrganization = components.GetValueOrDefault("O", string.Empty);
+        _dnOrganizationalUnit = components.GetValueOrDefault("OU", string.Empty);
+        _dnCountry = components.GetValueOrDefault("C", string.Empty);
+        _dnState = components.GetValueOrDefault("ST", string.Empty);
+        _dnLocality = components.GetValueOrDefault("L", string.Empty);
+        _dnEmail = components.GetValueOrDefault("E", components.GetValueOrDefault("EMAIL", string.Empty));
+        OnPropertyChanged(nameof(DnCommonName));
+        OnPropertyChanged(nameof(DnOrganization));
+        OnPropertyChanged(nameof(DnOrganizationalUnit));
+        OnPropertyChanged(nameof(DnCountry));
+        OnPropertyChanged(nameof(DnState));
+        OnPropertyChanged(nameof(DnLocality));
+        OnPropertyChanged(nameof(DnEmail));
+    }
+
+    private static Dictionary<string, string> ParseDnComponents(string dn)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(dn))
+            return result;
+        foreach (var part in dn.Split(','))
+        {
+            var eq = part.IndexOf('=');
+            if (eq > 0)
+                result[part[..eq].Trim()] = part[(eq + 1)..].Trim();
+        }
+        return result;
+    }
+
+    private void RebuildKeyUsages()
+    {
+        _syncingKu = true;
+        var parts = new List<string>();
+        if (_kuDigitalSignature) parts.Add("DigitalSignature");
+        if (_kuNonRepudiation) parts.Add("NonRepudiation");
+        if (_kuKeyEncipherment) parts.Add("KeyEncipherment");
+        if (_kuDataEncipherment) parts.Add("DataEncipherment");
+        if (_kuKeyAgreement) parts.Add("KeyAgreement");
+        if (_kuKeyCertSign) parts.Add("KeyCertSign");
+        if (_kuCrlSign) parts.Add("CrlSign");
+        if (_kuEncipherOnly) parts.Add("EncipherOnly");
+        if (_kuDecipherOnly) parts.Add("DecipherOnly");
+        _keyUsages = string.Join(", ", parts);
+        OnPropertyChanged(nameof(KeyUsages));
+        _syncingKu = false;
+    }
+
+    private void ParseKeyUsagesToBools(string value)
+    {
+        var set = SplitToSet(value);
+        _kuDigitalSignature = set.Contains("DigitalSignature");
+        _kuNonRepudiation = set.Contains("NonRepudiation");
+        _kuKeyEncipherment = set.Contains("KeyEncipherment");
+        _kuDataEncipherment = set.Contains("DataEncipherment");
+        _kuKeyAgreement = set.Contains("KeyAgreement");
+        _kuKeyCertSign = set.Contains("KeyCertSign");
+        _kuCrlSign = set.Contains("CrlSign");
+        _kuEncipherOnly = set.Contains("EncipherOnly");
+        _kuDecipherOnly = set.Contains("DecipherOnly");
+        OnPropertyChanged(nameof(KuDigitalSignature));
+        OnPropertyChanged(nameof(KuNonRepudiation));
+        OnPropertyChanged(nameof(KuKeyEncipherment));
+        OnPropertyChanged(nameof(KuDataEncipherment));
+        OnPropertyChanged(nameof(KuKeyAgreement));
+        OnPropertyChanged(nameof(KuKeyCertSign));
+        OnPropertyChanged(nameof(KuCrlSign));
+        OnPropertyChanged(nameof(KuEncipherOnly));
+        OnPropertyChanged(nameof(KuDecipherOnly));
+    }
+
+    private void RebuildEnhancedKeyUsages()
+    {
+        _syncingEku = true;
+        var parts = new List<string>();
+        if (_ekuServerAuth) parts.Add("Server Authentication");
+        if (_ekuClientAuth) parts.Add("Client Authentication");
+        if (_ekuCodeSigning) parts.Add("Code Signing");
+        if (_ekuEmailProtection) parts.Add("Email Protection");
+        if (_ekuTimeStamping) parts.Add("Time Stamping");
+        if (_ekuOcspSigning) parts.Add("OCSP Signing");
+        _enhancedKeyUsages = string.Join(", ", parts);
+        OnPropertyChanged(nameof(EnhancedKeyUsages));
+        _syncingEku = false;
+    }
+
+    private void ParseEnhancedKeyUsagesToBools(string value)
+    {
+        var set = SplitToSet(value);
+        _ekuServerAuth = set.Contains("Server Authentication");
+        _ekuClientAuth = set.Contains("Client Authentication");
+        _ekuCodeSigning = set.Contains("Code Signing");
+        _ekuEmailProtection = set.Contains("Email Protection");
+        _ekuTimeStamping = set.Contains("Time Stamping");
+        _ekuOcspSigning = set.Contains("OCSP Signing");
+        OnPropertyChanged(nameof(EkuServerAuth));
+        OnPropertyChanged(nameof(EkuClientAuth));
+        OnPropertyChanged(nameof(EkuCodeSigning));
+        OnPropertyChanged(nameof(EkuEmailProtection));
+        OnPropertyChanged(nameof(EkuTimeStamping));
+        OnPropertyChanged(nameof(EkuOcspSigning));
+    }
+
+    private static HashSet<string> SplitToSet(string value)
+        => value.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
     private static int BuildValidityDays(DateTimeOffset? notBefore, DateTimeOffset? notAfter, int fallback)
     {
         if (notBefore is null || notAfter is null)
-        {
             return fallback;
-        }
-
         return Math.Max(1, (int)Math.Round((notAfter.Value - notBefore.Value).TotalDays, MidpointRounding.AwayFromZero));
     }
 

--- a/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
@@ -9,6 +9,7 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
     private CryptoFormatView _selectedExportFormat = CryptoFormatView.Pem;
     private string _exportPreview = string.Empty;
     private bool _isDetailDialogOpen;
+    private bool _isDeleteConfirmDialogOpen;
 
     public CertificateRequestsPageViewModel()
         : base("Certificate signing requests")
@@ -18,6 +19,8 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
 
         ShowDetailsCommand = new DelegateCommand(() => { if (SelectedItem is not null) IsDetailDialogOpen = true; });
         CloseDetailCommand = new DelegateCommand(() => IsDetailDialogOpen = false);
+        OpenDeleteConfirmCommand = new DelegateCommand(() => { if (SelectedItem is not null) IsDeleteConfirmDialogOpen = true; });
+        CloseDeleteConfirmCommand = new DelegateCommand(() => IsDeleteConfirmDialogOpen = false);
     }
 
     public CertificateAuthoringViewModel IssuanceAuthoring { get; } = new(
@@ -46,6 +49,16 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
     public DelegateCommand ShowDetailsCommand { get; }
 
     public DelegateCommand CloseDetailCommand { get; }
+
+    public DelegateCommand OpenDeleteConfirmCommand { get; }
+
+    public DelegateCommand CloseDeleteConfirmCommand { get; }
+
+    public bool IsDeleteConfirmDialogOpen
+    {
+        get => _isDeleteConfirmDialogOpen;
+        set => SetProperty(ref _isDeleteConfirmDialogOpen, value);
+    }
 
     public bool IsDetailDialogOpen
     {

--- a/src/XcaNet.App/ViewModels/Pages/CertificatesPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificatesPageViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Windows.Input;
+using XcaNet.App.Commands;
 using XcaNet.Contracts.Browser;
 using XcaNet.Contracts.Revocation;
 
@@ -25,12 +26,16 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
     private bool _isPlainView;
     private bool _isDetailDialogOpen;
     private bool _isRevokeDialogOpen;
+    private bool _isDeleteConfirmDialogOpen;
 
     public CertificatesPageViewModel()
         : base("Certificates")
     {
         EmptyStateTitle = "No certificates yet";
         EmptyStateMessage = "Import certificate material, create a self-signed CA, or sign a CSR to populate this workspace.";
+
+        OpenDeleteConfirmCommand = new DelegateCommand(() => { if (SelectedItem is not null) IsDeleteConfirmDialogOpen = true; });
+        CloseDeleteConfirmCommand = new DelegateCommand(() => IsDeleteConfirmDialogOpen = false);
     }
 
     public IReadOnlyList<CertificateValidityFilter> ValidityFilters { get; } =
@@ -90,6 +95,12 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
     {
         get => _isRevokeDialogOpen;
         set => SetProperty(ref _isRevokeDialogOpen, value);
+    }
+
+    public bool IsDeleteConfirmDialogOpen
+    {
+        get => _isDeleteConfirmDialogOpen;
+        set => SetProperty(ref _isDeleteConfirmDialogOpen, value);
     }
 
     // --- Existing data properties ---
@@ -207,6 +218,12 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
     public ICommand? CloseDetailCommand { get; set; }
 
     public ICommand? TogglePlainViewCommand { get; set; }
+
+    public ICommand? DeleteSelectedCommand { get; set; }
+
+    public DelegateCommand OpenDeleteConfirmCommand { get; }
+
+    public DelegateCommand CloseDeleteConfirmCommand { get; }
 
     // --- Tree building ---
 

--- a/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
@@ -16,6 +16,7 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
     private string _exportPreview = string.Empty;
     private bool _isNewKeyDialogOpen;
     private bool _isKeyDetailDialogOpen;
+    private bool _isDeleteConfirmDialogOpen;
 
     public PrivateKeysPageViewModel()
         : base("Private Keys")
@@ -27,6 +28,8 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
         CloseNewKeyDialogCommand = new DelegateCommand(() => IsNewKeyDialogOpen = false);
         ShowDetailsCommand = new DelegateCommand(() => { if (SelectedItem is not null) IsKeyDetailDialogOpen = true; });
         CloseKeyDetailCommand = new DelegateCommand(() => IsKeyDetailDialogOpen = false);
+        OpenDeleteConfirmCommand = new DelegateCommand(() => { if (SelectedItem is not null) IsDeleteConfirmDialogOpen = true; });
+        CloseDeleteConfirmCommand = new DelegateCommand(() => IsDeleteConfirmDialogOpen = false);
     }
 
     public IReadOnlyList<KeyAlgorithmView> Algorithms { get; } = [KeyAlgorithmView.Rsa, KeyAlgorithmView.Ecdsa];
@@ -44,6 +47,16 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
     public DelegateCommand ShowDetailsCommand { get; }
 
     public DelegateCommand CloseKeyDetailCommand { get; }
+
+    public DelegateCommand OpenDeleteConfirmCommand { get; }
+
+    public DelegateCommand CloseDeleteConfirmCommand { get; }
+
+    public bool IsDeleteConfirmDialogOpen
+    {
+        get => _isDeleteConfirmDialogOpen;
+        set => SetProperty(ref _isDeleteConfirmDialogOpen, value);
+    }
 
     public CertificateAuthoringViewModel SelfSignedCaAuthoring { get; } = new(
         "Certificate Input",

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -65,6 +65,8 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly AsyncCommand _cloneTemplateCommand;
     private readonly AsyncCommand _toggleTemplateFavoriteCommand;
     private readonly AsyncCommand _toggleTemplateEnabledCommand;
+    private readonly AsyncCommand _deletePrivateKeyCommand;
+    private readonly AsyncCommand _deleteCsrCommand;
     private readonly AsyncCommand _deleteTemplateCommand;
     private readonly AsyncCommand _applySelfSignedCaTemplateCommand;
     private readonly AsyncCommand _applyCertificateSigningRequestTemplateCommand;
@@ -146,6 +148,8 @@ public sealed class ShellViewModel : ViewModelBase
         _cloneTemplateCommand = new AsyncCommand(CloneTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
         _toggleTemplateFavoriteCommand = new AsyncCommand(ToggleTemplateFavoriteAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
         _toggleTemplateEnabledCommand = new AsyncCommand(ToggleTemplateEnabledAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
+        _deletePrivateKeyCommand = new AsyncCommand(DeletePrivateKeyAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
+        _deleteCsrCommand = new AsyncCommand(DeleteCsrAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificateRequestsPage.HasSelection);
         _deleteTemplateCommand = new AsyncCommand(DeleteTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
         _applySelfSignedCaTemplateCommand = new AsyncCommand(ApplySelfSignedCaTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && PrivateKeysPage.SelfSignedCaAuthoring.SelectedTemplate is not null);
         _applyCertificateSigningRequestTemplateCommand = new AsyncCommand(ApplyCertificateSigningRequestTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && PrivateKeysPage.CertificateSigningRequestAuthoring.SelectedTemplate is not null);
@@ -191,6 +195,8 @@ public sealed class ShellViewModel : ViewModelBase
         PrivateKeysPage.ApplyCertificateSigningRequestTemplateCommand = _applyCertificateSigningRequestTemplateCommand;
         PrivateKeysPage.ExportSelectedCommand = _exportPrivateKeyCommand;
         PrivateKeysPage.ExportSelectedToFileCommand = _exportPrivateKeyToFileCommand;
+        PrivateKeysPage.ImportCommand = _importFilesCommand;
+        PrivateKeysPage.DeleteSelectedCommand = _deletePrivateKeyCommand;
         PrivateKeysPage.SelfSignedCaAuthoring.ApplyTemplateCommand = _applySelfSignedCaTemplateCommand;
         PrivateKeysPage.SelfSignedCaAuthoring.PrimaryActionCommand = _createSelfSignedCaCommand;
         PrivateKeysPage.CertificateSigningRequestAuthoring.ApplyTemplateCommand = _applyCertificateSigningRequestTemplateCommand;
@@ -205,6 +211,9 @@ public sealed class ShellViewModel : ViewModelBase
         CertificateRequestsPage.OpenSelectedPrivateKeyCommand = _navigateRequestPrivateKeyCommand;
         CertificateRequestsPage.CreateTemplateFromRequestCommand = _createTemplateFromRequestCommand;
         CertificateRequestsPage.CreateSimilarRequestCommand = _createSimilarRequestCommand;
+        CertificateRequestsPage.ImportCommand = _importFilesCommand;
+        CertificateRequestsPage.DeleteSelectedCommand = _deleteCsrCommand;
+        CertificateRequestsPage.OpenNewRequestAuthoringCommand = _openCertificateSigningRequestAuthoringCommand;
         CertificateRequestsPage.IssuanceAuthoring.ApplyTemplateCommand = _applyIssuanceTemplateCommand;
         CertificateRequestsPage.IssuanceAuthoring.PrimaryActionCommand = _signCertificateSigningRequestCommand;
 
@@ -1204,6 +1213,42 @@ public sealed class ShellViewModel : ViewModelBase
         NotifySuccess("Template enabled state updated.");
     }
 
+    private async Task DeletePrivateKeyAsync()
+    {
+        if (PrivateKeysPage.SelectedItem is null)
+            return;
+
+        PrivateKeysPage.IsDeleteConfirmDialogOpen = false;
+        using var scope = BeginBusy("Deleting private key");
+        var result = await _databaseSessionService.DeletePrivateKeyAsync(PrivateKeysPage.SelectedItem.PrivateKeyId, CancellationToken.None);
+        if (!result.IsSuccess)
+        {
+            NotifyFailure(result.Message);
+            return;
+        }
+
+        await LoadPrivateKeysAsync();
+        NotifySuccess("Private key deleted.");
+    }
+
+    private async Task DeleteCsrAsync()
+    {
+        if (CertificateRequestsPage.SelectedItem is null)
+            return;
+
+        CertificateRequestsPage.IsDeleteConfirmDialogOpen = false;
+        using var scope = BeginBusy("Deleting certificate signing request");
+        var result = await _databaseSessionService.DeleteCertificateSigningRequestAsync(CertificateRequestsPage.SelectedItem.CertificateSigningRequestId, CancellationToken.None);
+        if (!result.IsSuccess)
+        {
+            NotifyFailure(result.Message);
+            return;
+        }
+
+        await LoadCertificateRequestsAsync();
+        NotifySuccess("Certificate signing request deleted.");
+    }
+
     private async Task DeleteTemplateAsync()
     {
         if (TemplatesPage.SelectedItem is null)
@@ -1711,6 +1756,8 @@ public sealed class ShellViewModel : ViewModelBase
         _cloneTemplateCommand.RaiseCanExecuteChanged();
         _toggleTemplateFavoriteCommand.RaiseCanExecuteChanged();
         _toggleTemplateEnabledCommand.RaiseCanExecuteChanged();
+        _deletePrivateKeyCommand.RaiseCanExecuteChanged();
+        _deleteCsrCommand.RaiseCanExecuteChanged();
         _deleteTemplateCommand.RaiseCanExecuteChanged();
         _applySelfSignedCaTemplateCommand.RaiseCanExecuteChanged();
         _applyCertificateSigningRequestTemplateCommand.RaiseCanExecuteChanged();

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -65,6 +65,7 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly AsyncCommand _cloneTemplateCommand;
     private readonly AsyncCommand _toggleTemplateFavoriteCommand;
     private readonly AsyncCommand _toggleTemplateEnabledCommand;
+    private readonly AsyncCommand _deleteCertificateCommand;
     private readonly AsyncCommand _deletePrivateKeyCommand;
     private readonly AsyncCommand _deleteCsrCommand;
     private readonly AsyncCommand _deleteTemplateCommand;
@@ -148,6 +149,7 @@ public sealed class ShellViewModel : ViewModelBase
         _cloneTemplateCommand = new AsyncCommand(CloneTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
         _toggleTemplateFavoriteCommand = new AsyncCommand(ToggleTemplateFavoriteAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
         _toggleTemplateEnabledCommand = new AsyncCommand(ToggleTemplateEnabledAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
+        _deleteCertificateCommand = new AsyncCommand(DeleteCertificateAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificatesPage.HasSelection);
         _deletePrivateKeyCommand = new AsyncCommand(DeletePrivateKeyAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && PrivateKeysPage.HasSelection);
         _deleteCsrCommand = new AsyncCommand(DeleteCsrAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificateRequestsPage.HasSelection);
         _deleteTemplateCommand = new AsyncCommand(DeleteTemplateAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && TemplatesPage.HasSelection);
@@ -184,6 +186,7 @@ public sealed class ShellViewModel : ViewModelBase
         CertificatesPage.OpenRevokeDialogCommand = _openRevokeDialogCommand;
         CertificatesPage.CloseRevokeDialogCommand = _closeRevokeDialogCommand;
         CertificatesPage.TogglePlainViewCommand = _togglePlainViewCommand;
+        CertificatesPage.DeleteSelectedCommand = _deleteCertificateCommand;
 
         PrivateKeysPage.RefreshCommand = _refreshPrivateKeysCommand;
         PrivateKeysPage.GenerateKeyCommand = _generateKeyCommand;
@@ -1213,6 +1216,24 @@ public sealed class ShellViewModel : ViewModelBase
         NotifySuccess("Template enabled state updated.");
     }
 
+    private async Task DeleteCertificateAsync()
+    {
+        if (CertificatesPage.SelectedItem is null)
+            return;
+
+        CertificatesPage.IsDeleteConfirmDialogOpen = false;
+        using var scope = BeginBusy("Deleting certificate");
+        var result = await _databaseSessionService.DeleteCertificateAsync(CertificatesPage.SelectedItem.CertificateId, CancellationToken.None);
+        if (!result.IsSuccess)
+        {
+            NotifyFailure(result.Message);
+            return;
+        }
+
+        await LoadCertificatesAsync();
+        NotifySuccess("Certificate deleted.");
+    }
+
     private async Task DeletePrivateKeyAsync()
     {
         if (PrivateKeysPage.SelectedItem is null)
@@ -1756,6 +1777,7 @@ public sealed class ShellViewModel : ViewModelBase
         _cloneTemplateCommand.RaiseCanExecuteChanged();
         _toggleTemplateFavoriteCommand.RaiseCanExecuteChanged();
         _toggleTemplateEnabledCommand.RaiseCanExecuteChanged();
+        _deleteCertificateCommand.RaiseCanExecuteChanged();
         _deletePrivateKeyCommand.RaiseCanExecuteChanged();
         _deleteCsrCommand.RaiseCanExecuteChanged();
         _deleteTemplateCommand.RaiseCanExecuteChanged();

--- a/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
@@ -7,12 +7,13 @@
     <Border Grid.Row="0" Classes="workspace-pane">
       <Grid RowDefinitions="Auto,*">
         <Border Classes="table-header" Padding="8,6">
-          <Grid ColumnDefinitions="1.2*,2.0*,0.9*,0.9*,1.0*" ColumnSpacing="8">
+          <Grid ColumnDefinitions="1.2*,2.0*,0.7*,0.7*,0.9*,0.6*" ColumnSpacing="8">
             <TextBlock Text="Certificate signing requests" FontWeight="SemiBold" />
             <TextBlock Grid.Column="1" Text="Subject" Classes="table-header-text" />
             <TextBlock Grid.Column="2" Text="Key" Classes="table-header-text" />
             <TextBlock Grid.Column="3" Text="Created" Classes="table-header-text" />
             <TextBlock Grid.Column="4" Text="Algorithm" Classes="table-header-text" />
+            <TextBlock Grid.Column="5" Text="Signed" Classes="table-header-text" />
           </Grid>
         </Border>
         <Grid Grid.Row="1">
@@ -30,19 +31,20 @@
                 <MenuItem Header="To Template" Command="{Binding CreateTemplateFromRequestCommand}" />
                 <MenuItem Header="Open Key" Command="{Binding OpenSelectedPrivateKeyCommand}" />
                 <Separator />
-                <MenuItem Header="Import" IsEnabled="False" />
-                <MenuItem Header="Delete" IsEnabled="False" />
+                <MenuItem Header="Import" Command="{Binding ImportCommand}" />
+                <MenuItem Header="Delete" Command="{Binding OpenDeleteConfirmCommand}" />
               </ContextMenu>
             </ListBox.ContextMenu>
             <ListBox.ItemTemplate>
               <DataTemplate>
                 <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
-                  <Grid ColumnDefinitions="1.2*,2.0*,0.9*,0.9*,1.0*" ColumnSpacing="8">
+                  <Grid ColumnDefinitions="1.2*,2.0*,0.7*,0.7*,0.9*,0.6*" ColumnSpacing="8">
                     <TextBlock Text="{Binding DisplayName}" />
                     <TextBlock Grid.Column="1" Text="{Binding Subject}" TextWrapping="Wrap" />
                     <TextBlock Grid.Column="2" Text="{Binding PrivateKeySummary}" />
                     <TextBlock Grid.Column="3" Text="{Binding CreatedUtc, StringFormat='{}{0:yyyy-MM-dd}'}" />
                     <TextBlock Grid.Column="4" Text="{Binding KeyAlgorithm}" />
+                    <TextBlock Grid.Column="5" Text="{Binding IsSigned}" />
                   </Grid>
                 </Border>
               </DataTemplate>
@@ -55,12 +57,12 @@
     <!-- Side action panel -->
     <Border Grid.Column="1" Classes="classic-side-panel" Padding="8">
       <StackPanel>
-        <Button Classes="side-action" Content="New Request" IsEnabled="False" />
+        <Button Classes="side-action" Content="New Request" Command="{Binding OpenNewRequestAuthoringCommand}" IsEnabled="{Binding OpenNewRequestAuthoringCommand, Converter={x:Static ObjectConverters.IsNotNull}}" />
         <Button Classes="side-action" Content="Sign" Command="{Binding OpenIssuanceAuthoringCommand}" />
         <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedToFileCommand}" />
-        <Button Classes="side-action" Content="Import" IsEnabled="False" />
+        <Button Classes="side-action" Content="Import" Command="{Binding ImportCommand}" />
         <Button Classes="side-action" Content="Show Details" Command="{Binding ShowDetailsCommand}" IsEnabled="{Binding HasSelection}" />
-        <Button Classes="side-action" Content="Delete" IsEnabled="False" />
+        <Button Classes="side-action" Content="Delete" Command="{Binding OpenDeleteConfirmCommand}" IsEnabled="{Binding HasSelection}" />
         <Button Classes="side-action" Content="Similar Request" Command="{Binding CreateSimilarRequestCommand}" />
         <Button Classes="side-action" Content="To Template" Command="{Binding CreateTemplateFromRequestCommand}" />
         <Button Classes="side-action" Content="Open Key" Command="{Binding OpenSelectedPrivateKeyCommand}" />
@@ -107,7 +109,7 @@
             <TextBlock Text="Request Details" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
             <Button Grid.Column="1" Content="Close" Command="{Binding CloseDetailCommand}" />
           </Grid>
-          <Grid Grid.Row="1" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+          <Grid Grid.Row="1" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
             <TextBlock Text="Internal name" />
             <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" />
             <TextBlock Grid.Row="1" Text="Subject" />
@@ -118,8 +120,30 @@
             <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.KeyAlgorithm}" />
             <TextBlock Grid.Row="4" Text="Private key" />
             <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding SelectedItem.PrivateKeySummary}" />
+            <TextBlock Grid.Row="5" Text="Signed" />
+            <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding SelectedItem.IsSigned}" />
           </Grid>
           <Button Grid.Row="2" Content="OK" Command="{Binding CloseDetailCommand}" HorizontalAlignment="Right" MinWidth="80" />
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- Delete confirmation dialog overlay -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsDeleteConfirmDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="400"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+          <TextBlock Text="Delete Certificate Signing Request" FontSize="16" FontWeight="SemiBold" />
+          <TextBlock Grid.Row="1" Text="{Binding SelectedItem.DisplayName, StringFormat='Delete &quot;{0}&quot;? This action cannot be undone.'}" TextWrapping="Wrap" />
+          <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+            <Button Content="Cancel" Command="{Binding CloseDeleteConfirmCommand}" />
+            <Button Content="Delete" Command="{Binding DeleteSelectedCommand}" Classes="danger" />
+          </StackPanel>
         </Grid>
       </Border>
     </Grid>

--- a/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
@@ -55,7 +55,7 @@
                 <MenuItem Header="Renew" IsEnabled="False" />
                 <Separator />
                 <MenuItem Header="Open Issuer" Command="{Binding OpenIssuerCommand}" />
-                <MenuItem Header="Delete" IsEnabled="False" />
+                <MenuItem Header="Delete" Command="{Binding OpenDeleteConfirmCommand}" />
               </ContextMenu>
             </TreeView.ContextMenu>
             <TreeView.ItemTemplate>
@@ -92,7 +92,7 @@
                 <MenuItem Header="Renew" IsEnabled="False" />
                 <Separator />
                 <MenuItem Header="Open Issuer" Command="{Binding OpenIssuerCommand}" />
-                <MenuItem Header="Delete" IsEnabled="False" />
+                <MenuItem Header="Delete" Command="{Binding OpenDeleteConfirmCommand}" />
               </ContextMenu>
             </ListBox.ContextMenu>
             <ListBox.ItemTemplate>
@@ -122,7 +122,7 @@
         <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedCommand}" />
         <Button Classes="side-action" Content="Import" Command="{Binding ImportFilesCommand}" />
         <Button Classes="side-action" Content="Show Details" Command="{Binding ShowDetailsCommand}" />
-        <Button Classes="side-action" Content="Delete" IsEnabled="False" />
+        <Button Classes="side-action" Content="Delete" Command="{Binding OpenDeleteConfirmCommand}" IsEnabled="{Binding HasSelection}" />
         <Button Classes="side-action" Content="Revoke" Command="{Binding OpenRevokeDialogCommand}" />
         <Button Classes="side-action" Content="Generate CRL" Command="{Binding GenerateCertificateRevocationListCommand}" />
         <Button Classes="side-action" Content="Renew" IsEnabled="False" />
@@ -314,6 +314,26 @@
             <Button Grid.Column="1" Content="Revoke" Command="{Binding RevokeSelectedCommand}" />
             <Button Grid.Column="2" Content="Cancel" Command="{Binding CloseRevokeDialogCommand}" />
           </Grid>
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- Delete confirmation dialog overlay -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsDeleteConfirmDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="420"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+          <TextBlock Text="Delete Certificate" FontSize="16" FontWeight="SemiBold" />
+          <TextBlock Grid.Row="1" Text="{Binding SelectedItem.DisplayName, StringFormat='Delete &quot;{0}&quot;? This action cannot be undone.'}" TextWrapping="Wrap" />
+          <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+            <Button Content="Cancel" Command="{Binding CloseDeleteConfirmCommand}" />
+            <Button Content="Delete" Command="{Binding DeleteSelectedCommand}" Classes="danger" />
+          </StackPanel>
         </Grid>
       </Border>
     </Grid>

--- a/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
@@ -28,8 +28,8 @@
                 <MenuItem Header="Create CSR" Command="{Binding OpenCertificateSigningRequestAuthoringCommand}" />
                 <MenuItem Header="Create Certificate" Command="{Binding OpenSelfSignedCaAuthoringCommand}" />
                 <Separator />
-                <MenuItem Header="Import" IsEnabled="False" />
-                <MenuItem Header="Delete" IsEnabled="False" />
+                <MenuItem Header="Import" Command="{Binding ImportCommand}" />
+                <MenuItem Header="Delete" Command="{Binding OpenDeleteConfirmCommand}" />
               </ContextMenu>
             </ListBox.ContextMenu>
             <ListBox.ItemTemplate>
@@ -55,9 +55,9 @@
       <StackPanel>
         <Button Classes="side-action" Content="New Key" Command="{Binding OpenNewKeyDialogCommand}" />
         <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedToFileCommand}" />
-        <Button Classes="side-action" Content="Import" IsEnabled="False" />
+        <Button Classes="side-action" Content="Import" Command="{Binding ImportCommand}" />
         <Button Classes="side-action" Content="Show Details" Command="{Binding ShowDetailsCommand}" IsEnabled="{Binding HasSelection}" />
-        <Button Classes="side-action" Content="Delete" IsEnabled="False" />
+        <Button Classes="side-action" Content="Delete" Command="{Binding OpenDeleteConfirmCommand}" IsEnabled="{Binding HasSelection}" />
         <Button Classes="side-action" Content="Create CSR" Command="{Binding OpenCertificateSigningRequestAuthoringCommand}" />
         <Button Classes="side-action" Content="Create Certificate" Command="{Binding OpenSelfSignedCaAuthoringCommand}" />
         <Button Classes="side-action" Content="Refresh" Command="{Binding RefreshCommand}" />
@@ -165,6 +165,26 @@
             <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding SelectedItem.PublicKeyFingerprint}" TextWrapping="Wrap" />
           </Grid>
           <Button Grid.Row="2" Content="OK" Command="{Binding CloseKeyDetailCommand}" HorizontalAlignment="Right" MinWidth="80" />
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- Delete confirmation dialog overlay -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsDeleteConfirmDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="400"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+          <TextBlock Text="Delete Private Key" FontSize="16" FontWeight="SemiBold" />
+          <TextBlock Grid.Row="1" Text="{Binding SelectedItem.DisplayName, StringFormat='Delete &quot;{0}&quot;? This action cannot be undone.'}" TextWrapping="Wrap" />
+          <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+            <Button Content="Cancel" Command="{Binding CloseDeleteConfirmCommand}" />
+            <Button Content="Delete" Command="{Binding DeleteSelectedCommand}" Classes="danger" />
+          </StackPanel>
         </Grid>
       </Border>
     </Grid>

--- a/src/XcaNet.App/Views/Shared/CertificateAuthoringSurfaceView.axaml
+++ b/src/XcaNet.App/Views/Shared/CertificateAuthoringSurfaceView.axaml
@@ -4,7 +4,7 @@
   <Grid RowDefinitions="*,Auto" RowSpacing="10">
     <TabControl Classes="authoring-tabs">
       <TabItem Header="Source">
-        <Grid Margin="10" RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="8">
+        <Grid Margin="10" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="8">
           <Grid ColumnDefinitions="150,*" ColumnSpacing="10">
             <TextBlock Text="Operation" VerticalAlignment="Center" />
             <TextBlock Grid.Column="1" Text="{Binding OperationModeSummary}" TextWrapping="Wrap" />
@@ -29,34 +29,71 @@
             <TextBlock Text="Validity days" VerticalAlignment="Center" />
             <NumericUpDown Grid.Column="1" Minimum="1" Maximum="36500" Value="{Binding ValidityDays}" />
           </Grid>
+          <Grid Grid.Row="4" ColumnDefinitions="150,220" ColumnSpacing="10" IsVisible="{Binding ShowValiditySection}">
+            <TextBlock Text="Not before" VerticalAlignment="Center" />
+            <CalendarDatePicker Grid.Column="1" SelectedDate="{Binding NotBeforeDate}" />
+          </Grid>
+          <Grid Grid.Row="5" ColumnDefinitions="150,220" ColumnSpacing="10" IsVisible="{Binding ShowValiditySection}">
+            <TextBlock Text="Not after" VerticalAlignment="Center" />
+            <CalendarDatePicker Grid.Column="1" SelectedDate="{Binding NotAfterDate}" />
+          </Grid>
         </Grid>
       </TabItem>
 
       <TabItem Header="Subject">
-        <Grid Margin="10" RowDefinitions="Auto,Auto,Auto" RowSpacing="8">
-          <Grid ColumnDefinitions="150,*" ColumnSpacing="10">
-            <TextBlock Text="Name" VerticalAlignment="Center" />
-            <TextBox Grid.Column="1" Text="{Binding DisplayName}" />
+        <ScrollViewer>
+          <Grid Margin="10" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="8">
+            <Grid ColumnDefinitions="150,*" ColumnSpacing="10">
+              <TextBlock Text="Name" VerticalAlignment="Center" />
+              <TextBox Grid.Column="1" Text="{Binding DisplayName}" />
+            </Grid>
+            <Grid Grid.Row="1" ColumnDefinitions="150,*" ColumnSpacing="10">
+              <TextBlock Text="Common Name" VerticalAlignment="Center" />
+              <TextBox Grid.Column="1" Text="{Binding DnCommonName}" Watermark="CN" />
+            </Grid>
+            <Grid Grid.Row="2" ColumnDefinitions="150,*" ColumnSpacing="10">
+              <TextBlock Text="Organization" VerticalAlignment="Center" />
+              <TextBox Grid.Column="1" Text="{Binding DnOrganization}" Watermark="O" />
+            </Grid>
+            <Grid Grid.Row="3" ColumnDefinitions="150,*" ColumnSpacing="10">
+              <TextBlock Text="Org. Unit" VerticalAlignment="Center" />
+              <TextBox Grid.Column="1" Text="{Binding DnOrganizationalUnit}" Watermark="OU" />
+            </Grid>
+            <Grid Grid.Row="4" ColumnDefinitions="150,*" ColumnSpacing="10">
+              <TextBlock Text="Country" VerticalAlignment="Center" />
+              <TextBox Grid.Column="1" Text="{Binding DnCountry}" Watermark="C (2-letter code)" MaxLength="2" />
+            </Grid>
+            <Grid Grid.Row="5" ColumnDefinitions="150,*" ColumnSpacing="10">
+              <TextBlock Text="State / Province" VerticalAlignment="Center" />
+              <TextBox Grid.Column="1" Text="{Binding DnState}" Watermark="ST" />
+            </Grid>
+            <Grid Grid.Row="6" ColumnDefinitions="150,*" ColumnSpacing="10">
+              <TextBlock Text="Locality" VerticalAlignment="Center" />
+              <TextBox Grid.Column="1" Text="{Binding DnLocality}" Watermark="L" />
+            </Grid>
+            <Grid Grid.Row="7" ColumnDefinitions="150,*" ColumnSpacing="10">
+              <TextBlock Text="Email" VerticalAlignment="Center" />
+              <TextBox Grid.Column="1" Text="{Binding DnEmail}" Watermark="E" />
+            </Grid>
+            <Grid Grid.Row="8" ColumnDefinitions="150,*" ColumnSpacing="10">
+              <TextBlock Text="Subject (raw)" VerticalAlignment="Center" />
+              <TextBox Grid.Column="1" Text="{Binding SubjectName}" />
+            </Grid>
+            <Grid Grid.Row="9" ColumnDefinitions="150,*" ColumnSpacing="10">
+              <TextBlock Text="Alternative names" VerticalAlignment="Top" Margin="0,6,0,0" />
+              <TextBox Grid.Column="1" Text="{Binding SubjectAlternativeNames}" AcceptsReturn="True" Height="80" TextWrapping="Wrap" />
+            </Grid>
           </Grid>
-          <Grid Grid.Row="1" ColumnDefinitions="150,*" ColumnSpacing="10">
-            <TextBlock Text="Subject" VerticalAlignment="Center" />
-            <TextBox Grid.Column="1" Text="{Binding SubjectName}" />
-          </Grid>
-          <Grid Grid.Row="2" ColumnDefinitions="150,*" ColumnSpacing="10">
-            <TextBlock Text="Alternative names" VerticalAlignment="Top" Margin="0,6,0,0" />
-            <TextBox Grid.Column="1" Text="{Binding SubjectAlternativeNames}" AcceptsReturn="True" Height="100" TextWrapping="Wrap" />
-          </Grid>
-        </Grid>
+        </ScrollViewer>
       </TabItem>
 
       <TabItem Header="Extensions">
         <Grid Margin="10" RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="8">
           <CheckBox Content="Certificate authority" IsChecked="{Binding IsCertificateAuthority}" />
-          <Grid Grid.Row="1" ColumnDefinitions="150,Auto,120,*" ColumnSpacing="10">
+          <Grid Grid.Row="1" ColumnDefinitions="150,Auto,120" ColumnSpacing="10">
             <TextBlock Text="Path length" VerticalAlignment="Center" />
             <CheckBox Grid.Column="1" Content="Constrained" IsChecked="{Binding HasPathLengthConstraint}" />
             <NumericUpDown Grid.Column="2" Minimum="0" Maximum="16" Value="{Binding PathLengthConstraint}" IsEnabled="{Binding HasPathLengthConstraint}" />
-            <TextBox Grid.Column="3" Text="{Binding SignatureAlgorithm}" Watermark="Signature algorithm" IsVisible="{Binding ShowSignatureAlgorithm}" />
           </Grid>
           <Grid Grid.Row="2" ColumnDefinitions="150,*" ColumnSpacing="10">
             <TextBlock Text="Key algorithm" VerticalAlignment="Center" />
@@ -66,33 +103,39 @@
               <ComboBox Grid.Column="2" ItemsSource="{Binding Curves}" SelectedItem="{Binding Curve}" IsVisible="{Binding IsEcdsa}" />
             </Grid>
           </Grid>
+          <Grid Grid.Row="3" ColumnDefinitions="150,220" ColumnSpacing="10" IsVisible="{Binding ShowSignatureAlgorithm}">
+            <TextBlock Text="Signature algorithm" VerticalAlignment="Center" />
+            <ComboBox Grid.Column="1" ItemsSource="{Binding SignatureAlgorithms}" SelectedItem="{Binding SignatureAlgorithm}" />
+          </Grid>
         </Grid>
       </TabItem>
 
       <TabItem Header="Key usage">
-        <Grid Margin="10" RowDefinitions="Auto,Auto" RowSpacing="8">
-          <Grid ColumnDefinitions="150,*" ColumnSpacing="10">
-            <TextBlock Text="Key usage" VerticalAlignment="Top" Margin="0,6,0,0" />
-            <TextBox Grid.Column="1" Text="{Binding KeyUsages}" AcceptsReturn="True" Height="100" TextWrapping="Wrap" />
+        <ScrollViewer>
+          <Grid Margin="10" RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="12">
+            <TextBlock Text="Key Usage" FontWeight="SemiBold" />
+            <WrapPanel Grid.Row="1" Orientation="Horizontal">
+              <CheckBox Content="Digital Signature" IsChecked="{Binding KuDigitalSignature}" Margin="0,0,16,4" />
+              <CheckBox Content="Non-Repudiation" IsChecked="{Binding KuNonRepudiation}" Margin="0,0,16,4" />
+              <CheckBox Content="Key Encipherment" IsChecked="{Binding KuKeyEncipherment}" Margin="0,0,16,4" />
+              <CheckBox Content="Data Encipherment" IsChecked="{Binding KuDataEncipherment}" Margin="0,0,16,4" />
+              <CheckBox Content="Key Agreement" IsChecked="{Binding KuKeyAgreement}" Margin="0,0,16,4" />
+              <CheckBox Content="Key Cert Sign" IsChecked="{Binding KuKeyCertSign}" Margin="0,0,16,4" />
+              <CheckBox Content="CRL Sign" IsChecked="{Binding KuCrlSign}" Margin="0,0,16,4" />
+              <CheckBox Content="Encipher Only" IsChecked="{Binding KuEncipherOnly}" Margin="0,0,16,4" />
+              <CheckBox Content="Decipher Only" IsChecked="{Binding KuDecipherOnly}" Margin="0,0,16,4" />
+            </WrapPanel>
+            <TextBlock Grid.Row="2" Text="Extended Key Usage" FontWeight="SemiBold" />
+            <WrapPanel Grid.Row="3" Orientation="Horizontal">
+              <CheckBox Content="Server Authentication" IsChecked="{Binding EkuServerAuth}" Margin="0,0,16,4" />
+              <CheckBox Content="Client Authentication" IsChecked="{Binding EkuClientAuth}" Margin="0,0,16,4" />
+              <CheckBox Content="Code Signing" IsChecked="{Binding EkuCodeSigning}" Margin="0,0,16,4" />
+              <CheckBox Content="Email Protection" IsChecked="{Binding EkuEmailProtection}" Margin="0,0,16,4" />
+              <CheckBox Content="Time Stamping" IsChecked="{Binding EkuTimeStamping}" Margin="0,0,16,4" />
+              <CheckBox Content="OCSP Signing" IsChecked="{Binding EkuOcspSigning}" Margin="0,0,16,4" />
+            </WrapPanel>
           </Grid>
-          <Grid Grid.Row="1" ColumnDefinitions="150,*" ColumnSpacing="10">
-            <TextBlock Text="Extended key usage" VerticalAlignment="Top" Margin="0,6,0,0" />
-            <TextBox Grid.Column="1" Text="{Binding EnhancedKeyUsages}" AcceptsReturn="True" Height="100" TextWrapping="Wrap" />
-          </Grid>
-        </Grid>
-      </TabItem>
-
-      <TabItem Header="Advanced">
-        <Grid Margin="10" RowDefinitions="Auto,Auto" RowSpacing="8">
-          <Grid ColumnDefinitions="150,*" ColumnSpacing="10">
-            <TextBlock Text="Raw key usage" VerticalAlignment="Top" Margin="0,6,0,0" />
-            <TextBox Grid.Column="1" Text="{Binding KeyUsages}" AcceptsReturn="True" Height="110" TextWrapping="Wrap" />
-          </Grid>
-          <Grid Grid.Row="1" ColumnDefinitions="150,*" ColumnSpacing="10">
-            <TextBlock Text="Raw extended usage" VerticalAlignment="Top" Margin="0,6,0,0" />
-            <TextBox Grid.Column="1" Text="{Binding EnhancedKeyUsages}" AcceptsReturn="True" Height="110" TextWrapping="Wrap" />
-          </Grid>
-        </Grid>
+        </ScrollViewer>
       </TabItem>
 
       <TabItem Header="Signing / Issuer" IsVisible="{Binding ShowSigningSection}">
@@ -117,6 +160,12 @@
               </ComboBox.ItemTemplate>
             </ComboBox>
           </Grid>
+        </Grid>
+      </TabItem>
+
+      <TabItem Header="Comment">
+        <Grid Margin="10">
+          <TextBox Text="{Binding Comment}" AcceptsReturn="True" TextWrapping="Wrap" />
         </Grid>
       </TabItem>
     </TabControl>

--- a/src/XcaNet.Application/Services/DatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/DatabaseSessionService.cs
@@ -1419,6 +1419,24 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
         }
     }
 
+    public async Task<OperationResult> DeleteCertificateAsync(Guid certificateId, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (!TryGetOpenDatabasePath<object>(out var databasePath, out var failure))
+                return OperationResult.Failure(failure!.ErrorCode, failure.Message);
+
+            return await _certificateRepository.DeleteAsync(databasePath, certificateId, cancellationToken)
+                ? OperationResult.Success("Certificate deleted.")
+                : OperationResult.Failure(OperationErrorCode.DatabaseNotFound, "Certificate not found.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     public async Task<OperationResult> DeletePrivateKeyAsync(Guid privateKeyId, CancellationToken cancellationToken)
     {
         await _gate.WaitAsync(cancellationToken);

--- a/src/XcaNet.Application/Services/DatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/DatabaseSessionService.cs
@@ -537,6 +537,7 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
                     request.IssuerCertificateId),
                 cancellationToken);
 
+            await _certificateRequestRepository.MarkSignedAsync(databasePath, request.CertificateSigningRequestId, cancellationToken);
             await _auditEventRepository.AddAsync(databasePath, CreateAuditEvent(AuditEventKind.CertificateSigningRequestSigned, "Certificate signing request signed."), cancellationToken);
 
             return OperationResult<StoredCertificateResult>.Success(
@@ -1192,7 +1193,8 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
                     x.PrivateKeyId == Guid.Empty ? null : new NavigationTarget(BrowserEntityType.PrivateKey, x.PrivateKeyId, NavigationFocusSection.Overview),
                     x.KeyAlgorithm,
                     x.SubjectAlternativeNames,
-                    DateTime.SpecifyKind(x.CreatedUtc, DateTimeKind.Utc)))
+                    DateTime.SpecifyKind(x.CreatedUtc, DateTimeKind.Utc),
+                    x.IsSigned))
                 .ToList();
 
             return OperationResult<IReadOnlyList<CertificateRequestListItem>>.Success(items, "Certificate signing requests loaded.");
@@ -1410,6 +1412,42 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
 
             var template = await _templateRepository.GetAsync(databasePath, request.TemplateId, cancellationToken);
             return OperationResult<TemplateDetails>.Success(TemplateModelMapper.ToDetails(template!), "Template enabled state updated.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<OperationResult> DeletePrivateKeyAsync(Guid privateKeyId, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (!TryGetOpenDatabasePath<object>(out var databasePath, out var failure))
+                return OperationResult.Failure(failure!.ErrorCode, failure.Message);
+
+            return await _privateKeyRepository.DeleteAsync(databasePath, privateKeyId, cancellationToken)
+                ? OperationResult.Success("Private key deleted.")
+                : OperationResult.Failure(OperationErrorCode.DatabaseNotFound, "Private key not found.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<OperationResult> DeleteCertificateSigningRequestAsync(Guid csrId, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (!TryGetOpenDatabasePath<object>(out var databasePath, out var failure))
+                return OperationResult.Failure(failure!.ErrorCode, failure.Message);
+
+            return await _certificateRequestRepository.DeleteAsync(databasePath, csrId, cancellationToken)
+                ? OperationResult.Success("Certificate signing request deleted.")
+                : OperationResult.Failure(OperationErrorCode.DatabaseNotFound, "Certificate signing request not found.");
         }
         finally
         {

--- a/src/XcaNet.Application/Services/IDatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/IDatabaseSessionService.cs
@@ -70,6 +70,8 @@ public interface IDatabaseSessionService
 
     Task<OperationResult<TemplateDetails>> SetTemplateEnabledAsync(SetTemplateEnabledRequest request, CancellationToken cancellationToken);
 
+    Task<OperationResult> DeleteCertificateAsync(Guid certificateId, CancellationToken cancellationToken);
+
     Task<OperationResult> DeletePrivateKeyAsync(Guid privateKeyId, CancellationToken cancellationToken);
 
     Task<OperationResult> DeleteCertificateSigningRequestAsync(Guid csrId, CancellationToken cancellationToken);

--- a/src/XcaNet.Application/Services/IDatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/IDatabaseSessionService.cs
@@ -70,6 +70,10 @@ public interface IDatabaseSessionService
 
     Task<OperationResult<TemplateDetails>> SetTemplateEnabledAsync(SetTemplateEnabledRequest request, CancellationToken cancellationToken);
 
+    Task<OperationResult> DeletePrivateKeyAsync(Guid privateKeyId, CancellationToken cancellationToken);
+
+    Task<OperationResult> DeleteCertificateSigningRequestAsync(Guid csrId, CancellationToken cancellationToken);
+
     Task<OperationResult> DeleteTemplateAsync(Guid templateId, CancellationToken cancellationToken);
 
     Task<OperationResult<AppliedTemplateDefaults>> ApplyTemplateAsync(ApplyTemplateRequest request, CancellationToken cancellationToken);

--- a/src/XcaNet.Contracts/Browser/CertificateRequestListItem.cs
+++ b/src/XcaNet.Contracts/Browser/CertificateRequestListItem.cs
@@ -8,7 +8,8 @@ public sealed record CertificateRequestListItem(
     NavigationTarget? PrivateKeyTarget,
     string KeyAlgorithm,
     string SubjectAlternativeNames,
-    DateTimeOffset CreatedUtc)
+    DateTimeOffset CreatedUtc,
+    bool IsSigned)
 {
     public string PrivateKeySummary => PrivateKeyId is null ? "Imported" : "Stored key";
 }

--- a/src/XcaNet.Storage/Persistence/Entities/CertificateRequestEntity.cs
+++ b/src/XcaNet.Storage/Persistence/Entities/CertificateRequestEntity.cs
@@ -11,4 +11,5 @@ public sealed class CertificateRequestEntity
     public string KeyAlgorithm { get; set; } = string.Empty;
     public string SubjectAlternativeNames { get; set; } = string.Empty;
     public DateTime CreatedUtc { get; set; }
+    public bool IsSigned { get; set; }
 }

--- a/src/XcaNet.Storage/Persistence/Migrations/20260425000000_CsrSignedFlag.Designer.cs
+++ b/src/XcaNet.Storage/Persistence/Migrations/20260425000000_CsrSignedFlag.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using XcaNet.Storage.Persistence;
 
@@ -10,9 +11,11 @@ using XcaNet.Storage.Persistence;
 namespace XcaNet.Storage.Persistence.Migrations
 {
     [DbContext(typeof(XcaNetDbContext))]
-    partial class XcaNetDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425000000_CsrSignedFlag")]
+    partial class CsrSignedFlag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.0");

--- a/src/XcaNet.Storage/Persistence/Migrations/20260425000000_CsrSignedFlag.cs
+++ b/src/XcaNet.Storage/Persistence/Migrations/20260425000000_CsrSignedFlag.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XcaNet.Storage.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class CsrSignedFlag : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsSigned",
+                table: "CertificateRequests",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsSigned",
+                table: "CertificateRequests");
+        }
+    }
+}

--- a/src/XcaNet.Storage/Repositories/CertificateRepository.cs
+++ b/src/XcaNet.Storage/Repositories/CertificateRepository.cs
@@ -100,6 +100,18 @@ public sealed class CertificateRepository : ICertificateRepository
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<bool> DeleteAsync(string databasePath, Guid certificateId, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var existing = await dbContext.Certificates.SingleOrDefaultAsync(x => x.Id == certificateId, cancellationToken);
+        if (existing is null)
+            return false;
+
+        dbContext.Certificates.Remove(existing);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
     public async Task UpdateRevocationAsync(
         string databasePath,
         Guid certificateId,

--- a/src/XcaNet.Storage/Repositories/CertificateRequestRepository.cs
+++ b/src/XcaNet.Storage/Repositories/CertificateRequestRepository.cs
@@ -34,4 +34,28 @@ public sealed class CertificateRequestRepository : ICertificateRequestRepository
             .OrderByDescending(x => x.CreatedUtc)
             .ToListAsync(cancellationToken);
     }
+
+    public async Task<bool> DeleteAsync(string databasePath, Guid certificateRequestId, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var existing = await dbContext.CertificateRequests.SingleOrDefaultAsync(x => x.Id == certificateRequestId, cancellationToken);
+        if (existing is null)
+            return false;
+
+        dbContext.CertificateRequests.Remove(existing);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    public async Task<bool> MarkSignedAsync(string databasePath, Guid certificateRequestId, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var existing = await dbContext.CertificateRequests.SingleOrDefaultAsync(x => x.Id == certificateRequestId, cancellationToken);
+        if (existing is null)
+            return false;
+
+        existing.IsSigned = true;
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return true;
+    }
 }

--- a/src/XcaNet.Storage/Repositories/ICertificateRepository.cs
+++ b/src/XcaNet.Storage/Repositories/ICertificateRepository.cs
@@ -20,4 +20,6 @@ public interface ICertificateRepository
         int? revocationReason,
         DateTime? revokedAtUtc,
         CancellationToken cancellationToken);
+
+    Task<bool> DeleteAsync(string databasePath, Guid certificateId, CancellationToken cancellationToken);
 }

--- a/src/XcaNet.Storage/Repositories/ICertificateRequestRepository.cs
+++ b/src/XcaNet.Storage/Repositories/ICertificateRequestRepository.cs
@@ -9,4 +9,8 @@ public interface ICertificateRequestRepository
     Task<CertificateRequestEntity?> GetAsync(string databasePath, Guid certificateRequestId, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<CertificateRequestEntity>> ListAsync(string databasePath, CancellationToken cancellationToken);
+
+    Task<bool> DeleteAsync(string databasePath, Guid certificateRequestId, CancellationToken cancellationToken);
+
+    Task<bool> MarkSignedAsync(string databasePath, Guid certificateRequestId, CancellationToken cancellationToken);
 }

--- a/src/XcaNet.Storage/Repositories/IPrivateKeyRepository.cs
+++ b/src/XcaNet.Storage/Repositories/IPrivateKeyRepository.cs
@@ -9,4 +9,6 @@ public interface IPrivateKeyRepository
     Task<PrivateKeyEntity?> GetAsync(string databasePath, Guid privateKeyId, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<PrivateKeyEntity>> ListAsync(string databasePath, CancellationToken cancellationToken);
+
+    Task<bool> DeleteAsync(string databasePath, Guid privateKeyId, CancellationToken cancellationToken);
 }

--- a/src/XcaNet.Storage/Repositories/PrivateKeyRepository.cs
+++ b/src/XcaNet.Storage/Repositories/PrivateKeyRepository.cs
@@ -34,4 +34,16 @@ public sealed class PrivateKeyRepository : IPrivateKeyRepository
             .OrderByDescending(x => x.CreatedUtc)
             .ToListAsync(cancellationToken);
     }
+
+    public async Task<bool> DeleteAsync(string databasePath, Guid privateKeyId, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var existing = await dbContext.PrivateKeys.SingleOrDefaultAsync(x => x.Id == privateKeyId, cancellationToken);
+        if (existing is null)
+            return false;
+
+        dbContext.PrivateKeys.Remove(existing);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary

- Add structured DN fields (CN, O, OU, C, ST, L, E) with bidirectional sync to/from raw SubjectName string
- Add `CalendarDatePicker` controls for NotBefore/NotAfter dates with bidirectional sync to/from ValidityDays
- Replace SignatureAlgorithm `TextBox` with `ComboBox` (SHA-256/384/512) in Extensions tab
- Replace Key Usage and Enhanced Key Usage `TextBox`es with checkbox grids (9 KU flags, 6 EKU flags) with bidirectional sync
- Add Comment tab with free-form `TextBox`
- Remove duplicate Advanced tab

## Test plan

- [ ] Open self-signed CA authoring dialog — DN fields pre-populate from existing subject string
- [ ] Edit Common Name field — SubjectName raw field updates accordingly
- [ ] Edit raw SubjectName — DN fields parse and update
- [ ] Change ValidityDays — NotAfter date moves forward
- [ ] Change NotAfter date — ValidityDays recalculates
- [ ] Toggle KU checkboxes — KeyUsages string updates
- [ ] Toggle EKU checkboxes — EnhancedKeyUsages string updates
- [ ] Signature algorithm ComboBox shows SHA-256/384/512
- [ ] Comment tab accepts free-form text
- [ ] All existing tests pass