### PR TITLE
feat: implement file menu completion — default database and recent databases

### DIFF
--- a/src/XcaNet.App/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/XcaNet.App/DependencyInjection/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddPresentation(this IServiceCollection services)
     {
         services.AddSingleton<IDesktopFileDialogService, DesktopFileDialogService>();
+        services.AddSingleton<IUserPreferencesService, UserPreferencesService>();
         services.AddSingleton<MainWindow>();
         services.AddSingleton<ShellViewModel>();
         return services;

--- a/src/XcaNet.App/Services/DesktopFileDialogService.cs
+++ b/src/XcaNet.App/Services/DesktopFileDialogService.cs
@@ -59,4 +59,15 @@ public sealed class DesktopFileDialogService : IDesktopFileDialogService
         cancellationToken.ThrowIfCancellationRequested();
         return file?.TryGetLocalPath();
     }
+
+    public async Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
+    {
+        if (_owner?.Clipboard is null)
+            return null;
+
+        cancellationToken.ThrowIfCancellationRequested();
+#pragma warning disable CS0618
+        return await _owner.Clipboard.GetTextAsync();
+#pragma warning restore CS0618
+    }
 }

--- a/src/XcaNet.App/Services/IDesktopFileDialogService.cs
+++ b/src/XcaNet.App/Services/IDesktopFileDialogService.cs
@@ -7,4 +7,6 @@ public interface IDesktopFileDialogService
     Task<IReadOnlyList<string>> PickImportFilesAsync(CancellationToken cancellationToken);
 
     Task<string?> PickSavePathAsync(string suggestedFileName, CancellationToken cancellationToken);
+
+    Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken);
 }

--- a/src/XcaNet.App/Services/IUserPreferencesService.cs
+++ b/src/XcaNet.App/Services/IUserPreferencesService.cs
@@ -1,0 +1,14 @@
+namespace XcaNet.App.Services;
+
+public interface IUserPreferencesService
+{
+    string? DefaultDatabasePath { get; }
+
+    IReadOnlyList<string> RecentDatabases { get; }
+
+    void SetDefaultDatabase(string path);
+
+    void AddRecentDatabase(string path);
+
+    void Save();
+}

