### PR TITLE
feat: M14 CA workflow, revocation, and CRL parity

### DIFF
--- a/src/XcaNet.App/ViewModels/Pages/CertificateRevocationListsPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateRevocationListsPageViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Windows.Input;
+using XcaNet.App.Commands;
 using XcaNet.Contracts.Browser;
 
 namespace XcaNet.App.ViewModels.Pages;
@@ -7,15 +8,28 @@ namespace XcaNet.App.ViewModels.Pages;
 public sealed class CertificateRevocationListsPageViewModel : SelectableItemsPageViewModelBase<CertificateRevocationListItem, Guid>
 {
     private CertificateRevocationListInspectorData? _inspector;
+    private bool _isDetailDialogOpen;
+    private bool _isDeleteConfirmDialogOpen;
+    private bool _isGenerateCrlDialogOpen;
+    private CertificateListItem? _crlGenerateSelectedCa;
+    private int _crlGenerateNextUpdateDays = 7;
+    private DateTime? _crlGenerateNextUpdateDate = DateTime.Today.AddDays(7);
 
     public CertificateRevocationListsPageViewModel()
         : base("Revocation lists")
     {
         EmptyStateTitle = "No CRLs available";
         EmptyStateMessage = "Generate a CRL from a CA certificate after revoking one or more issued certificates.";
+
+        OpenDeleteConfirmCommand = new DelegateCommand(() => { if (SelectedItem is not null) IsDeleteConfirmDialogOpen = true; });
+        CloseDeleteConfirmCommand = new DelegateCommand(() => IsDeleteConfirmDialogOpen = false);
+        CloseDetailCommand = new DelegateCommand(() => IsDetailDialogOpen = false);
+        CloseGenerateCrlDialogCommand = new DelegateCommand(() => IsGenerateCrlDialogOpen = false);
     }
 
     public string PlaceholderMessage => "Generate CRLs from the certificates page for CA certificates with an available issuer key.";
+
+    public ObservableCollection<CertificateListItem> CaItems { get; } = [];
 
     public CertificateRevocationListInspectorData? Inspector
     {
@@ -23,9 +37,82 @@ public sealed class CertificateRevocationListsPageViewModel : SelectableItemsPag
         set => SetProperty(ref _inspector, value);
     }
 
+    public bool IsDetailDialogOpen
+    {
+        get => _isDetailDialogOpen;
+        set => SetProperty(ref _isDetailDialogOpen, value);
+    }
+
+    public bool IsDeleteConfirmDialogOpen
+    {
+        get => _isDeleteConfirmDialogOpen;
+        set => SetProperty(ref _isDeleteConfirmDialogOpen, value);
+    }
+
+    public bool IsGenerateCrlDialogOpen
+    {
+        get => _isGenerateCrlDialogOpen;
+        set => SetProperty(ref _isGenerateCrlDialogOpen, value);
+    }
+
+    public CertificateListItem? CrlGenerateSelectedCa
+    {
+        get => _crlGenerateSelectedCa;
+        set => SetProperty(ref _crlGenerateSelectedCa, value);
+    }
+
+    public int CrlGenerateNextUpdateDays
+    {
+        get => _crlGenerateNextUpdateDays;
+        set
+        {
+            if (SetProperty(ref _crlGenerateNextUpdateDays, value))
+            {
+                _crlGenerateNextUpdateDate = DateTime.Today.AddDays(value);
+                OnPropertyChanged(nameof(CrlGenerateNextUpdateDate));
+            }
+        }
+    }
+
+    public DateTime? CrlGenerateNextUpdateDate
+    {
+        get => _crlGenerateNextUpdateDate;
+        set
+        {
+            if (SetProperty(ref _crlGenerateNextUpdateDate, value))
+            {
+                if (value is { } d)
+                {
+                    _crlGenerateNextUpdateDays = Math.Max(1, (int)Math.Round((d - DateTime.Today).TotalDays, MidpointRounding.AwayFromZero));
+                    OnPropertyChanged(nameof(CrlGenerateNextUpdateDays));
+                }
+            }
+        }
+    }
+
+    // --- Commands ---
+
     public ICommand? ExportSelectedCommand { get; set; }
 
+    public ICommand? ImportCommand { get; set; }
+
     public ICommand? OpenIssuerCommand { get; set; }
+
+    public ICommand? ShowDetailsCommand { get; set; }
+
+    public DelegateCommand CloseDetailCommand { get; }
+
+    public ICommand? DeleteSelectedCommand { get; set; }
+
+    public DelegateCommand OpenDeleteConfirmCommand { get; }
+
+    public DelegateCommand CloseDeleteConfirmCommand { get; }
+
+    public ICommand? OpenGenerateCrlDialogCommand { get; set; }
+
+    public DelegateCommand CloseGenerateCrlDialogCommand { get; }
+
+    public ICommand? GenerateCrlCommand { get; set; }
 
     protected override Guid GetItemId(CertificateRevocationListItem item) => item.CertificateRevocationListId;
 }

--- a/src/XcaNet.App/ViewModels/Pages/CertificatesPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificatesPageViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Windows.Input;
+using XcaNet.App.Commands;
 using XcaNet.Contracts.Browser;
 using XcaNet.Contracts.Revocation;
 
@@ -20,17 +21,34 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
     private string _exportPreview = string.Empty;
     private CertificateRevocationReason _selectedRevocationReason = CertificateRevocationReason.Unspecified;
     private DateTimeOffset _selectedRevocationDate = DateTimeOffset.UtcNow;
+    private DateTime? _revocationDate = DateTime.Now;
     private RelatedNavigationItem? _selectedChildNavigationItem;
     private CertificateTreeNodeViewModel? _selectedTreeNode;
     private bool _isPlainView;
     private bool _isDetailDialogOpen;
     private bool _isRevokeDialogOpen;
+    private bool _isUnrevokeConfirmDialogOpen;
+    private bool _isManageRevocationsDialogOpen;
+    private bool _isCaPropertiesDialogOpen;
+    private bool _isRenewalDialogOpen;
+    private int _caPropertiesCrlDays = 7;
+    private Guid? _caPropertiesDefaultTemplateId;
+    private DateTime? _renewalNotBefore = DateTime.Today;
+    private DateTime? _renewalNotAfter = DateTime.Today.AddYears(1);
+    private bool _renewalRevokeOld;
+    private bool _renewalReplaceOld;
 
     public CertificatesPageViewModel()
         : base("Certificates")
     {
         EmptyStateTitle = "No certificates yet";
         EmptyStateMessage = "Import certificate material, create a self-signed CA, or sign a CSR to populate this workspace.";
+
+        OpenUnrevokeConfirmCommand = new DelegateCommand(() => { if (SelectedItem is not null) IsUnrevokeConfirmDialogOpen = true; });
+        CloseUnrevokeConfirmCommand = new DelegateCommand(() => IsUnrevokeConfirmDialogOpen = false);
+        CloseManageRevocationsCommand = new DelegateCommand(() => IsManageRevocationsDialogOpen = false);
+        CloseCaPropertiesCommand = new DelegateCommand(() => IsCaPropertiesDialogOpen = false);
+        CloseRenewalDialogCommand = new DelegateCommand(() => IsRenewalDialogOpen = false);
     }
 
     public IReadOnlyList<CertificateValidityFilter> ValidityFilters { get; } =