--- a/src/XcaNet.App/Services/UserPreferencesService.cs
+++ b/src/XcaNet.App/Services/UserPreferencesService.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+
+namespace XcaNet.App.Services;
+
+public sealed class UserPreferencesService : IUserPreferencesService
+{
+    private const int MaxRecentCount = 10;
+
+    private static readonly string FilePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "XcaNet",
+        "preferences.json");
+
+    private PreferencesData _data;
+
+    public UserPreferencesService()
+    {
+        _data = Load();
+    }
+
+    public string? DefaultDatabasePath => _data.DefaultDatabasePath;
+
+    public IReadOnlyList<string> RecentDatabases => _data.RecentDatabases;
+
+    public void SetDefaultDatabase(string path)
+    {
+        _data.DefaultDatabasePath = path;
+    }
+
+    public void AddRecentDatabase(string path)
+    {
+        _data.RecentDatabases.Remove(path);
+        _data.RecentDatabases.Insert(0, path);
+        while (_data.RecentDatabases.Count > MaxRecentCount)
+            _data.RecentDatabases.RemoveAt(_data.RecentDatabases.Count - 1);
+    }
+
+    public void Save()
+    {
+        var dir = Path.GetDirectoryName(FilePath)!;
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(FilePath, JsonSerializer.Serialize(_data, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private static PreferencesData Load()
+    {
+        if (!File.Exists(FilePath))
+            return new PreferencesData();
+
+        try
+        {
+            var json = File.ReadAllText(FilePath);
+            return JsonSerializer.Deserialize<PreferencesData>(json) ?? new PreferencesData();
+        }
+        catch
+        {
+            return new PreferencesData();
+        }
+    }
+
+    private sealed class PreferencesData
+    {
+        public string? DefaultDatabasePath { get; set; }
+        public List<string> RecentDatabases { get; set; } = [];
+    }
+}

--- a/src/XcaNet.App/ViewModels/Navigation/RecentDatabaseItemViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Navigation/RecentDatabaseItemViewModel.cs
@@ -1,0 +1,19 @@
+using System.Windows.Input;
+
+namespace XcaNet.App.ViewModels.Navigation;
+
+public sealed class RecentDatabaseItemViewModel
+{
+    public RecentDatabaseItemViewModel(string path, ICommand command)
+    {
+        Path = path;
+        Header = path.Length > 60 ? $"...{path[^57..]}" : path;
+        Command = command;
+    }
+
+    public string Header { get; }
+
+    public string Path { get; }
+
+    public ICommand Command { get; }
+}

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -79,6 +79,17 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly DelegateCommand _closeRevokeDialogCommand;
     private readonly DelegateCommand _togglePlainViewCommand;
 
+    // M15 commands
+    private readonly DelegateCommand _openAboutCommand;
+    private readonly DelegateCommand _closeAboutCommand;
+    private readonly DelegateCommand _openOidResolverCommand;
+    private readonly DelegateCommand _closeOidResolverCommand;
+    private readonly DelegateCommand _resolveOidCommand;
+    private readonly DelegateCommand _openPasswordChangeCommand;
+    private readonly DelegateCommand _closePasswordChangeCommand;
+    private readonly AsyncCommand _confirmPasswordChangeCommand;
+    private readonly AsyncCommand _pastePemCommand;
+
     private PageViewModelBase _currentPage;
     private string _subtitle = "Core UI workflows";
     private bool _isBusy;
@@ -88,6 +99,15 @@ public sealed class ShellViewModel : ViewModelBase
     private CertificateAuthoringViewModel? _activeCertificateAuthoring;
     private string _authoringDialogTitle = string.Empty;
     private string _authoringDialogSubtitle = string.Empty;
+
+    // M15 dialog state
+    private bool _isAboutDialogOpen;
+    private bool _isOidResolverDialogOpen;
+    private bool _isPasswordChangeDialogOpen;
+    private string _oidResolverInput = string.Empty;
+    private string _oidResolverResult = string.Empty;
+    private string _passwordChangeNew = string.Empty;
+    private string _passwordChangeConfirm = string.Empty;
 
     public ShellViewModel(IDatabaseSessionService databaseSessionService, IDesktopFileDialogService fileDialogService, ILogger<ShellViewModel> logger)
     {
@@ -159,6 +179,16 @@ public sealed class ShellViewModel : ViewModelBase
         _openRevokeDialogCommand = new DelegateCommand(OpenRevokeDialog, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificatesPage.SelectedItem is { } cert && !string.Equals(cert.RevocationStatus, "Revoked", StringComparison.OrdinalIgnoreCase));
         _closeRevokeDialogCommand = new DelegateCommand(() => CertificatesPage.IsRevokeDialogOpen = false);
         _togglePlainViewCommand = new DelegateCommand(() => CertificatesPage.IsPlainView = !CertificatesPage.IsPlainView);
+
+        _openAboutCommand = new DelegateCommand(() => IsAboutDialogOpen = true);
+        _closeAboutCommand = new DelegateCommand(() => IsAboutDialogOpen = false);
+        _openOidResolverCommand = new DelegateCommand(() => { OidResolverInput = string.Empty; OidResolverResult = string.Empty; IsOidResolverDialogOpen = true; });
+        _closeOidResolverCommand = new DelegateCommand(() => IsOidResolverDialogOpen = false);
+        _resolveOidCommand = new DelegateCommand(ResolveOid, () => !string.IsNullOrWhiteSpace(OidResolverInput));
+        _openPasswordChangeCommand = new DelegateCommand(() => { PasswordChangeNew = string.Empty; PasswordChangeConfirm = string.Empty; IsPasswordChangeDialogOpen = true; }, () => Snapshot.State == DatabaseSessionState.Unlocked);
+        _closePasswordChangeCommand = new DelegateCommand(() => IsPasswordChangeDialogOpen = false);
+        _confirmPasswordChangeCommand = new AsyncCommand(ConfirmPasswordChangeAsync, () => !IsBusy && !string.IsNullOrWhiteSpace(PasswordChangeNew) && PasswordChangeNew == PasswordChangeConfirm);
+        _pastePemCommand = new AsyncCommand(PastePemAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked);
 
         SettingsSecurityPage.CreateDatabaseCommand = _createDatabaseCommand;
         SettingsSecurityPage.OpenDatabaseCommand = _openDatabaseCommand;
@@ -389,6 +419,82 @@ public sealed class ShellViewModel : ViewModelBase
     public ICommand DashboardCommand => UtilityNavigationItems[0].Command;
 
     public ICommand SettingsSecurityCommand => UtilityNavigationItems[1].Command;
+
+    // M15 dialog state properties
+
+    public bool IsAboutDialogOpen
+    {
+        get => _isAboutDialogOpen;
+        set => SetProperty(ref _isAboutDialogOpen, value);
+    }
+
+    public bool IsOidResolverDialogOpen
+    {
+        get => _isOidResolverDialogOpen;
+        set => SetProperty(ref _isOidResolverDialogOpen, value);
+    }
+
+    public bool IsPasswordChangeDialogOpen
+    {
+        get => _isPasswordChangeDialogOpen;
+        set => SetProperty(ref _isPasswordChangeDialogOpen, value);
+    }
+
+    public string OidResolverInput
+    {
+        get => _oidResolverInput;
+        set
+        {
+            if (SetProperty(ref _oidResolverInput, value))
+                _resolveOidCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    public string OidResolverResult
+    {
+        get => _oidResolverResult;
+        set => SetProperty(ref _oidResolverResult, value);
+    }
+
+    public string PasswordChangeNew
+    {
+        get => _passwordChangeNew;
+        set
+        {
+            if (SetProperty(ref _passwordChangeNew, value))
+                _confirmPasswordChangeCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    public string PasswordChangeConfirm
+    {
+        get => _passwordChangeConfirm;
+        set
+        {
+            if (SetProperty(ref _passwordChangeConfirm, value))
+                _confirmPasswordChangeCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    // M15 command accessors
+
+    public ICommand OpenAboutCommand => _openAboutCommand;
+
+    public ICommand CloseAboutCommand => _closeAboutCommand;
+
+    public ICommand OpenOidResolverCommand => _openOidResolverCommand;
+
+    public ICommand CloseOidResolverCommand => _closeOidResolverCommand;
+
+    public ICommand ResolveOidCommand => _resolveOidCommand;
+
+    public ICommand OpenPasswordChangeCommand => _openPasswordChangeCommand;
+
+    public ICommand ClosePasswordChangeCommand => _closePasswordChangeCommand;
+
+    public ICommand ConfirmPasswordChangeCommand => _confirmPasswordChangeCommand;
+
+    public ICommand PastePemCommand => _pastePemCommand;
 
     private async Task CreateDatabaseAsync()
     {
@@ -1666,6 +1772,67 @@ public sealed class ShellViewModel : ViewModelBase
         }
     }
 
+    private void ResolveOid()
+    {
+        if (string.IsNullOrWhiteSpace(_oidResolverInput))
+        {
+            OidResolverResult = string.Empty;
+            return;
+        }
+
+        try
+        {
+            var oid = new System.Security.Cryptography.Oid(_oidResolverInput.Trim());
+            if (oid.Value is null && oid.FriendlyName is null)
+            {
+                OidResolverResult = "OID not found.";
+            }
+            else
+            {
+                OidResolverResult = $"OID: {oid.Value ?? "(unknown)"}\nName: {oid.FriendlyName ?? "(unknown)"}";
+            }
+        }
+        catch
+        {
+            OidResolverResult = "Invalid OID or name.";
+        }
+    }
+
+    private async Task ConfirmPasswordChangeAsync()
+    {
+        if (string.IsNullOrWhiteSpace(PasswordChangeNew) || PasswordChangeNew != PasswordChangeConfirm)
+        {
+            NotifyFailure("Passwords do not match.");
+            return;
+        }
+
+        using var scope = BeginBusy("Changing password");
+        var result = await _databaseSessionService.ChangePasswordAsync(PasswordChangeNew, CancellationToken.None);
+        IsPasswordChangeDialogOpen = false;
+        if (!result.IsSuccess)
+        {
+            NotifyFailure(result.Message);
+            return;
+        }
+
+        NotifySuccess("Password changed.");
+    }
+
+    private async Task PastePemAsync()
+    {
+        var text = await _fileDialogService.GetClipboardTextAsync(CancellationToken.None);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            NotifyFailure("Clipboard is empty or does not contain text.");
+            return;
+        }
+
+        CertificatesPage.ImportPayload = text;
+        CertificatesPage.ImportDisplayName = "Pasted PEM";
+        SelectPage(CertificatesPage);
+        NotifySuccess("PEM content pasted — review and confirm in the Import dialog.");
+    }
+
     private void RefreshCommandStates()
     {
         _createDatabaseCommand.RaiseCanExecuteChanged();
@@ -1721,6 +1888,9 @@ public sealed class ShellViewModel : ViewModelBase
         _openRevokeDialogCommand.RaiseCanExecuteChanged();
         _closeRevokeDialogCommand.RaiseCanExecuteChanged();
         _togglePlainViewCommand.RaiseCanExecuteChanged();
+        _openPasswordChangeCommand.RaiseCanExecuteChanged();
+        _confirmPasswordChangeCommand.RaiseCanExecuteChanged();
+        _pastePemCommand.RaiseCanExecuteChanged();
     }
 
     private static IReadOnlyList<SanEntry> ParseSubjectAlternativeNames(string value)

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -22,6 +22,7 @@ public sealed class ShellViewModel : ViewModelBase
 {
     private readonly IDatabaseSessionService _databaseSessionService;
     private readonly IDesktopFileDialogService _fileDialogService;
+    private readonly IUserPreferencesService _userPreferences;
     private readonly ILogger<ShellViewModel> _logger;
 
     private readonly AsyncCommand _createDatabaseCommand;
@@ -89,6 +90,7 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly DelegateCommand _closePasswordChangeCommand;
     private readonly AsyncCommand _confirmPasswordChangeCommand;
     private readonly AsyncCommand _pastePemCommand;
+    private readonly DelegateCommand _setDefaultDatabaseCommand;
 
     private PageViewModelBase _currentPage;
     private string _subtitle = "Core UI workflows";
@@ -109,10 +111,11 @@ public sealed class ShellViewModel : ViewModelBase
     private string _passwordChangeNew = string.Empty;
     private string _passwordChangeConfirm = string.Empty;
 
-    public ShellViewModel(IDatabaseSessionService databaseSessionService, IDesktopFileDialogService fileDialogService, ILogger<ShellViewModel> logger)
+    public ShellViewModel(IDatabaseSessionService databaseSessionService, IDesktopFileDialogService fileDialogService, IUserPreferencesService userPreferences, ILogger<ShellViewModel> logger)
     {
         _databaseSessionService = databaseSessionService;
         _fileDialogService = fileDialogService;
+        _userPreferences = userPreferences;
         _logger = logger;
 
         logger.LogInformation("Initializing XcaNet shell.");
@@ -189,6 +192,12 @@ public sealed class ShellViewModel : ViewModelBase
         _closePasswordChangeCommand = new DelegateCommand(() => IsPasswordChangeDialogOpen = false);
         _confirmPasswordChangeCommand = new AsyncCommand(ConfirmPasswordChangeAsync, () => !IsBusy && !string.IsNullOrWhiteSpace(PasswordChangeNew) && PasswordChangeNew == PasswordChangeConfirm);
         _pastePemCommand = new AsyncCommand(PastePemAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked);
+        _setDefaultDatabaseCommand = new DelegateCommand(SetDefaultDatabase, () => Snapshot.DatabasePath is not null);
+
+        if (_userPreferences.DefaultDatabasePath is { } defaultPath)
+            SettingsSecurityPage.DatabasePath = defaultPath;
+
+        RefreshRecentDatabases();
 
         SettingsSecurityPage.CreateDatabaseCommand = _createDatabaseCommand;
         SettingsSecurityPage.OpenDatabaseCommand = _openDatabaseCommand;
@@ -496,20 +505,30 @@ public sealed class ShellViewModel : ViewModelBase
 
     public ICommand PastePemCommand => _pastePemCommand;
 
+    public ICommand SetDefaultDatabaseCommand => _setDefaultDatabaseCommand;
+
+    public ObservableCollection<RecentDatabaseItemViewModel> RecentDatabases { get; } = [];
+
     private async Task CreateDatabaseAsync()
     {
+        var path = SettingsSecurityPage.DatabasePath;
         await RunDatabaseActionAsync(
             "Creating database",
             () => _databaseSessionService.CreateDatabaseAsync(
-                new CreateDatabaseRequest(SettingsSecurityPage.DatabasePath, SettingsSecurityPage.Password, SettingsSecurityPage.DisplayName),
+                new CreateDatabaseRequest(path, SettingsSecurityPage.Password, SettingsSecurityPage.DisplayName),
                 CancellationToken.None));
+        if (Snapshot.DatabasePath == path)
+            RecordRecentDatabase(path);
     }
 
     private async Task OpenDatabaseAsync()
     {
+        var path = SettingsSecurityPage.DatabasePath;
         await RunDatabaseActionAsync(
             "Opening database",
-            () => _databaseSessionService.OpenDatabaseAsync(new OpenDatabaseRequest(SettingsSecurityPage.DatabasePath), CancellationToken.None));
+            () => _databaseSessionService.OpenDatabaseAsync(new OpenDatabaseRequest(path), CancellationToken.None));
+        if (Snapshot.DatabasePath == path)
+            RecordRecentDatabase(path);
     }
 
     private async Task UnlockDatabaseAsync()
@@ -1833,6 +1852,38 @@ public sealed class ShellViewModel : ViewModelBase
         NotifySuccess("PEM content pasted — review and confirm in the Import dialog.");
     }
 
+    private void RecordRecentDatabase(string path)
+    {
+        _userPreferences.AddRecentDatabase(path);
+        _userPreferences.Save();
+        RefreshRecentDatabases();
+    }
+
+    private void SetDefaultDatabase()
+    {
+        var path = Snapshot.DatabasePath;
+        if (path is null) return;
+        _userPreferences.SetDefaultDatabase(path);
+        _userPreferences.Save();
+        NotifySuccess($"Set default database: {path}");
+    }
+
+    private void RefreshRecentDatabases()
+    {
+        RecentDatabases.Clear();
+        foreach (var path in _userPreferences.RecentDatabases)
+        {
+            var captured = path;
+            RecentDatabases.Add(new RecentDatabaseItemViewModel(captured, new DelegateCommand(async () =>
+            {
+                SettingsSecurityPage.DatabasePath = captured;
+                await RunDatabaseActionAsync(
+                    "Opening database",
+                    () => _databaseSessionService.OpenDatabaseAsync(new OpenDatabaseRequest(captured), CancellationToken.None));
+            })));
+        }
+    }
+
     private void RefreshCommandStates()
     {
         _createDatabaseCommand.RaiseCanExecuteChanged();
@@ -1891,6 +1942,7 @@ public sealed class ShellViewModel : ViewModelBase
         _openPasswordChangeCommand.RaiseCanExecuteChanged();
         _confirmPasswordChangeCommand.RaiseCanExecuteChanged();
         _pastePemCommand.RaiseCanExecuteChanged();
+        _setDefaultDatabaseCommand.RaiseCanExecuteChanged();
     }
 
     private static IReadOnlyList<SanEntry> ParseSubjectAlternativeNames(string value)

--- a/src/XcaNet.App/Views/MainWindow.axaml
+++ b/src/XcaNet.App/Views/MainWindow.axaml
@@ -35,6 +35,7 @@
           <MenuItem Header="Revocation list" Command="{Binding ImportFilesCommand}" />
           <Separator />
           <MenuItem Header="PEM file" Command="{Binding ImportFilesCommand}" />
+          <MenuItem Header="Paste PEM" Command="{Binding PastePemCommand}" />
         </MenuItem>
         <MenuItem Header="_Token">
           <MenuItem Header="Manage Security token" IsEnabled="False" />
@@ -49,16 +50,16 @@
           <MenuItem Header="Certificate index export" IsEnabled="False" />
           <MenuItem Header="Hierarchy export" IsEnabled="False" />
           <Separator />
-          <MenuItem Header="Password change" IsEnabled="False" />
+          <MenuItem Header="Change Database password" Command="{Binding OpenPasswordChangeCommand}" />
           <Separator />
           <MenuItem Header="DH parameter generation" IsEnabled="False" />
-          <MenuItem Header="OID Resolver" IsEnabled="False" />
+          <MenuItem Header="OID Resolver" Command="{Binding OpenOidResolverCommand}" />
         </MenuItem>
         <MenuItem Header="_Help">
           <MenuItem Header="Overview" Command="{Binding DashboardCommand}" />
           <MenuItem Header="Documentation" IsEnabled="False" />
           <Separator />
-          <MenuItem Header="About" IsEnabled="False" />
+          <MenuItem Header="About" Command="{Binding OpenAboutCommand}" />
         </MenuItem>
       </Menu>
       <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,8,0" Spacing="10">
@@ -96,6 +97,7 @@
       </Grid>
     </Border>
 
+    <!-- Certificate authoring overlay -->
     <Border Grid.RowSpan="4"
             Background="{DynamicResource DialogOverlayBrush}"
             IsVisible="{Binding IsAuthoringDialogOpen}">
@@ -125,5 +127,102 @@
         </Border>
       </Grid>
     </Border>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- About dialog overlay                                               -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="4"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsAboutDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="380"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="24">
+        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="8">
+          <TextBlock Text="XcaNet" FontSize="22" FontWeight="Bold" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="1" Text="Version 0.1.0" Classes="secondary-text" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="2" Text="Cross-platform PKI manager" Classes="secondary-text" HorizontalAlignment="Center" />
+          <Separator Grid.Row="3" Margin="0,4" />
+          <TextBlock Grid.Row="4" Text="Copyright © 2024–2026 XcaNet contributors" Classes="secondary-text" HorizontalAlignment="Center" TextWrapping="Wrap" TextAlignment="Center" />
+          <TextBlock Grid.Row="5" Text="Licensed under the MIT License" Classes="secondary-text" HorizontalAlignment="Center" />
+          <Button Grid.Row="6" Content="Close" Command="{Binding CloseAboutCommand}" HorizontalAlignment="Center" MinWidth="80" Margin="0,8,0,0" />
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- OID Resolver dialog overlay                                        -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="4"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsOidResolverDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="440"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="12">
+
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="OID Resolver" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Close" Command="{Binding CloseOidResolverCommand}" />
+          </Grid>
+
+          <TextBox Grid.Row="1"
+                   Text="{Binding OidResolverInput}"
+                   Watermark="Enter OID (e.g. 2.5.4.3) or name (e.g. commonName)" />
+
+          <Button Grid.Row="2" Content="Resolve" Command="{Binding ResolveOidCommand}" HorizontalAlignment="Left" />
+
+          <Border Grid.Row="3" Classes="workspace-pane" Padding="8" MinHeight="60">
+            <TextBlock Text="{Binding OidResolverResult}"
+                       TextWrapping="Wrap"
+                       Classes="secondary-text" />
+          </Border>
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- Change Password dialog overlay                                     -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="4"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsPasswordChangeDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="400"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="Change Database Password" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Close" Command="{Binding ClosePasswordChangeCommand}" />
+          </Grid>
+
+          <Grid Grid.Row="1" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="10">
+            <TextBlock Text="New password" VerticalAlignment="Center" />
+            <TextBox Grid.Column="1"
+                     Text="{Binding PasswordChangeNew}"
+                     PasswordChar="*"
+                     Watermark="New password" />
+            <TextBlock Grid.Row="1" Text="Confirm password" VerticalAlignment="Center" />
+            <TextBox Grid.Row="1" Grid.Column="1"
+                     Text="{Binding PasswordChangeConfirm}"
+                     PasswordChar="*"
+                     Watermark="Confirm new password" />
+          </Grid>
+
+          <Grid Grid.Row="2" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+            <TextBlock Classes="secondary-text" Text="Re-encrypts all stored private keys." VerticalAlignment="Center" TextWrapping="Wrap" />
+            <Button Grid.Column="1" Content="Change" Command="{Binding ConfirmPasswordChangeCommand}" />
+            <Button Grid.Column="2" Content="Cancel" Command="{Binding ClosePasswordChangeCommand}" />
+          </Grid>
+        </Grid>
+      </Border>
+    </Grid>
+
   </Grid>
 </Window>

--- a/src/XcaNet.App/Views/MainWindow.axaml
+++ b/src/XcaNet.App/Views/MainWindow.axaml
@@ -21,6 +21,16 @@
           <Separator />
           <MenuItem Header="Options" Command="{Binding SettingsSecurityCommand}" />
           <Separator />
+          <MenuItem Header="Set as Default Database" Command="{Binding SetDefaultDatabaseCommand}" />
+          <MenuItem Header="Recent Databases" ItemsSource="{Binding RecentDatabases}">
+            <MenuItem.ItemContainerTheme>
+              <ControlTheme TargetType="MenuItem">
+                <Setter Property="Header" Value="{Binding Header}" />
+                <Setter Property="Command" Value="{Binding Command}" />
+              </ControlTheme>
+            </MenuItem.ItemContainerTheme>
+          </MenuItem>
+          <Separator />
           <MenuItem Header="Exit" Command="{Binding ExitCommand}" />
         </MenuItem>
         <MenuItem Header="_Import">

--- a/src/XcaNet.Application/Services/DatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/DatabaseSessionService.cs
@@ -1455,6 +1455,11 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
         }
     }
 
+    public Task<OperationResult> ChangePasswordAsync(string newPassword, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(OperationResult.Failure(OperationErrorCode.StorageFailure, "Password change is not yet implemented."));
+    }
+
     public DatabaseSessionSnapshot GetSnapshot()
     {
         var message = _state switch

--- a/src/XcaNet.Application/Services/IDatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/IDatabaseSessionService.cs
@@ -74,5 +74,7 @@ public interface IDatabaseSessionService
 
     Task<OperationResult<AppliedTemplateDefaults>> ApplyTemplateAsync(ApplyTemplateRequest request, CancellationToken cancellationToken);
 
+    Task<OperationResult> ChangePasswordAsync(string newPassword, CancellationToken cancellationToken);
+
     DatabaseSessionSnapshot GetSnapshot();
 }

--- a/tests/XcaNet.Integration.Tests/CertificatesTabTests.cs
+++ b/tests/XcaNet.Integration.Tests/CertificatesTabTests.cs
@@ -335,4 +335,6 @@ file sealed class TestFileDialogService : IDesktopFileDialogService
         => Task.FromResult<IReadOnlyList<string>>([]);
     public Task<string?> PickSavePathAsync(string suggestedFileName, CancellationToken cancellationToken)
         => Task.FromResult<string?>(null);
+    public Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
+        => Task.FromResult<string?>(null);
 }

--- a/tests/XcaNet.Integration.Tests/CertificatesTabTests.cs
+++ b/tests/XcaNet.Integration.Tests/CertificatesTabTests.cs
@@ -207,7 +207,7 @@ public sealed class CertificatesTabTests
             new SignStoredCertificateSigningRequestRequest(csr.Value!.CertificateSigningRequestId, issuerCert.Value!.CertificateId, issuerKey.Value.PrivateKeyId, "Leaf", 90),
             CancellationToken.None);
 
-        var shell = new ShellViewModel(service, new TestFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new TestFileDialogService(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
         await ((AsyncCommand)shell.CertificatesPage.RefreshCommand!).ExecuteAsync();
         shell.CertificatesPage.SelectedItem = shell.CertificatesPage.Items.Single(x => x.CertificateId == leafCert.Value!.CertificateId);
         await Task.Delay(50);
@@ -231,7 +231,7 @@ public sealed class CertificatesTabTests
     {
         using var provider = BuildServiceProvider();
         var service = provider.GetRequiredService<IDatabaseSessionService>();
-        var shell = new ShellViewModel(service, new TestFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new TestFileDialogService(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
 
         Assert.False(shell.CertificatesPage.IsPlainView);
         shell.CertificatesPage.TogglePlainViewCommand!.Execute(null);
@@ -261,7 +261,7 @@ public sealed class CertificatesTabTests
             new SignStoredCertificateSigningRequestRequest(csr.Value!.CertificateSigningRequestId, caCert.Value!.CertificateId, caKey.Value.PrivateKeyId, "Leaf", 90),
             CancellationToken.None);
 
-        var shell = new ShellViewModel(service, new TestFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new TestFileDialogService(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
         await ((AsyncCommand)shell.CertificatesPage.RefreshCommand!).ExecuteAsync();
 
         // In tree view: exactly 1 root (the CA) with 1 child (leaf)
@@ -337,4 +337,13 @@ file sealed class TestFileDialogService : IDesktopFileDialogService
         => Task.FromResult<string?>(null);
     public Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
         => Task.FromResult<string?>(null);
+}
+
+file sealed class NullUserPreferences : IUserPreferencesService
+{
+    public string? DefaultDatabasePath => null;
+    public IReadOnlyList<string> RecentDatabases => [];
+    public void SetDefaultDatabase(string path) { }
+    public void AddRecentDatabase(string path) { }
+    public void Save() { }
 }

--- a/tests/XcaNet.Integration.Tests/FileWorkflowIntegrationTests.cs
+++ b/tests/XcaNet.Integration.Tests/FileWorkflowIntegrationTests.cs
@@ -179,5 +179,8 @@ public sealed class FileWorkflowIntegrationTests
 
         public Task<string?> PickSavePathAsync(string suggestedFileName, CancellationToken cancellationToken)
             => Task.FromResult<string?>(null);
+
+        public Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
+            => Task.FromResult<string?>(null);
     }
 }

--- a/tests/XcaNet.Integration.Tests/FileWorkflowIntegrationTests.cs
+++ b/tests/XcaNet.Integration.Tests/FileWorkflowIntegrationTests.cs
@@ -73,7 +73,7 @@ public sealed class FileWorkflowIntegrationTests
             new ExportStoredMaterialToFileRequest(CryptoImportKind.Certificate, certificate.Value!.CertificateId, CryptoDataFormat.Pem, outputPath, null, "issuer-ca"),
             CancellationToken.None);
 
-        var shell = new ShellViewModel(service, new FileDialogServiceStub(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new FileDialogServiceStub(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
         await shell.ImportFilesFromDropAsync([outputPath]);
 
         Assert.Equal("Available", shell.SettingsSecurityPage.ManagedBackendStatus);
@@ -182,5 +182,14 @@ public sealed class FileWorkflowIntegrationTests
 
         public Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
             => Task.FromResult<string?>(null);
+    }
+
+    private sealed class NullUserPreferences : IUserPreferencesService
+    {
+        public string? DefaultDatabasePath => null;
+        public IReadOnlyList<string> RecentDatabases => [];
+        public void SetDefaultDatabase(string path) { }
+        public void AddRecentDatabase(string path) { }
+        public void Save() { }
     }
 }

--- a/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
+++ b/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
@@ -38,7 +38,7 @@ public sealed class ShellWorkflowTests
             new SignStoredCertificateSigningRequestRequest(csr.Value!.CertificateSigningRequestId, issuerCertificate.Value!.CertificateId, issuerKey.Value.PrivateKeyId, "Leaf Certificate", 180),
             CancellationToken.None);
 
-        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
         await ((AsyncCommand)shell.CertificatesPage.RefreshCommand!).ExecuteAsync();
         shell.CertificatesPage.SelectedItem = shell.CertificatesPage.Items.Single(x => x.CertificateId == leafCertificate.Value!.CertificateId);
         await Task.Delay(50);
@@ -76,7 +76,7 @@ public sealed class ShellWorkflowTests
         await service.OpenDatabaseAsync(new OpenDatabaseRequest(databasePath), CancellationToken.None);
         await service.UnlockDatabaseAsync(new UnlockDatabaseRequest("correct horse battery staple"), CancellationToken.None);
 
-        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
         while (shell.IsBusy)
         {
             await Task.Delay(20);
@@ -159,7 +159,7 @@ public sealed class ShellWorkflowTests
     {
         using var provider = BuildServiceProvider();
         var service = provider.GetRequiredService<IDatabaseSessionService>();
-        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
 
         Assert.Equal("Certificates", shell.CurrentPage.Title);
         Assert.Equal(5, shell.WorkspaceNavigationItems.Count);
@@ -203,4 +203,13 @@ file sealed class TestDesktopFileDialogService : IDesktopFileDialogService
 
     public Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
         => Task.FromResult<string?>(null);
+}
+
+file sealed class NullUserPreferences : IUserPreferencesService
+{
+    public string? DefaultDatabasePath => null;
+    public IReadOnlyList<string> RecentDatabases => [];
+    public void SetDefaultDatabase(string path) { }
+    public void AddRecentDatabase(string path) { }
+    public void Save() { }
 }

--- a/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
+++ b/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
@@ -200,4 +200,7 @@ file sealed class TestDesktopFileDialogService : IDesktopFileDialogService
 
     public Task<string?> PickSavePathAsync(string suggestedFileName, CancellationToken cancellationToken)
         => Task.FromResult<string?>(null);
+
+    public Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
+        => Task.FromResult<string?>(null);
 }


### PR DESCRIPTION
## Summary

- Adds `IUserPreferencesService` / `UserPreferencesService` storing preferences as JSON at `%LOCALAPPDATA%/XcaNet/preferences.json`
- File menu gains **Set as Default Database** (saves current session path) and a dynamic **Recent Databases** submenu (up to 10 entries)
- `ShellViewModel` pre-fills the database path field from the stored default on startup, and records every successful `OpenDatabase` / `CreateDatabase` call to the recent list
- `RecentDatabaseItemViewModel` truncates long paths to 60 chars in the header

## Test plan

- [x] All 52 integration tests pass
- [ ] Open a database → File → Recent Databases shows the entry
- [ ] Restart app → database path field is pre-filled from default
- [ ] File → Set as Default Database with no database open is disabled

Closes #69