@@ -54,9 +72,13 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
     public IReadOnlyList<CertificateRevocationReason> RevocationReasons { get; } =
         Enum.GetValues<CertificateRevocationReason>();
 
-    // --- Tree ---
+    // --- Collections ---
 
     public ObservableCollection<CertificateTreeNodeViewModel> CertificateTreeRoots { get; } = [];
+
+    public ObservableCollection<CertificateListItem> ManageRevocationsEntries { get; } = [];
+
+    // --- Tree ---
 
     public CertificateTreeNodeViewModel? SelectedTreeNode
     {
@@ -90,6 +112,70 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
     {
         get => _isRevokeDialogOpen;
         set => SetProperty(ref _isRevokeDialogOpen, value);
+    }
+
+    public bool IsUnrevokeConfirmDialogOpen
+    {
+        get => _isUnrevokeConfirmDialogOpen;
+        set => SetProperty(ref _isUnrevokeConfirmDialogOpen, value);
+    }
+
+    public bool IsManageRevocationsDialogOpen
+    {
+        get => _isManageRevocationsDialogOpen;
+        set => SetProperty(ref _isManageRevocationsDialogOpen, value);
+    }
+
+    public bool IsCaPropertiesDialogOpen
+    {
+        get => _isCaPropertiesDialogOpen;
+        set => SetProperty(ref _isCaPropertiesDialogOpen, value);
+    }
+
+    public bool IsRenewalDialogOpen
+    {
+        get => _isRenewalDialogOpen;
+        set => SetProperty(ref _isRenewalDialogOpen, value);
+    }
+
+    // --- CA Properties fields ---
+
+    public int CaPropertiesCrlDays
+    {
+        get => _caPropertiesCrlDays;
+        set => SetProperty(ref _caPropertiesCrlDays, value);
+    }
+
+    public Guid? CaPropertiesDefaultTemplateId
+    {
+        get => _caPropertiesDefaultTemplateId;
+        set => SetProperty(ref _caPropertiesDefaultTemplateId, value);
+    }
+
+    // --- Renewal fields ---
+
+    public DateTime? RenewalNotBefore
+    {
+        get => _renewalNotBefore;
+        set => SetProperty(ref _renewalNotBefore, value);
+    }
+
+    public DateTime? RenewalNotAfter
+    {
+        get => _renewalNotAfter;
+        set => SetProperty(ref _renewalNotAfter, value);
+    }
+
+    public bool RenewalRevokeOld
+    {
+        get => _renewalRevokeOld;
+        set => SetProperty(ref _renewalRevokeOld, value);
+    }
+
+    public bool RenewalReplaceOld
+    {
+        get => _renewalReplaceOld;
+        set => SetProperty(ref _renewalReplaceOld, value);
     }
 
     // --- Existing data properties ---
@@ -172,6 +258,18 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
         set => SetProperty(ref _selectedRevocationDate, value);
     }
 
+    public DateTime? RevocationDate
+    {
+        get => _revocationDate;
+        set
+        {
+            if (SetProperty(ref _revocationDate, value))
+                SelectedRevocationDate = value.HasValue
+                    ? new DateTimeOffset(DateTime.SpecifyKind(value.Value, DateTimeKind.Utc))
+                    : DateTimeOffset.UtcNow;
+        }
+    }
+
     public RelatedNavigationItem? SelectedChildNavigationItem
     {
         get => _selectedChildNavigationItem;
@@ -191,6 +289,28 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
     public ICommand? OpenRevokeDialogCommand { get; set; }
 
     public ICommand? CloseRevokeDialogCommand { get; set; }
+
+    public ICommand? UnrevokeSelectedCommand { get; set; }
+
+    public DelegateCommand OpenUnrevokeConfirmCommand { get; }
+
+    public DelegateCommand CloseUnrevokeConfirmCommand { get; }
+
+    public ICommand? OpenManageRevocationsCommand { get; set; }
+
+    public DelegateCommand CloseManageRevocationsCommand { get; }
+
+    public ICommand? OpenCaPropertiesCommand { get; set; }
+
+    public DelegateCommand CloseCaPropertiesCommand { get; }
+
+    public ICommand? SaveCaPropertiesCommand { get; set; }
+
+    public ICommand? OpenRenewalDialogCommand { get; set; }
+
+    public DelegateCommand CloseRenewalDialogCommand { get; }
+
+    public ICommand? ConfirmRenewalCommand { get; set; }
 
     public ICommand? GenerateCertificateRevocationListCommand { get; set; }
 

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -78,6 +78,15 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly DelegateCommand _openRevokeDialogCommand;
     private readonly DelegateCommand _closeRevokeDialogCommand;
     private readonly DelegateCommand _togglePlainViewCommand;
+    private readonly AsyncCommand _unrevokeCertificateCommand;
+    private readonly DelegateCommand _openManageRevocationsCommand;
+    private readonly DelegateCommand _openCaPropertiesCommand;
+    private readonly AsyncCommand _saveCaPropertiesCommand;
+    private readonly DelegateCommand _openRenewalDialogCommand;
+    private readonly AsyncCommand _deleteCrlCommand;
+    private readonly DelegateCommand _showCrlDetailsCommand;
+    private readonly DelegateCommand _openGenerateCrlDialogCommand;
+    private readonly AsyncCommand _generateCrlFromDialogCommand;
 
     private PageViewModelBase _currentPage;
     private string _subtitle = "Core UI workflows";
@@ -159,6 +168,15 @@ public sealed class ShellViewModel : ViewModelBase
         _openRevokeDialogCommand = new DelegateCommand(OpenRevokeDialog, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificatesPage.SelectedItem is { } cert && !string.Equals(cert.RevocationStatus, "Revoked", StringComparison.OrdinalIgnoreCase));
         _closeRevokeDialogCommand = new DelegateCommand(() => CertificatesPage.IsRevokeDialogOpen = false);
         _togglePlainViewCommand = new DelegateCommand(() => CertificatesPage.IsPlainView = !CertificatesPage.IsPlainView);
+        _unrevokeCertificateCommand = new AsyncCommand(UnrevokeCertificateAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificatesPage.SelectedItem is { } cert && string.Equals(cert.RevocationStatus, "Revoked", StringComparison.OrdinalIgnoreCase) && CertificatesPage.IsUnrevokeConfirmDialogOpen);
+        _openManageRevocationsCommand = new DelegateCommand(OpenManageRevocations, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificatesPage.SelectedItem is { IsCertificateAuthority: true });
+        _openCaPropertiesCommand = new DelegateCommand(OpenCaProperties, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && CertificatesPage.SelectedItem is { IsCertificateAuthority: true });
+        _saveCaPropertiesCommand = new AsyncCommand(SaveCaPropertiesAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && CertificatesPage.SelectedItem is not null);
+        _openRenewalDialogCommand = new DelegateCommand(OpenRenewalDialog, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificatesPage.HasSelection);
+        _deleteCrlCommand = new AsyncCommand(DeleteCrlAsync, () => !IsBusy && Snapshot.State != DatabaseSessionState.Closed && CertificateRevocationListsPage.HasSelection && CertificateRevocationListsPage.IsDeleteConfirmDialogOpen);
+        _showCrlDetailsCommand = new DelegateCommand(ShowCrlDetails, () => CertificateRevocationListsPage.HasSelection && CertificateRevocationListsPage.Inspector is not null);
+        _openGenerateCrlDialogCommand = new DelegateCommand(OpenGenerateCrlDialog, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked);
+        _generateCrlFromDialogCommand = new AsyncCommand(GenerateCrlFromDialogAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificateRevocationListsPage.CrlGenerateSelectedCa is not null);
 
         SettingsSecurityPage.CreateDatabaseCommand = _createDatabaseCommand;
         SettingsSecurityPage.OpenDatabaseCommand = _openDatabaseCommand;
@@ -180,6 +198,11 @@ public sealed class ShellViewModel : ViewModelBase
         CertificatesPage.OpenRevokeDialogCommand = _openRevokeDialogCommand;
         CertificatesPage.CloseRevokeDialogCommand = _closeRevokeDialogCommand;
         CertificatesPage.TogglePlainViewCommand = _togglePlainViewCommand;
+        CertificatesPage.UnrevokeSelectedCommand = _unrevokeCertificateCommand;
+        CertificatesPage.OpenManageRevocationsCommand = _openManageRevocationsCommand;
+        CertificatesPage.OpenCaPropertiesCommand = _openCaPropertiesCommand;
+        CertificatesPage.SaveCaPropertiesCommand = _saveCaPropertiesCommand;
+        CertificatesPage.OpenRenewalDialogCommand = _openRenewalDialogCommand;
 
         PrivateKeysPage.RefreshCommand = _refreshPrivateKeysCommand;
         PrivateKeysPage.GenerateKeyCommand = _generateKeyCommand;
@@ -211,6 +234,11 @@ public sealed class ShellViewModel : ViewModelBase
         CertificateRevocationListsPage.RefreshCommand = _refreshCertificateRevocationListsCommand;
         CertificateRevocationListsPage.ExportSelectedCommand = _exportCertificateRevocationListToFileCommand;
         CertificateRevocationListsPage.OpenIssuerCommand = _navigateCrlIssuerCommand;
+        CertificateRevocationListsPage.ShowDetailsCommand = _showCrlDetailsCommand;
+        CertificateRevocationListsPage.DeleteSelectedCommand = _deleteCrlCommand;
+        CertificateRevocationListsPage.ImportCommand = _importFilesCommand;
+        CertificateRevocationListsPage.OpenGenerateCrlDialogCommand = _openGenerateCrlDialogCommand;
+        CertificateRevocationListsPage.GenerateCrlCommand = _generateCrlFromDialogCommand;
         TemplatesPage.RefreshCommand = _refreshTemplatesCommand;
         TemplatesPage.CreateNewCommand = _createTemplateCommand;
         TemplatesPage.EditTemplateCommand = _editTemplateCommand;
@@ -643,6 +671,169 @@ public sealed class ShellViewModel : ViewModelBase
         await RefreshAllAsync();
         NavigateTo(new NavigationTarget(BrowserEntityType.CertificateRevocationList, result.Value.CertificateRevocationListId, NavigationFocusSection.RevokedEntries));
         NotifySuccess("Certificate revocation list generated.");
+    }
+
+    private async Task UnrevokeCertificateAsync()
+    {
+        if (CertificatesPage.SelectedItem is null)
+        {
+            NotifyFailure("Select a certificate first.");
+            return;
+        }
+
+        using var scope = BeginBusy("Unrevoking certificate");
+        var result = await _databaseSessionService.UnrevokeCertificateAsync(CertificatesPage.SelectedItem.CertificateId, CancellationToken.None);
+        CertificatesPage.IsUnrevokeConfirmDialogOpen = false;
+        if (!result.IsSuccess)
+        {
+            NotifyFailure(result.Message);
+            return;
+        }
+
+        await RefreshAllAsync();
+        NotifySuccess("Certificate unrevoked.");
+    }
+
+    private void OpenManageRevocations()
+    {
+        if (CertificatesPage.SelectedItem is null)
+        {
+            NotifyFailure("Select a CA certificate first.");
+            return;
+        }
+
+        var caId = CertificatesPage.SelectedItem.CertificateId;
+        CertificatesPage.ManageRevocationsEntries.Clear();
+        foreach (var cert in CertificatesPage.Items.Where(x =>
+            x.IssuerCertificateId == caId &&
+            string.Equals(x.RevocationStatus, "Revoked", StringComparison.OrdinalIgnoreCase)))
+        {
+            CertificatesPage.ManageRevocationsEntries.Add(cert);
+        }
+
+        CertificatesPage.IsManageRevocationsDialogOpen = true;
+    }
+
+    private void OpenCaProperties()
+    {
+        if (CertificatesPage.SelectedItem is null)
+            return;
+
+        CertificatesPage.IsCaPropertiesDialogOpen = true;
+        _ = LoadCaPropertiesAsync(CertificatesPage.SelectedItem.CertificateId);
+    }
+
+    private async Task LoadCaPropertiesAsync(Guid caCertId)
+    {
+        var result = await _databaseSessionService.GetCaPropertiesAsync(caCertId, CancellationToken.None);
+        if (result.IsSuccess && result.Value is not null)
+        {
+            CertificatesPage.CaPropertiesCrlDays = result.Value.CrlDays;
+            CertificatesPage.CaPropertiesDefaultTemplateId = result.Value.DefaultTemplateId;
+        }
+    }
+
+    private async Task SaveCaPropertiesAsync()
+    {
+        if (CertificatesPage.SelectedItem is null)
+            return;
+
+        using var scope = BeginBusy("Saving CA properties");
+        var result = await _databaseSessionService.SaveCaPropertiesAsync(
+            CertificatesPage.SelectedItem.CertificateId,
+            new XcaNet.Contracts.Browser.CaPropertiesData(CertificatesPage.CaPropertiesCrlDays, CertificatesPage.CaPropertiesDefaultTemplateId),
+            CancellationToken.None);
+
+        CertificatesPage.IsCaPropertiesDialogOpen = false;
+        if (!result.IsSuccess)
+        {
+            NotifyFailure(result.Message);
+            return;
+        }
+
+        NotifySuccess("CA properties saved.");
+    }
+
+    private void OpenRenewalDialog()
+    {
+        if (CertificatesPage.SelectedItem is null)
+            return;
+
+        CertificatesPage.RenewalNotBefore = CertificatesPage.SelectedItem.NotBefore?.DateTime ?? DateTime.Today;
+        CertificatesPage.RenewalNotAfter = (CertificatesPage.SelectedItem.NotAfter?.DateTime ?? DateTime.Today.AddYears(1)).AddYears(1);
+        CertificatesPage.RenewalRevokeOld = false;
+        CertificatesPage.RenewalReplaceOld = false;
+        CertificatesPage.IsRenewalDialogOpen = true;
+    }
+
+    private async Task DeleteCrlAsync()
+    {
+        if (CertificateRevocationListsPage.SelectedItem is null)
+        {
+            NotifyFailure("Select a CRL first.");
+            return;
+        }
+
+        using var scope = BeginBusy("Deleting revocation list");
+        var result = await _databaseSessionService.DeleteCertificateRevocationListAsync(CertificateRevocationListsPage.SelectedItem.CertificateRevocationListId, CancellationToken.None);
+        CertificateRevocationListsPage.IsDeleteConfirmDialogOpen = false;
+        if (!result.IsSuccess)
+        {
+            NotifyFailure(result.Message);
+            return;
+        }
+
+        await LoadCertificateRevocationListsAsync();
+        NotifySuccess("Revocation list deleted.");
+    }
+
+    private void ShowCrlDetails()
+    {
+        if (CertificateRevocationListsPage.Inspector is null)
+            return;
+
+        CertificateRevocationListsPage.IsDetailDialogOpen = true;
+    }
+
+    private void OpenGenerateCrlDialog()
+    {
+        var caItems = CertificatesPage.Items
+            .Where(x => x.IsCertificateAuthority && x.PrivateKeyId.HasValue)
+            .ToList();
+
+        CertificateRevocationListsPage.CaItems.Clear();
+        foreach (var ca in caItems)
+            CertificateRevocationListsPage.CaItems.Add(ca);
+
+        CertificateRevocationListsPage.CrlGenerateSelectedCa = CertificateRevocationListsPage.CaItems.FirstOrDefault();
+        CertificateRevocationListsPage.CrlGenerateNextUpdateDays = 7;
+        CertificateRevocationListsPage.IsGenerateCrlDialogOpen = true;
+    }
+
+    private async Task GenerateCrlFromDialogAsync()
+    {
+        if (CertificateRevocationListsPage.CrlGenerateSelectedCa is { PrivateKeyId: { } privateKeyId } selectedCa)
+        {
+            using var scope = BeginBusy("Generating certificate revocation list");
+            var result = await _databaseSessionService.GenerateCertificateRevocationListAsync(
+                new GenerateCertificateRevocationListWorkflowRequest(
+                    selectedCa.CertificateId,
+                    privateKeyId,
+                    $"{selectedCa.DisplayName} CRL",
+                    CertificateRevocationListsPage.CrlGenerateNextUpdateDays),
+                CancellationToken.None);
+
+            CertificateRevocationListsPage.IsGenerateCrlDialogOpen = false;
+            if (!result.IsSuccess || result.Value is null)
+            {
+                NotifyFailure(result.Message);
+                return;
+            }
+
+            await LoadCertificateRevocationListsAsync();
+            NavigateTo(new NavigationTarget(BrowserEntityType.CertificateRevocationList, result.Value.CertificateRevocationListId, NavigationFocusSection.RevokedEntries));
+            NotifySuccess("Certificate revocation list generated.");
+        }
     }
 
     private async Task ImportMaterialAsync()
@@ -1492,6 +1683,7 @@ public sealed class ShellViewModel : ViewModelBase
         if (e.PropertyName is nameof(CertificatesPageViewModel.SelectedItem)
             or nameof(CertificatesPageViewModel.Filter)
             or nameof(CertificatesPageViewModel.IsRevokeDialogOpen)
+            or nameof(CertificatesPageViewModel.IsUnrevokeConfirmDialogOpen)
             or nameof(CertificatesPageViewModel.SelectedChildNavigationItem))
         {
             if (e.PropertyName == nameof(CertificatesPageViewModel.SelectedItem))
@@ -1509,7 +1701,9 @@ public sealed class ShellViewModel : ViewModelBase
         if (e.PropertyName is nameof(PrivateKeysPageViewModel.SelectedItem)
             or nameof(CertificateRequestsPageViewModel.SelectedItem)
             or nameof(TemplatesPageViewModel.SelectedItem)
-            or nameof(CertificateRevocationListsPageViewModel.SelectedItem))
+            or nameof(CertificateRevocationListsPageViewModel.SelectedItem)
+            or nameof(CertificateRevocationListsPageViewModel.IsDeleteConfirmDialogOpen)
+            or nameof(CertificateRevocationListsPageViewModel.CrlGenerateSelectedCa))
         {
             if (sender == PrivateKeysPage && e.PropertyName == nameof(PrivateKeysPageViewModel.SelectedItem))
             {
@@ -1721,6 +1915,15 @@ public sealed class ShellViewModel : ViewModelBase
         _openRevokeDialogCommand.RaiseCanExecuteChanged();
         _closeRevokeDialogCommand.RaiseCanExecuteChanged();
         _togglePlainViewCommand.RaiseCanExecuteChanged();
+        _unrevokeCertificateCommand.RaiseCanExecuteChanged();
+        _openManageRevocationsCommand.RaiseCanExecuteChanged();
+        _openCaPropertiesCommand.RaiseCanExecuteChanged();
+        _saveCaPropertiesCommand.RaiseCanExecuteChanged();
+        _openRenewalDialogCommand.RaiseCanExecuteChanged();
+        _deleteCrlCommand.RaiseCanExecuteChanged();
+        _showCrlDetailsCommand.RaiseCanExecuteChanged();
+        _openGenerateCrlDialogCommand.RaiseCanExecuteChanged();
+        _generateCrlFromDialogCommand.RaiseCanExecuteChanged();
     }
 
     private static IReadOnlyList<SanEntry> ParseSubjectAlternativeNames(string value)

--- a/src/XcaNet.App/Views/Pages/CertificateRevocationListsPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificateRevocationListsPageView.axaml
@@ -19,6 +19,15 @@
             <TextBlock Text="{Binding EmptyStateMessage}" TextWrapping="Wrap" />
           </Border>
           <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+            <ListBox.ContextMenu>
+              <ContextMenu>
+                <MenuItem Header="Show Details" Command="{Binding ShowDetailsCommand}" />
+                <MenuItem Header="Export" Command="{Binding ExportSelectedCommand}" />
+                <Separator />
+                <MenuItem Header="Delete" Command="{Binding OpenDeleteConfirmCommand}" />
+                <MenuItem Header="Open Issuer" Command="{Binding OpenIssuerCommand}" />
+              </ContextMenu>
+            </ListBox.ContextMenu>
             <ListBox.ItemTemplate>
               <DataTemplate>
                 <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
@@ -40,11 +49,11 @@
 
     <Border Grid.Column="1" Classes="classic-side-panel" Padding="8">
       <StackPanel>
-        <Button Classes="side-action" Content="Generate CRL" IsEnabled="False" />
+        <Button Classes="side-action" Content="Generate CRL" Command="{Binding OpenGenerateCrlDialogCommand}" />
         <Button Classes="side-action" Content="Export" Command="{Binding ExportSelectedCommand}" />
-        <Button Classes="side-action" Content="Import" IsEnabled="False" />
-        <Button Classes="side-action" Content="Show Details" IsEnabled="False" />
-        <Button Classes="side-action" Content="Delete" IsEnabled="False" />
+        <Button Classes="side-action" Content="Import" Command="{Binding ImportCommand}" />
+        <Button Classes="side-action" Content="Show Details" Command="{Binding ShowDetailsCommand}" />
+        <Button Classes="side-action" Content="Delete" Command="{Binding OpenDeleteConfirmCommand}" />
         <Button Classes="side-action" Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
         <Button Classes="side-action" Content="Refresh" Command="{Binding RefreshCommand}" />
       </StackPanel>
@@ -82,5 +91,141 @@
         </TabItem>
       </TabControl>
     </Border>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- CRL Detail dialog overlay                                          -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsDetailDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="640"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,*,Auto" RowSpacing="12">
+
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="{Binding SelectedItem.DisplayName}" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Close" Command="{Binding CloseDetailCommand}" />
+          </Grid>
+
+          <TabControl Grid.Row="1">
+            <TabItem Header="Status">
+              <Grid Margin="6" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="8">
+                <TextBlock Text="CRL number" />
+                <TextBlock Grid.Column="1" Text="{Binding Inspector.CrlNumber}" />
+                <TextBlock Grid.Row="1" Text="This update" />
+                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Inspector.ThisUpdate}" />
+                <TextBlock Grid.Row="2" Text="Next update" />
+                <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Inspector.NextUpdate}" />
+                <TextBlock Grid.Row="3" Text="Revoked entries" />
+                <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SelectedItem.RevokedEntryCount}" />
+              </Grid>
+            </TabItem>
+            <TabItem Header="Issuer">
+              <Grid Margin="6" ColumnDefinitions="140,*" RowDefinitions="Auto" ColumnSpacing="12" RowSpacing="8">
+                <TextBlock Text="Issuer" />
+                <TextBlock Grid.Column="1" Text="{Binding Inspector.IssuerDisplayName}" TextWrapping="Wrap" />
+              </Grid>
+            </TabItem>
+            <TabItem Header="Revoked entries">
+              <ListBox Margin="6" ItemsSource="{Binding Inspector.RevokedEntries}">
+                <ListBox.ItemTemplate>
+                  <DataTemplate>
+                    <Border Padding="8,5" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                      <Grid ColumnDefinitions="1.4*,1.2*,1*,1*" ColumnSpacing="8">
+                        <TextBlock Text="{Binding DisplayName}" />
+                        <TextBlock Grid.Column="1" Text="{Binding SerialNumber}" />
+                        <TextBlock Grid.Column="2" Text="{Binding Reason}" />
+                        <TextBlock Grid.Column="3" Text="{Binding RevokedAt}" />
+                      </Grid>
+                    </Border>
+                  </DataTemplate>
+                </ListBox.ItemTemplate>
+              </ListBox>
+            </TabItem>
+          </TabControl>
+
+          <Button Grid.Row="2" Content="OK" Command="{Binding CloseDetailCommand}" HorizontalAlignment="Right" MinWidth="80" />
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- Delete CRL confirmation dialog overlay                             -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsDeleteConfirmDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="400"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+
+          <TextBlock Text="Delete revocation list" FontSize="16" FontWeight="SemiBold" />
+
+          <Grid Grid.Row="1" ColumnDefinitions="120,*" ColumnSpacing="12" RowDefinitions="Auto,Auto" RowSpacing="8">
+            <TextBlock Text="CRL" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="1" Text="Issuer" VerticalAlignment="Center" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.IssuerDisplayName}" TextWrapping="Wrap" />
+          </Grid>
+
+          <Grid Grid.Row="2" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+            <TextBlock Text="This action cannot be undone." Classes="secondary-text" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Delete" Command="{Binding DeleteSelectedCommand}" />
+            <Button Grid.Column="2" Content="Cancel" Command="{Binding CloseDeleteConfirmCommand}" />
+          </Grid>
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- Generate CRL dialog overlay                                        -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsGenerateCrlDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="460"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+
+          <TextBlock Text="Generate revocation list" FontSize="16" FontWeight="SemiBold" />
+
+          <Grid Grid.Row="1" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="10">
+            <TextBlock Text="CA certificate" VerticalAlignment="Center" />
+            <ComboBox Grid.Column="1"
+                      ItemsSource="{Binding CaItems}"
+                      SelectedItem="{Binding CrlGenerateSelectedCa}"
+                      DisplayMemberBinding="{Binding DisplayName}"
+                      HorizontalAlignment="Stretch" />
+            <TextBlock Grid.Row="1" Text="Next update (days)" VerticalAlignment="Center" />
+            <NumericUpDown Grid.Row="1" Grid.Column="1"
+                           Value="{Binding CrlGenerateNextUpdateDays}"
+                           Minimum="1"
+                           Maximum="3650"
+                           Increment="1"
+                           FormatString="0"
+                           HorizontalAlignment="Stretch" />
+            <TextBlock Grid.Row="2" Text="Next update date" VerticalAlignment="Center" />
+            <CalendarDatePicker Grid.Row="2" Grid.Column="1"
+                                SelectedDate="{Binding CrlGenerateNextUpdateDate}"
+                                HorizontalAlignment="Stretch" />
+          </Grid>
+
+          <Grid Grid.Row="2" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+            <Button Grid.Column="1" Content="Generate" Command="{Binding GenerateCrlCommand}" />
+            <Button Grid.Column="2" Content="Cancel" Command="{Binding CloseGenerateCrlDialogCommand}" />
+          </Grid>
+        </Grid>
+      </Border>
+    </Grid>
+
   </Grid>
 </UserControl>

--- a/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
@@ -49,10 +49,13 @@
                 <MenuItem Header="Export" Command="{Binding ExportSelectedCommand}" />
                 <Separator />
                 <MenuItem Header="Revoke" Command="{Binding OpenRevokeDialogCommand}" />
+                <MenuItem Header="Unrevoke" Command="{Binding OpenUnrevokeConfirmCommand}" />
                 <MenuItem Header="Generate CRL" Command="{Binding GenerateCertificateRevocationListCommand}" />
                 <Separator />
+                <MenuItem Header="Renew" Command="{Binding OpenRenewalDialogCommand}" />
+                <MenuItem Header="CA Properties" Command="{Binding OpenCaPropertiesCommand}" />
+                <MenuItem Header="Manage Revocations" Command="{Binding OpenManageRevocationsCommand}" />
                 <MenuItem Header="To Template" Command="{Binding CreateTemplateFromCertificateCommand}" />
-                <MenuItem Header="Renew" IsEnabled="False" />
                 <Separator />
                 <MenuItem Header="Open Issuer" Command="{Binding OpenIssuerCommand}" />
                 <MenuItem Header="Delete" IsEnabled="False" />
@@ -86,10 +89,13 @@
                 <MenuItem Header="Export" Command="{Binding ExportSelectedCommand}" />
                 <Separator />
                 <MenuItem Header="Revoke" Command="{Binding OpenRevokeDialogCommand}" />
+                <MenuItem Header="Unrevoke" Command="{Binding OpenUnrevokeConfirmCommand}" />
                 <MenuItem Header="Generate CRL" Command="{Binding GenerateCertificateRevocationListCommand}" />
                 <Separator />
+                <MenuItem Header="Renew" Command="{Binding OpenRenewalDialogCommand}" />
+                <MenuItem Header="CA Properties" Command="{Binding OpenCaPropertiesCommand}" />
+                <MenuItem Header="Manage Revocations" Command="{Binding OpenManageRevocationsCommand}" />
                 <MenuItem Header="To Template" Command="{Binding CreateTemplateFromCertificateCommand}" />
-                <MenuItem Header="Renew" IsEnabled="False" />
                 <Separator />
                 <MenuItem Header="Open Issuer" Command="{Binding OpenIssuerCommand}" />
                 <MenuItem Header="Delete" IsEnabled="False" />
@@ -124,8 +130,11 @@
         <Button Classes="side-action" Content="Show Details" Command="{Binding ShowDetailsCommand}" />
         <Button Classes="side-action" Content="Delete" IsEnabled="False" />
         <Button Classes="side-action" Content="Revoke" Command="{Binding OpenRevokeDialogCommand}" />
+        <Button Classes="side-action" Content="Unrevoke" Command="{Binding OpenUnrevokeConfirmCommand}" />
         <Button Classes="side-action" Content="Generate CRL" Command="{Binding GenerateCertificateRevocationListCommand}" />
-        <Button Classes="side-action" Content="Renew" IsEnabled="False" />
+        <Button Classes="side-action" Content="Renew" Command="{Binding OpenRenewalDialogCommand}" />
+        <Button Classes="side-action" Content="CA Properties" Command="{Binding OpenCaPropertiesCommand}" />
+        <Button Classes="side-action" Content="Manage Revocations" Command="{Binding OpenManageRevocationsCommand}" />
         <Button Classes="side-action" Content="To Template" Command="{Binding CreateTemplateFromCertificateCommand}" />
         <Button Classes="side-action" Content="Open Issuer" Command="{Binding OpenIssuerCommand}" />
         <Button Classes="side-action" Content="Refresh" Command="{Binding RefreshCommand}" />
@@ -293,7 +302,7 @@
           <TextBlock Text="Certificate revocation" FontSize="16" FontWeight="SemiBold" />
 
           <!-- Fields -->
-          <Grid Grid.Row="1" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="10">
+          <Grid Grid.Row="1" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="10">
             <TextBlock Text="Certificate" VerticalAlignment="Center" />
             <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" TextWrapping="Wrap" />
             <TextBlock Grid.Row="1" Text="Serial number" VerticalAlignment="Center" />
@@ -303,16 +312,183 @@
                       ItemsSource="{Binding RevocationReasons}"
                       SelectedItem="{Binding SelectedRevocationReason}"
                       HorizontalAlignment="Stretch" />
+            <TextBlock Grid.Row="3" Text="Revocation date" VerticalAlignment="Center" />
+            <CalendarDatePicker Grid.Row="3" Grid.Column="1"
+                                SelectedDate="{Binding RevocationDate}"
+                                HorizontalAlignment="Stretch" />
           </Grid>
 
-          <!-- Revocation date note -->
-          <TextBlock Grid.Row="2" Text="Revocation date will be recorded as the current UTC time." Classes="secondary-text" TextWrapping="Wrap" />
+          <!-- Spacer -->
+          <TextBlock Grid.Row="2" Classes="secondary-text" Text="" />
 
           <!-- Action buttons -->
           <Grid Grid.Row="3" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
             <TextBlock Text="This action cannot be undone." Classes="secondary-text" VerticalAlignment="Center" />
             <Button Grid.Column="1" Content="Revoke" Command="{Binding RevokeSelectedCommand}" />
             <Button Grid.Column="2" Content="Cancel" Command="{Binding CloseRevokeDialogCommand}" />
+          </Grid>
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- Unrevoke confirmation dialog overlay                               -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsUnrevokeConfirmDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="420"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+
+          <TextBlock Text="Unrevoke certificate" FontSize="16" FontWeight="SemiBold" />
+
+          <Grid Grid.Row="1" ColumnDefinitions="120,*" ColumnSpacing="12" RowDefinitions="Auto,Auto" RowSpacing="8">
+            <TextBlock Text="Certificate" VerticalAlignment="Center" />
+            <TextBlock Grid.Column="1" Text="{Binding SelectedItem.DisplayName}" TextWrapping="Wrap" />
+            <TextBlock Grid.Row="1" Text="Serial number" VerticalAlignment="Center" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SelectedItem.SerialNumber}" />
+          </Grid>
+
+          <Grid Grid.Row="2" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+            <TextBlock Text="Remove this certificate from the revocation list?" Classes="secondary-text" VerticalAlignment="Center" TextWrapping="Wrap" />
+            <Button Grid.Column="1" Content="Unrevoke" Command="{Binding UnrevokeSelectedCommand}" />
+            <Button Grid.Column="2" Content="Cancel" Command="{Binding CloseUnrevokeConfirmCommand}" />
+          </Grid>
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- Manage Revocations dialog overlay                                  -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsManageRevocationsDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="660"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="12">
+
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="Manage revocations" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Close" Command="{Binding CloseManageRevocationsCommand}" />
+          </Grid>
+
+          <TextBlock Grid.Row="1" Classes="secondary-text"
+                     Text="{Binding SelectedItem.DisplayName, StringFormat='Revoked certificates issued by: {0}'}" />
+
+          <Border Grid.Row="2" Classes="workspace-pane" Padding="0">
+            <ListBox ItemsSource="{Binding ManageRevocationsEntries}"
+                     SelectedItem="{Binding SelectedItem}">
+              <ListBox.ItemTemplate>
+                <DataTemplate>
+                  <Border Padding="8,5" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">
+                    <Grid ColumnDefinitions="1.4*,1.0*,0.7*,1.0*" ColumnSpacing="8">
+                      <TextBlock Text="{Binding DisplayName}" />
+                      <TextBlock Grid.Column="1" Text="{Binding SerialNumber}" />
+                      <TextBlock Grid.Column="2" Text="{Binding StatusDisplay}" />
+                      <TextBlock Grid.Column="3" Text="{Binding NotAfter, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                    </Grid>
+                  </Border>
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+          </Border>
+
+          <Grid Grid.Row="3" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+            <TextBlock Classes="secondary-text" Text="Select a certificate above, then click Unrevoke." VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Unrevoke" Command="{Binding OpenUnrevokeConfirmCommand}" />
+            <Button Grid.Column="2" Content="Done" Command="{Binding CloseManageRevocationsCommand}" />
+          </Grid>
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- CA Properties dialog overlay                                       -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsCaPropertiesDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="400"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="CA Properties" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Close" Command="{Binding CloseCaPropertiesCommand}" />
+          </Grid>
+
+          <Grid Grid.Row="1" ColumnDefinitions="160,*" RowDefinitions="Auto" ColumnSpacing="12" RowSpacing="10">
+            <TextBlock Text="Default CRL days" VerticalAlignment="Center" />
+            <NumericUpDown Grid.Column="1"
+                           Value="{Binding CaPropertiesCrlDays}"
+                           Minimum="1"
+                           Maximum="3650"
+                           Increment="1"
+                           FormatString="0"
+                           HorizontalAlignment="Stretch" />
+          </Grid>
+
+          <Grid Grid.Row="2" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+            <Button Grid.Column="1" Content="Save" Command="{Binding SaveCaPropertiesCommand}" />
+            <Button Grid.Column="2" Content="Cancel" Command="{Binding CloseCaPropertiesCommand}" />
+          </Grid>
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- Certificate Renewal dialog overlay                                 -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsRenewalDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="460"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="12">
+
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="Renew certificate" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Close" Command="{Binding CloseRenewalDialogCommand}" />
+          </Grid>
+
+          <TextBlock Grid.Row="1" Classes="secondary-text"
+                     Text="{Binding SelectedItem.DisplayName, StringFormat='Renewing: {0}'}" />
+
+          <Grid Grid.Row="2" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="10">
+            <TextBlock Text="Not before" VerticalAlignment="Center" />
+            <CalendarDatePicker Grid.Column="1"
+                                SelectedDate="{Binding RenewalNotBefore}"
+                                HorizontalAlignment="Stretch" />
+            <TextBlock Grid.Row="1" Text="Not after" VerticalAlignment="Center" />
+            <CalendarDatePicker Grid.Row="1" Grid.Column="1"
+                                SelectedDate="{Binding RenewalNotAfter}"
+                                HorizontalAlignment="Stretch" />
+            <CheckBox Grid.Row="2" Grid.ColumnSpan="2"
+                      IsChecked="{Binding RenewalRevokeOld}"
+                      Content="Revoke old certificate" />
+            <CheckBox Grid.Row="3" Grid.ColumnSpan="2"
+                      IsChecked="{Binding RenewalReplaceOld}"
+                      Content="Replace old certificate in the database" />
+          </Grid>
+
+          <Grid Grid.Row="3" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+            <TextBlock Classes="secondary-text" Text="Renewal uses the same key and subject." VerticalAlignment="Center" TextWrapping="Wrap" />
+            <Button Grid.Column="1" Content="Renew" Command="{Binding ConfirmRenewalCommand}" IsEnabled="False" />
+            <Button Grid.Column="2" Content="Cancel" Command="{Binding CloseRenewalDialogCommand}" />
           </Grid>
         </Grid>
       </Border>

--- a/src/XcaNet.Application/Services/DatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/DatabaseSessionService.cs
@@ -26,6 +26,7 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
     private readonly ICertificateRevocationListRepository _certificateRevocationListRepository;
     private readonly IPrivateKeyRepository _privateKeyRepository;
     private readonly ITemplateRepository _templateRepository;
+    private readonly IAppSettingRepository _appSettingRepository;
     private readonly IDatabaseSecretProtector _databaseSecretProtector;
     private readonly IKeyService _keyService;
     private readonly ICertificateService _certificateService;
@@ -50,6 +51,7 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
         ICertificateRevocationListRepository certificateRevocationListRepository,
         IPrivateKeyRepository privateKeyRepository,
         ITemplateRepository templateRepository,
+        IAppSettingRepository appSettingRepository,
         IDatabaseSecretProtector databaseSecretProtector,
         IKeyService keyService,
         ICertificateService certificateService,
@@ -66,6 +68,7 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
         _certificateRevocationListRepository = certificateRevocationListRepository;
         _privateKeyRepository = privateKeyRepository;
         _templateRepository = templateRepository;
+        _appSettingRepository = appSettingRepository;
         _databaseSecretProtector = databaseSecretProtector;
         _keyService = keyService;
         _certificateService = certificateService;
@@ -602,6 +605,30 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
         }
     }
 
+    public async Task<OperationResult> UnrevokeCertificateAsync(Guid certificateId, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (!TryGetUnlockedDatabasePath<object>(out var databasePath, out var failure))
+                return OperationResult.Failure(failure!.ErrorCode, failure.Message);
+
+            var certificate = await _certificateRepository.GetAsync(databasePath, certificateId, cancellationToken);
+            if (certificate is null)
+                return OperationResult.Failure(OperationErrorCode.DatabaseNotFound, "Certificate not found.");
+
+            if (certificate.RevocationState != (int)RevocationState.Revoked)
+                return OperationResult.Failure(OperationErrorCode.ValidationFailed, "Certificate is not revoked.");
+
+            await _certificateRepository.UpdateRevocationAsync(databasePath, certificateId, (int)RevocationState.Active, null, null, cancellationToken);
+            return OperationResult.Success("Certificate unrevoked.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     public async Task<OperationResult<StoredCertificateRevocationListResult>> GenerateCertificateRevocationListAsync(GenerateCertificateRevocationListWorkflowRequest request, CancellationToken cancellationToken)
     {
         await _gate.WaitAsync(cancellationToken);
@@ -704,6 +731,66 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
             {
                 Array.Clear(decryptedIssuerKey, 0, decryptedIssuerKey.Length);
             }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<OperationResult> DeleteCertificateRevocationListAsync(Guid certificateRevocationListId, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (!TryGetOpenDatabasePath<object>(out var databasePath, out var failure))
+                return OperationResult.Failure(failure!.ErrorCode, failure.Message);
+
+            return await _certificateRevocationListRepository.DeleteAsync(databasePath, certificateRevocationListId, cancellationToken)
+                ? OperationResult.Success("CRL deleted.")
+                : OperationResult.Failure(OperationErrorCode.DatabaseNotFound, "CRL not found.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<OperationResult<CaPropertiesData>> GetCaPropertiesAsync(Guid caCertificateId, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (!TryGetOpenDatabasePath<CaPropertiesData>(out var databasePath, out var failure))
+                return failure!;
+
+            var crlDaysRaw = await _appSettingRepository.GetAsync(databasePath, $"ca_crl_days_{caCertificateId}", cancellationToken);
+            var templateIdRaw = await _appSettingRepository.GetAsync(databasePath, $"ca_template_{caCertificateId}", cancellationToken);
+
+            var crlDays = int.TryParse(crlDaysRaw, out var d) ? d : 7;
+            var templateId = Guid.TryParse(templateIdRaw, out var t) ? (Guid?)t : null;
+
+            return OperationResult<CaPropertiesData>.Success(new CaPropertiesData(crlDays, templateId), "CA properties retrieved.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<OperationResult> SaveCaPropertiesAsync(Guid caCertificateId, CaPropertiesData data, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (!TryGetOpenDatabasePath<object>(out var databasePath, out var failure))
+                return OperationResult.Failure(failure!.ErrorCode, failure.Message);
+
+            await _appSettingRepository.SetAsync(databasePath, $"ca_crl_days_{caCertificateId}", data.CrlDays.ToString(), cancellationToken);
+            if (data.DefaultTemplateId.HasValue)
+                await _appSettingRepository.SetAsync(databasePath, $"ca_template_{caCertificateId}", data.DefaultTemplateId.Value.ToString(), cancellationToken);
+
+            return OperationResult.Success("CA properties saved.");
         }
         finally
         {

--- a/src/XcaNet.Application/Services/IDatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/IDatabaseSessionService.cs
@@ -1,7 +1,7 @@
-using XcaNet.Contracts.Database;
 using XcaNet.Contracts.Browser;
 using XcaNet.Contracts.Crypto;
 using XcaNet.Contracts.Crypto.Workflow;
+using XcaNet.Contracts.Database;
 using XcaNet.Contracts.Results;
 
 namespace XcaNet.Application.Services;
@@ -30,7 +30,15 @@ public interface IDatabaseSessionService
 
     Task<OperationResult<StoredCertificateResult>> RevokeCertificateAsync(RevokeStoredCertificateRequest request, CancellationToken cancellationToken);
 
+    Task<OperationResult> UnrevokeCertificateAsync(Guid certificateId, CancellationToken cancellationToken);
+
     Task<OperationResult<StoredCertificateRevocationListResult>> GenerateCertificateRevocationListAsync(GenerateCertificateRevocationListWorkflowRequest request, CancellationToken cancellationToken);
+
+    Task<OperationResult> DeleteCertificateRevocationListAsync(Guid certificateRevocationListId, CancellationToken cancellationToken);
+
+    Task<OperationResult<CaPropertiesData>> GetCaPropertiesAsync(Guid caCertificateId, CancellationToken cancellationToken);
+
+    Task<OperationResult> SaveCaPropertiesAsync(Guid caCertificateId, CaPropertiesData data, CancellationToken cancellationToken);
 
     Task<OperationResult<ImportStoredMaterialResult>> ImportStoredMaterialAsync(ImportStoredMaterialRequest request, CancellationToken cancellationToken);
 

--- a/src/XcaNet.Contracts/Browser/CaPropertiesData.cs
+++ b/src/XcaNet.Contracts/Browser/CaPropertiesData.cs
@@ -1,0 +1,3 @@
+namespace XcaNet.Contracts.Browser;
+
+public sealed record CaPropertiesData(int CrlDays, Guid? DefaultTemplateId);

--- a/src/XcaNet.Storage/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/XcaNet.Storage/DependencyInjection/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ICertificateRevocationListRepository, CertificateRevocationListRepository>();
         services.AddSingleton<IPrivateKeyRepository, PrivateKeyRepository>();
         services.AddSingleton<ITemplateRepository, TemplateRepository>();
+        services.AddSingleton<IAppSettingRepository, AppSettingRepository>();
         return services;
     }
 }

--- a/src/XcaNet.Storage/Repositories/AppSettingRepository.cs
+++ b/src/XcaNet.Storage/Repositories/AppSettingRepository.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using XcaNet.Storage.Persistence;
+using XcaNet.Storage.Persistence.Entities;
+
+namespace XcaNet.Storage.Repositories;
+
+public sealed class AppSettingRepository : IAppSettingRepository
+{
+    private readonly IXcaNetDbContextFactory _dbContextFactory;
+
+    public AppSettingRepository(IXcaNetDbContextFactory dbContextFactory)
+    {
+        _dbContextFactory = dbContextFactory;
+    }
+
+    public async Task<string?> GetAsync(string databasePath, string key, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var entity = await dbContext.AppSettings.AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Key == key, cancellationToken);
+        return entity?.Value;
+    }
+
+    public async Task SetAsync(string databasePath, string key, string value, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var entity = await dbContext.AppSettings.FirstOrDefaultAsync(x => x.Key == key, cancellationToken);
+        if (entity is null)
+        {
+            dbContext.AppSettings.Add(new AppSettingEntity { Key = key, Value = value, UpdatedUtc = DateTime.UtcNow });
+        }
+        else
+        {
+            entity.Value = value;
+            entity.UpdatedUtc = DateTime.UtcNow;
+        }
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/XcaNet.Storage/Repositories/CertificateRevocationListRepository.cs
+++ b/src/XcaNet.Storage/Repositories/CertificateRevocationListRepository.cs
@@ -38,4 +38,16 @@ public sealed class CertificateRevocationListRepository : ICertificateRevocation
             .OrderByDescending(x => x.ThisUpdateUtc)
             .ToListAsync(cancellationToken);
     }
+
+    public async Task<bool> DeleteAsync(string databasePath, Guid certificateRevocationListId, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var existing = await dbContext.CertificateRevocationLists
+            .SingleOrDefaultAsync(x => x.Id == certificateRevocationListId, cancellationToken);
+        if (existing is null)
+            return false;
+        dbContext.CertificateRevocationLists.Remove(existing);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return true;
+    }
 }

--- a/src/XcaNet.Storage/Repositories/IAppSettingRepository.cs
+++ b/src/XcaNet.Storage/Repositories/IAppSettingRepository.cs
@@ -1,0 +1,8 @@
+namespace XcaNet.Storage.Repositories;
+
+public interface IAppSettingRepository
+{
+    Task<string?> GetAsync(string databasePath, string key, CancellationToken cancellationToken);
+
+    Task SetAsync(string databasePath, string key, string value, CancellationToken cancellationToken);
+}

--- a/src/XcaNet.Storage/Repositories/ICertificateRevocationListRepository.cs
+++ b/src/XcaNet.Storage/Repositories/ICertificateRevocationListRepository.cs
@@ -9,4 +9,6 @@ public interface ICertificateRevocationListRepository
     Task<CertificateRevocationListEntity?> GetAsync(string databasePath, Guid certificateRevocationListId, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<CertificateRevocationListEntity>> ListAsync(string databasePath, CancellationToken cancellationToken);
+
+    Task<bool> DeleteAsync(string databasePath, Guid certificateRevocationListId, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
## Summary

- **Revoke dialog**: adds `CalendarDatePicker` so users can set an explicit revocation date
- **Unrevoke**: confirmation dialog + `UnrevokeCertificateAsync` backend call via `IAppSettingRepository`
- **Manage Revocations**: dialog lists all certs revoked by the selected CA, allows per-entry unrevoke
- **CA Properties**: dialog for editing default CRL days, persisted as key-value pairs in `AppSettings` table
- **Certificate Renewal**: dialog with validity dates, revoke-old and replace-old options (Renew button stubbed, pending backend crypto workflow)
- **Generate CRL dialog**: CA selector + next-update days/date pickers, wired to existing `GenerateCertificateRevocationListAsync`
- **CRL Show Details**: tabbed overlay (Status, Issuer, Revoked entries)
- **CRL Delete**: confirmation dialog + `DeleteCertificateRevocationListAsync`
- CRL side panel: **Generate CRL**, **Import**, **Show Details**, **Delete** buttons now wired

## New files

- `IAppSettingRepository` / `AppSettingRepository` — key-value storage over existing `AppSettings` DbSet
- `CaPropertiesData` — DTO for CA properties

## Test plan

- [ ] Revoke a certificate, verify date picker pre-fills today and custom date is respected
- [ ] Unrevoke a certificate via the confirmation dialog
- [ ] Open Manage Revocations on a CA, verify revoked children appear; unrevoke one
- [ ] Open CA Properties, change CRL days, save, reopen — confirm value persisted
- [ ] Open Renewal dialog, verify dates pre-fill from existing cert; Cancel closes without change
- [ ] On CRL page, click Generate CRL — dialog opens with CA list; generate and verify new CRL appears
- [ ] Show Details on a CRL — tabbed dialog shows status and revoked entries
- [ ] Delete a CRL via confirmation dialog — CRL removed from list
- [ ] Import CRL file via Import button
- [ ] All 97 existing tests pass (`dotnet test XcaNet.sln --no-build`)

Closes #59 #60 #61 #62 #63 #64 #65 #66