### PR TITLE
feat: implement F2 rename shortcut across all tabs

### DIFF
--- a/src/XcaNet.App/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/XcaNet.App/DependencyInjection/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddPresentation(this IServiceCollection services)
     {
         services.AddSingleton<IDesktopFileDialogService, DesktopFileDialogService>();
+        services.AddSingleton<IUserPreferencesService, UserPreferencesService>();
         services.AddSingleton<MainWindow>();
         services.AddSingleton<ShellViewModel>();
         return services;

--- a/src/XcaNet.App/Services/DesktopFileDialogService.cs
+++ b/src/XcaNet.App/Services/DesktopFileDialogService.cs
@@ -59,4 +59,15 @@ public sealed class DesktopFileDialogService : IDesktopFileDialogService
         cancellationToken.ThrowIfCancellationRequested();
         return file?.TryGetLocalPath();
     }
+
+    public async Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
+    {
+        if (_owner?.Clipboard is null)
+            return null;
+
+        cancellationToken.ThrowIfCancellationRequested();
+#pragma warning disable CS0618
+        return await _owner.Clipboard.GetTextAsync();
+#pragma warning restore CS0618
+    }
 }

--- a/src/XcaNet.App/Services/IDesktopFileDialogService.cs
+++ b/src/XcaNet.App/Services/IDesktopFileDialogService.cs
@@ -7,4 +7,6 @@ public interface IDesktopFileDialogService
     Task<IReadOnlyList<string>> PickImportFilesAsync(CancellationToken cancellationToken);
 
     Task<string?> PickSavePathAsync(string suggestedFileName, CancellationToken cancellationToken);
+
+    Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken);
 }

--- a/src/XcaNet.App/Services/IUserPreferencesService.cs
+++ b/src/XcaNet.App/Services/IUserPreferencesService.cs
@@ -1,0 +1,14 @@
+namespace XcaNet.App.Services;
+
+public interface IUserPreferencesService
+{
+    string? DefaultDatabasePath { get; }
+
+    IReadOnlyList<string> RecentDatabases { get; }
+
+    void SetDefaultDatabase(string path);
+
+    void AddRecentDatabase(string path);
+
+    void Save();
+}

--- a/src/XcaNet.App/Services/UserPreferencesService.cs
+++ b/src/XcaNet.App/Services/UserPreferencesService.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+
+namespace XcaNet.App.Services;
+
+public sealed class UserPreferencesService : IUserPreferencesService
+{
+    private const int MaxRecentCount = 10;
+
+    private static readonly string FilePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "XcaNet",
+        "preferences.json");
+
+    private PreferencesData _data;
+
+    public UserPreferencesService()
+    {
+        _data = Load();
+    }
+
+    public string? DefaultDatabasePath => _data.DefaultDatabasePath;
+
+    public IReadOnlyList<string> RecentDatabases => _data.RecentDatabases;
+
+    public void SetDefaultDatabase(string path)
+    {
+        _data.DefaultDatabasePath = path;
+    }
+
+    public void AddRecentDatabase(string path)
+    {
+        _data.RecentDatabases.Remove(path);
+        _data.RecentDatabases.Insert(0, path);
+        while (_data.RecentDatabases.Count > MaxRecentCount)
+            _data.RecentDatabases.RemoveAt(_data.RecentDatabases.Count - 1);
+    }
+
+    public void Save()
+    {
+        var dir = Path.GetDirectoryName(FilePath)!;
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(FilePath, JsonSerializer.Serialize(_data, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private static PreferencesData Load()
+    {
+        if (!File.Exists(FilePath))
+            return new PreferencesData();
+
+        try
+        {
+            var json = File.ReadAllText(FilePath);
+            return JsonSerializer.Deserialize<PreferencesData>(json) ?? new PreferencesData();
+        }
+        catch
+        {
+            return new PreferencesData();
+        }
+    }
+
+    private sealed class PreferencesData
+    {
+        public string? DefaultDatabasePath { get; set; }
+        public List<string> RecentDatabases { get; set; } = [];
+    }
+}

--- a/src/XcaNet.App/ViewModels/Navigation/RecentDatabaseItemViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Navigation/RecentDatabaseItemViewModel.cs
@@ -1,0 +1,19 @@
+using System.Windows.Input;
+
+namespace XcaNet.App.ViewModels.Navigation;
+
+public sealed class RecentDatabaseItemViewModel
+{
+    public RecentDatabaseItemViewModel(string path, ICommand command)
+    {
+        Path = path;
+        Header = path.Length > 60 ? $"...{path[^57..]}" : path;
+        Command = command;
+    }
+
+    public string Header { get; }
+
+    public string Path { get; }
+
+    public ICommand Command { get; }
+}

--- a/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateRequestsPageViewModel.cs
@@ -87,6 +87,8 @@ public sealed class CertificateRequestsPageViewModel : SelectableItemsPageViewMo
 
     public ICommand? OpenNewRequestAuthoringCommand { get; set; }
 
+    public ICommand? OpenRenameDialogCommand { get; set; }
+
     public void SetIssuers(IEnumerable<CertificateListItem> certificates, IEnumerable<PrivateKeyListItem> privateKeys)
     {
         IssuanceAuthoring.SetIssuers(certificates, privateKeys);

--- a/src/XcaNet.App/ViewModels/Pages/CertificateRevocationListsPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificateRevocationListsPageViewModel.cs
@@ -27,5 +27,7 @@ public sealed class CertificateRevocationListsPageViewModel : SelectableItemsPag
 
     public ICommand? OpenIssuerCommand { get; set; }
 
+    public ICommand? OpenRenameDialogCommand { get; set; }
+
     protected override Guid GetItemId(CertificateRevocationListItem item) => item.CertificateRevocationListId;
 }

--- a/src/XcaNet.App/ViewModels/Pages/CertificatesPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/CertificatesPageViewModel.cs
@@ -208,6 +208,8 @@ public sealed class CertificatesPageViewModel : SelectableItemsPageViewModelBase
 
     public ICommand? TogglePlainViewCommand { get; set; }
 
+    public ICommand? OpenRenameDialogCommand { get; set; }
+
     // --- Tree building ---
 
     public void RebuildTree(IReadOnlyList<CertificateListItem> items)

--- a/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/PrivateKeysPageViewModel.cs
@@ -166,6 +166,8 @@ public sealed class PrivateKeysPageViewModel : SelectableItemsPageViewModelBase<
 
     public ICommand? DeleteSelectedCommand { get; set; }
 
+    public ICommand? OpenRenameDialogCommand { get; set; }
+
     public void SetTemplates(IEnumerable<TemplateListItem> templates)
     {
         ResetTemplateCollection(SelfSignedCaAuthoring.Templates, templates.Where(x => x.IntendedUsage == TemplateIntendedUsage.SelfSignedCa && x.IsEnabled));

--- a/src/XcaNet.App/ViewModels/Pages/TemplatesPageViewModel.cs
+++ b/src/XcaNet.App/ViewModels/Pages/TemplatesPageViewModel.cs
@@ -177,6 +177,8 @@ public sealed class TemplatesPageViewModel : SelectableItemsPageViewModelBase<Te
 
     public ICommand? DeleteTemplateCommand { get; set; }
 
+    public ICommand? OpenRenameDialogCommand { get; set; }
+
     protected override Guid GetItemId(TemplateListItem item) => item.TemplateId;
 
     public void SetTemplates(IEnumerable<TemplateListItem> items)

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -79,6 +79,17 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly DelegateCommand _closeRevokeDialogCommand;
     private readonly DelegateCommand _togglePlainViewCommand;
 
+    // M15 commands
+    private readonly DelegateCommand _openAboutCommand;
+    private readonly DelegateCommand _closeAboutCommand;
+    private readonly DelegateCommand _openOidResolverCommand;
+    private readonly DelegateCommand _closeOidResolverCommand;
+    private readonly DelegateCommand _resolveOidCommand;
+    private readonly DelegateCommand _openPasswordChangeCommand;
+    private readonly DelegateCommand _closePasswordChangeCommand;
+    private readonly AsyncCommand _confirmPasswordChangeCommand;
+    private readonly AsyncCommand _pastePemCommand;
+
     private PageViewModelBase _currentPage;
     private string _subtitle = "Core UI workflows";
     private bool _isBusy;
@@ -88,6 +99,15 @@ public sealed class ShellViewModel : ViewModelBase
     private CertificateAuthoringViewModel? _activeCertificateAuthoring;
     private string _authoringDialogTitle = string.Empty;
     private string _authoringDialogSubtitle = string.Empty;
+
+    // M15 dialog state
+    private bool _isAboutDialogOpen;
+    private bool _isOidResolverDialogOpen;
+    private bool _isPasswordChangeDialogOpen;
+    private string _oidResolverInput = string.Empty;
+    private string _oidResolverResult = string.Empty;
+    private string _passwordChangeNew = string.Empty;
+    private string _passwordChangeConfirm = string.Empty;
 
     public ShellViewModel(IDatabaseSessionService databaseSessionService, IDesktopFileDialogService fileDialogService, ILogger<ShellViewModel> logger)
     {
@@ -159,6 +179,16 @@ public sealed class ShellViewModel : ViewModelBase
         _openRevokeDialogCommand = new DelegateCommand(OpenRevokeDialog, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && CertificatesPage.SelectedItem is { } cert && !string.Equals(cert.RevocationStatus, "Revoked", StringComparison.OrdinalIgnoreCase));
         _closeRevokeDialogCommand = new DelegateCommand(() => CertificatesPage.IsRevokeDialogOpen = false);
         _togglePlainViewCommand = new DelegateCommand(() => CertificatesPage.IsPlainView = !CertificatesPage.IsPlainView);
+
+        _openAboutCommand = new DelegateCommand(() => IsAboutDialogOpen = true);
+        _closeAboutCommand = new DelegateCommand(() => IsAboutDialogOpen = false);
+        _openOidResolverCommand = new DelegateCommand(() => { OidResolverInput = string.Empty; OidResolverResult = string.Empty; IsOidResolverDialogOpen = true; });
+        _closeOidResolverCommand = new DelegateCommand(() => IsOidResolverDialogOpen = false);
+        _resolveOidCommand = new DelegateCommand(ResolveOid, () => !string.IsNullOrWhiteSpace(OidResolverInput));
+        _openPasswordChangeCommand = new DelegateCommand(() => { PasswordChangeNew = string.Empty; PasswordChangeConfirm = string.Empty; IsPasswordChangeDialogOpen = true; }, () => Snapshot.State == DatabaseSessionState.Unlocked);
+        _closePasswordChangeCommand = new DelegateCommand(() => IsPasswordChangeDialogOpen = false);
+        _confirmPasswordChangeCommand = new AsyncCommand(ConfirmPasswordChangeAsync, () => !IsBusy && !string.IsNullOrWhiteSpace(PasswordChangeNew) && PasswordChangeNew == PasswordChangeConfirm);
+        _pastePemCommand = new AsyncCommand(PastePemAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked);
 
         SettingsSecurityPage.CreateDatabaseCommand = _createDatabaseCommand;
         SettingsSecurityPage.OpenDatabaseCommand = _openDatabaseCommand;
@@ -389,6 +419,82 @@ public sealed class ShellViewModel : ViewModelBase
     public ICommand DashboardCommand => UtilityNavigationItems[0].Command;
 
     public ICommand SettingsSecurityCommand => UtilityNavigationItems[1].Command;
+
+    // M15 dialog state properties
+
+    public bool IsAboutDialogOpen
+    {
+        get => _isAboutDialogOpen;
+        set => SetProperty(ref _isAboutDialogOpen, value);
+    }
+
+    public bool IsOidResolverDialogOpen
+    {
+        get => _isOidResolverDialogOpen;
+        set => SetProperty(ref _isOidResolverDialogOpen, value);
+    }
+
+    public bool IsPasswordChangeDialogOpen
+    {
+        get => _isPasswordChangeDialogOpen;
+        set => SetProperty(ref _isPasswordChangeDialogOpen, value);
+    }
+
+    public string OidResolverInput
+    {
+        get => _oidResolverInput;
+        set
+        {
+            if (SetProperty(ref _oidResolverInput, value))
+                _resolveOidCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    public string OidResolverResult
+    {
+        get => _oidResolverResult;
+        set => SetProperty(ref _oidResolverResult, value);
+    }
+
+    public string PasswordChangeNew
+    {
+        get => _passwordChangeNew;
+        set
+        {
+            if (SetProperty(ref _passwordChangeNew, value))
+                _confirmPasswordChangeCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    public string PasswordChangeConfirm
+    {
+        get => _passwordChangeConfirm;
+        set
+        {
+            if (SetProperty(ref _passwordChangeConfirm, value))
+                _confirmPasswordChangeCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    // M15 command accessors
+
+    public ICommand OpenAboutCommand => _openAboutCommand;
+
+    public ICommand CloseAboutCommand => _closeAboutCommand;
+
+    public ICommand OpenOidResolverCommand => _openOidResolverCommand;
+
+    public ICommand CloseOidResolverCommand => _closeOidResolverCommand;
+
+    public ICommand ResolveOidCommand => _resolveOidCommand;
+
+    public ICommand OpenPasswordChangeCommand => _openPasswordChangeCommand;
+
+    public ICommand ClosePasswordChangeCommand => _closePasswordChangeCommand;
+
+    public ICommand ConfirmPasswordChangeCommand => _confirmPasswordChangeCommand;
+
+    public ICommand PastePemCommand => _pastePemCommand;
 
     private async Task CreateDatabaseAsync()
     {
@@ -1666,6 +1772,67 @@ public sealed class ShellViewModel : ViewModelBase
         }
     }
 
+    private void ResolveOid()
+    {
+        if (string.IsNullOrWhiteSpace(_oidResolverInput))
+        {
+            OidResolverResult = string.Empty;
+            return;
+        }
+
+        try
+        {
+            var oid = new System.Security.Cryptography.Oid(_oidResolverInput.Trim());
+            if (oid.Value is null && oid.FriendlyName is null)
+            {
+                OidResolverResult = "OID not found.";
+            }
+            else
+            {
+                OidResolverResult = $"OID: {oid.Value ?? "(unknown)"}\nName: {oid.FriendlyName ?? "(unknown)"}";
+            }
+        }
+        catch
+        {
+            OidResolverResult = "Invalid OID or name.";
+        }
+    }
+
+    private async Task ConfirmPasswordChangeAsync()
+    {
+        if (string.IsNullOrWhiteSpace(PasswordChangeNew) || PasswordChangeNew != PasswordChangeConfirm)
+        {
+            NotifyFailure("Passwords do not match.");
+            return;
+        }
+
+        using var scope = BeginBusy("Changing password");
+        var result = await _databaseSessionService.ChangePasswordAsync(PasswordChangeNew, CancellationToken.None);
+        IsPasswordChangeDialogOpen = false;
+        if (!result.IsSuccess)
+        {
+            NotifyFailure(result.Message);
+            return;
+        }
+
+        NotifySuccess("Password changed.");
+    }
+
+    private async Task PastePemAsync()
+    {
+        var text = await _fileDialogService.GetClipboardTextAsync(CancellationToken.None);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            NotifyFailure("Clipboard is empty or does not contain text.");
+            return;
+        }
+
+        CertificatesPage.ImportPayload = text;
+        CertificatesPage.ImportDisplayName = "Pasted PEM";
+        SelectPage(CertificatesPage);
+        NotifySuccess("PEM content pasted — review and confirm in the Import dialog.");
+    }
+
     private void RefreshCommandStates()
     {
         _createDatabaseCommand.RaiseCanExecuteChanged();
@@ -1721,6 +1888,9 @@ public sealed class ShellViewModel : ViewModelBase
         _openRevokeDialogCommand.RaiseCanExecuteChanged();
         _closeRevokeDialogCommand.RaiseCanExecuteChanged();
         _togglePlainViewCommand.RaiseCanExecuteChanged();
+        _openPasswordChangeCommand.RaiseCanExecuteChanged();
+        _confirmPasswordChangeCommand.RaiseCanExecuteChanged();
+        _pastePemCommand.RaiseCanExecuteChanged();
     }
 
     private static IReadOnlyList<SanEntry> ParseSubjectAlternativeNames(string value)

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -91,6 +91,9 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly AsyncCommand _confirmPasswordChangeCommand;
     private readonly AsyncCommand _pastePemCommand;
     private readonly DelegateCommand _setDefaultDatabaseCommand;
+    private readonly DelegateCommand _openRenameDialogCommand;
+    private readonly DelegateCommand _closeRenameDialogCommand;
+    private readonly AsyncCommand _confirmRenameCommand;
 
     private PageViewModelBase _currentPage;
     private string _subtitle = "Core UI workflows";
@@ -101,6 +104,10 @@ public sealed class ShellViewModel : ViewModelBase
     private CertificateAuthoringViewModel? _activeCertificateAuthoring;
     private string _authoringDialogTitle = string.Empty;
     private string _authoringDialogSubtitle = string.Empty;
+
+    // M15.7 rename state
+    private bool _isRenameDialogOpen;
+    private string _renamePendingName = string.Empty;
 
     // M15 dialog state
     private bool _isAboutDialogOpen;
@@ -193,6 +200,9 @@ public sealed class ShellViewModel : ViewModelBase
         _confirmPasswordChangeCommand = new AsyncCommand(ConfirmPasswordChangeAsync, () => !IsBusy && !string.IsNullOrWhiteSpace(PasswordChangeNew) && PasswordChangeNew == PasswordChangeConfirm);
         _pastePemCommand = new AsyncCommand(PastePemAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked);
         _setDefaultDatabaseCommand = new DelegateCommand(SetDefaultDatabase, () => Snapshot.DatabasePath is not null);
+        _openRenameDialogCommand = new DelegateCommand(OpenRenameDialog, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked && HasActiveSelection());
+        _closeRenameDialogCommand = new DelegateCommand(() => IsRenameDialogOpen = false);
+        _confirmRenameCommand = new AsyncCommand(ConfirmRenameAsync, () => !IsBusy && !string.IsNullOrWhiteSpace(RenamePendingName));
 
         if (_userPreferences.DefaultDatabasePath is { } defaultPath)
             SettingsSecurityPage.DatabasePath = defaultPath;
@@ -219,6 +229,7 @@ public sealed class ShellViewModel : ViewModelBase
         CertificatesPage.OpenRevokeDialogCommand = _openRevokeDialogCommand;
         CertificatesPage.CloseRevokeDialogCommand = _closeRevokeDialogCommand;
         CertificatesPage.TogglePlainViewCommand = _togglePlainViewCommand;
+        CertificatesPage.OpenRenameDialogCommand = _openRenameDialogCommand;
 
         PrivateKeysPage.RefreshCommand = _refreshPrivateKeysCommand;
         PrivateKeysPage.GenerateKeyCommand = _generateKeyCommand;
@@ -230,6 +241,7 @@ public sealed class ShellViewModel : ViewModelBase
         PrivateKeysPage.ApplyCertificateSigningRequestTemplateCommand = _applyCertificateSigningRequestTemplateCommand;
         PrivateKeysPage.ExportSelectedCommand = _exportPrivateKeyCommand;
         PrivateKeysPage.ExportSelectedToFileCommand = _exportPrivateKeyToFileCommand;
+        PrivateKeysPage.OpenRenameDialogCommand = _openRenameDialogCommand;
         PrivateKeysPage.SelfSignedCaAuthoring.ApplyTemplateCommand = _applySelfSignedCaTemplateCommand;
         PrivateKeysPage.SelfSignedCaAuthoring.PrimaryActionCommand = _createSelfSignedCaCommand;
         PrivateKeysPage.CertificateSigningRequestAuthoring.ApplyTemplateCommand = _applyCertificateSigningRequestTemplateCommand;
@@ -244,12 +256,14 @@ public sealed class ShellViewModel : ViewModelBase
         CertificateRequestsPage.OpenSelectedPrivateKeyCommand = _navigateRequestPrivateKeyCommand;
         CertificateRequestsPage.CreateTemplateFromRequestCommand = _createTemplateFromRequestCommand;
         CertificateRequestsPage.CreateSimilarRequestCommand = _createSimilarRequestCommand;
+        CertificateRequestsPage.OpenRenameDialogCommand = _openRenameDialogCommand;
         CertificateRequestsPage.IssuanceAuthoring.ApplyTemplateCommand = _applyIssuanceTemplateCommand;
         CertificateRequestsPage.IssuanceAuthoring.PrimaryActionCommand = _signCertificateSigningRequestCommand;
 
         CertificateRevocationListsPage.RefreshCommand = _refreshCertificateRevocationListsCommand;
         CertificateRevocationListsPage.ExportSelectedCommand = _exportCertificateRevocationListToFileCommand;
         CertificateRevocationListsPage.OpenIssuerCommand = _navigateCrlIssuerCommand;
+        CertificateRevocationListsPage.OpenRenameDialogCommand = _openRenameDialogCommand;
         TemplatesPage.RefreshCommand = _refreshTemplatesCommand;
         TemplatesPage.CreateNewCommand = _createTemplateCommand;
         TemplatesPage.EditTemplateCommand = _editTemplateCommand;
@@ -259,6 +273,7 @@ public sealed class ShellViewModel : ViewModelBase
         TemplatesPage.ToggleEnabledCommand = _toggleTemplateEnabledCommand;
         TemplatesPage.DeleteTemplateCommand = _deleteTemplateCommand;
         TemplatesPage.Authoring.PrimaryActionCommand = _saveTemplateCommand;
+        TemplatesPage.OpenRenameDialogCommand = _openRenameDialogCommand;
 
         WorkspaceNavigationItems =
         [
@@ -506,6 +521,28 @@ public sealed class ShellViewModel : ViewModelBase
     public ICommand PastePemCommand => _pastePemCommand;
 
     public ICommand SetDefaultDatabaseCommand => _setDefaultDatabaseCommand;
+
+    public ICommand OpenRenameDialogCommand => _openRenameDialogCommand;
+
+    public ICommand CloseRenameDialogCommand => _closeRenameDialogCommand;
+
+    public ICommand ConfirmRenameCommand => _confirmRenameCommand;
+
+    public bool IsRenameDialogOpen
+    {
+        get => _isRenameDialogOpen;
+        set => SetProperty(ref _isRenameDialogOpen, value);
+    }
+
+    public string RenamePendingName
+    {
+        get => _renamePendingName;
+        set
+        {
+            if (SetProperty(ref _renamePendingName, value))
+                _confirmRenameCommand.RaiseCanExecuteChanged();
+        }
+    }
 
     public ObservableCollection<RecentDatabaseItemViewModel> RecentDatabases { get; } = [];
 
@@ -1852,6 +1889,80 @@ public sealed class ShellViewModel : ViewModelBase
         NotifySuccess("PEM content pasted — review and confirm in the Import dialog.");
     }
 
+    private bool HasActiveSelection() => CurrentPage switch
+    {
+        var p when p == CertificatesPage => CertificatesPage.SelectedItem is not null,
+        var p when p == PrivateKeysPage => PrivateKeysPage.SelectedItem is not null,
+        var p when p == CertificateRequestsPage => CertificateRequestsPage.SelectedItem is not null,
+        var p when p == CertificateRevocationListsPage => CertificateRevocationListsPage.SelectedItem is not null,
+        var p when p == TemplatesPage => TemplatesPage.SelectedItem is not null,
+        _ => false
+    };
+
+    private void OpenRenameDialog()
+    {
+        var currentName = CurrentPage switch
+        {
+            var p when p == CertificatesPage => CertificatesPage.SelectedItem?.DisplayName,
+            var p when p == PrivateKeysPage => PrivateKeysPage.SelectedItem?.DisplayName,
+            var p when p == CertificateRequestsPage => CertificateRequestsPage.SelectedItem?.DisplayName,
+            var p when p == CertificateRevocationListsPage => CertificateRevocationListsPage.SelectedItem?.DisplayName,
+            var p when p == TemplatesPage => TemplatesPage.SelectedItem?.Name,
+            _ => null
+        };
+
+        if (currentName is null) return;
+        RenamePendingName = currentName;
+        IsRenameDialogOpen = true;
+    }
+
+    private async Task ConfirmRenameAsync()
+    {
+        var newName = RenamePendingName.Trim();
+        if (string.IsNullOrWhiteSpace(newName)) return;
+
+        (BrowserEntityType kind, Guid id) = CurrentPage switch
+        {
+            var p when p == CertificatesPage && CertificatesPage.SelectedItem is { } cert =>
+                (BrowserEntityType.Certificate, cert.CertificateId),
+            var p when p == PrivateKeysPage && PrivateKeysPage.SelectedItem is { } key =>
+                (BrowserEntityType.PrivateKey, key.PrivateKeyId),
+            var p when p == CertificateRequestsPage && CertificateRequestsPage.SelectedItem is { } csr =>
+                (BrowserEntityType.CertificateSigningRequest, csr.CertificateSigningRequestId),
+            var p when p == CertificateRevocationListsPage && CertificateRevocationListsPage.SelectedItem is { } crl =>
+                (BrowserEntityType.CertificateRevocationList, crl.CertificateRevocationListId),
+            var p when p == TemplatesPage && TemplatesPage.SelectedItem is { } tmpl =>
+                (BrowserEntityType.Template, tmpl.TemplateId),
+            _ => (BrowserEntityType.Certificate, Guid.Empty)
+        };
+
+        if (id == Guid.Empty) return;
+
+        using var scope = BeginBusy("Renaming");
+        var result = await _databaseSessionService.RenameStoredItemAsync(
+            new RenameStoredItemRequest(kind, id, newName), CancellationToken.None);
+
+        if (!result.IsSuccess)
+        {
+            NotifyFailure(result.Message);
+            return;
+        }
+
+        IsRenameDialogOpen = false;
+        await RefreshCurrentPageAsync();
+        NotifySuccess($"Renamed to \"{newName}\".");
+    }
+
+    private Task RefreshCurrentPageAsync() => CurrentPage switch
+    {
+        var p when p == CertificatesPage => LoadCertificatesAsync(),
+        var p when p == PrivateKeysPage => LoadPrivateKeysAsync(),
+        var p when p == CertificateRequestsPage => LoadCertificateRequestsAsync(),
+        var p when p == CertificateRevocationListsPage => LoadCertificateRevocationListsAsync(),
+        var p when p == TemplatesPage => LoadTemplatesAsync(),
+        _ => Task.CompletedTask
+    };
+
     private void RecordRecentDatabase(string path)
     {
         _userPreferences.AddRecentDatabase(path);
@@ -1943,6 +2054,8 @@ public sealed class ShellViewModel : ViewModelBase
         _confirmPasswordChangeCommand.RaiseCanExecuteChanged();
         _pastePemCommand.RaiseCanExecuteChanged();
         _setDefaultDatabaseCommand.RaiseCanExecuteChanged();
+        _openRenameDialogCommand.RaiseCanExecuteChanged();
+        _confirmRenameCommand.RaiseCanExecuteChanged();
     }
 
     private static IReadOnlyList<SanEntry> ParseSubjectAlternativeNames(string value)

--- a/src/XcaNet.App/ViewModels/ShellViewModel.cs
+++ b/src/XcaNet.App/ViewModels/ShellViewModel.cs
@@ -22,6 +22,7 @@ public sealed class ShellViewModel : ViewModelBase
 {
     private readonly IDatabaseSessionService _databaseSessionService;
     private readonly IDesktopFileDialogService _fileDialogService;
+    private readonly IUserPreferencesService _userPreferences;
     private readonly ILogger<ShellViewModel> _logger;
 
     private readonly AsyncCommand _createDatabaseCommand;
@@ -89,6 +90,7 @@ public sealed class ShellViewModel : ViewModelBase
     private readonly DelegateCommand _closePasswordChangeCommand;
     private readonly AsyncCommand _confirmPasswordChangeCommand;
     private readonly AsyncCommand _pastePemCommand;
+    private readonly DelegateCommand _setDefaultDatabaseCommand;
 
     private PageViewModelBase _currentPage;
     private string _subtitle = "Core UI workflows";
@@ -109,10 +111,11 @@ public sealed class ShellViewModel : ViewModelBase
     private string _passwordChangeNew = string.Empty;
     private string _passwordChangeConfirm = string.Empty;
 
-    public ShellViewModel(IDatabaseSessionService databaseSessionService, IDesktopFileDialogService fileDialogService, ILogger<ShellViewModel> logger)
+    public ShellViewModel(IDatabaseSessionService databaseSessionService, IDesktopFileDialogService fileDialogService, IUserPreferencesService userPreferences, ILogger<ShellViewModel> logger)
     {
         _databaseSessionService = databaseSessionService;
         _fileDialogService = fileDialogService;
+        _userPreferences = userPreferences;
         _logger = logger;
 
         logger.LogInformation("Initializing XcaNet shell.");
@@ -189,6 +192,12 @@ public sealed class ShellViewModel : ViewModelBase
         _closePasswordChangeCommand = new DelegateCommand(() => IsPasswordChangeDialogOpen = false);
         _confirmPasswordChangeCommand = new AsyncCommand(ConfirmPasswordChangeAsync, () => !IsBusy && !string.IsNullOrWhiteSpace(PasswordChangeNew) && PasswordChangeNew == PasswordChangeConfirm);
         _pastePemCommand = new AsyncCommand(PastePemAsync, () => !IsBusy && Snapshot.State == DatabaseSessionState.Unlocked);
+        _setDefaultDatabaseCommand = new DelegateCommand(SetDefaultDatabase, () => Snapshot.DatabasePath is not null);
+
+        if (_userPreferences.DefaultDatabasePath is { } defaultPath)
+            SettingsSecurityPage.DatabasePath = defaultPath;
+
+        RefreshRecentDatabases();
 
         SettingsSecurityPage.CreateDatabaseCommand = _createDatabaseCommand;
         SettingsSecurityPage.OpenDatabaseCommand = _openDatabaseCommand;
@@ -496,20 +505,30 @@ public sealed class ShellViewModel : ViewModelBase
 
     public ICommand PastePemCommand => _pastePemCommand;
 
+    public ICommand SetDefaultDatabaseCommand => _setDefaultDatabaseCommand;
+
+    public ObservableCollection<RecentDatabaseItemViewModel> RecentDatabases { get; } = [];
+
     private async Task CreateDatabaseAsync()
     {
+        var path = SettingsSecurityPage.DatabasePath;
         await RunDatabaseActionAsync(
             "Creating database",
             () => _databaseSessionService.CreateDatabaseAsync(
-                new CreateDatabaseRequest(SettingsSecurityPage.DatabasePath, SettingsSecurityPage.Password, SettingsSecurityPage.DisplayName),
+                new CreateDatabaseRequest(path, SettingsSecurityPage.Password, SettingsSecurityPage.DisplayName),
                 CancellationToken.None));
+        if (Snapshot.DatabasePath == path)
+            RecordRecentDatabase(path);
     }
 
     private async Task OpenDatabaseAsync()
     {
+        var path = SettingsSecurityPage.DatabasePath;
         await RunDatabaseActionAsync(
             "Opening database",
-            () => _databaseSessionService.OpenDatabaseAsync(new OpenDatabaseRequest(SettingsSecurityPage.DatabasePath), CancellationToken.None));
+            () => _databaseSessionService.OpenDatabaseAsync(new OpenDatabaseRequest(path), CancellationToken.None));
+        if (Snapshot.DatabasePath == path)
+            RecordRecentDatabase(path);
     }
 
     private async Task UnlockDatabaseAsync()
@@ -1833,6 +1852,38 @@ public sealed class ShellViewModel : ViewModelBase
         NotifySuccess("PEM content pasted — review and confirm in the Import dialog.");
     }
 
+    private void RecordRecentDatabase(string path)
+    {
+        _userPreferences.AddRecentDatabase(path);
+        _userPreferences.Save();
+        RefreshRecentDatabases();
+    }
+
+    private void SetDefaultDatabase()
+    {
+        var path = Snapshot.DatabasePath;
+        if (path is null) return;
+        _userPreferences.SetDefaultDatabase(path);
+        _userPreferences.Save();
+        NotifySuccess($"Set default database: {path}");
+    }
+
+    private void RefreshRecentDatabases()
+    {
+        RecentDatabases.Clear();
+        foreach (var path in _userPreferences.RecentDatabases)
+        {
+            var captured = path;
+            RecentDatabases.Add(new RecentDatabaseItemViewModel(captured, new DelegateCommand(async () =>
+            {
+                SettingsSecurityPage.DatabasePath = captured;
+                await RunDatabaseActionAsync(
+                    "Opening database",
+                    () => _databaseSessionService.OpenDatabaseAsync(new OpenDatabaseRequest(captured), CancellationToken.None));
+            })));
+        }
+    }
+
     private void RefreshCommandStates()
     {
         _createDatabaseCommand.RaiseCanExecuteChanged();
@@ -1891,6 +1942,7 @@ public sealed class ShellViewModel : ViewModelBase
         _openPasswordChangeCommand.RaiseCanExecuteChanged();
         _confirmPasswordChangeCommand.RaiseCanExecuteChanged();
         _pastePemCommand.RaiseCanExecuteChanged();
+        _setDefaultDatabaseCommand.RaiseCanExecuteChanged();
     }
 
     private static IReadOnlyList<SanEntry> ParseSubjectAlternativeNames(string value)

--- a/src/XcaNet.App/Views/MainWindow.axaml
+++ b/src/XcaNet.App/Views/MainWindow.axaml
@@ -35,6 +35,7 @@
           <MenuItem Header="Revocation list" Command="{Binding ImportFilesCommand}" />
           <Separator />
           <MenuItem Header="PEM file" Command="{Binding ImportFilesCommand}" />
+          <MenuItem Header="Paste PEM" Command="{Binding PastePemCommand}" />
         </MenuItem>
         <MenuItem Header="_Token">
           <MenuItem Header="Manage Security token" IsEnabled="False" />
@@ -49,16 +50,16 @@
           <MenuItem Header="Certificate index export" IsEnabled="False" />
           <MenuItem Header="Hierarchy export" IsEnabled="False" />
           <Separator />
-          <MenuItem Header="Password change" IsEnabled="False" />
+          <MenuItem Header="Change Database password" Command="{Binding OpenPasswordChangeCommand}" />
           <Separator />
           <MenuItem Header="DH parameter generation" IsEnabled="False" />
-          <MenuItem Header="OID Resolver" IsEnabled="False" />
+          <MenuItem Header="OID Resolver" Command="{Binding OpenOidResolverCommand}" />
         </MenuItem>
         <MenuItem Header="_Help">
           <MenuItem Header="Overview" Command="{Binding DashboardCommand}" />
           <MenuItem Header="Documentation" IsEnabled="False" />
           <Separator />
-          <MenuItem Header="About" IsEnabled="False" />
+          <MenuItem Header="About" Command="{Binding OpenAboutCommand}" />
         </MenuItem>
       </Menu>
       <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,8,0" Spacing="10">
@@ -96,6 +97,7 @@
       </Grid>
     </Border>
 
+    <!-- Certificate authoring overlay -->
     <Border Grid.RowSpan="4"
             Background="{DynamicResource DialogOverlayBrush}"
             IsVisible="{Binding IsAuthoringDialogOpen}">
@@ -125,5 +127,102 @@
         </Border>
       </Grid>
     </Border>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- About dialog overlay                                               -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="4"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsAboutDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="380"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="24">
+        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="8">
+          <TextBlock Text="XcaNet" FontSize="22" FontWeight="Bold" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="1" Text="Version 0.1.0" Classes="secondary-text" HorizontalAlignment="Center" />
+          <TextBlock Grid.Row="2" Text="Cross-platform PKI manager" Classes="secondary-text" HorizontalAlignment="Center" />
+          <Separator Grid.Row="3" Margin="0,4" />
+          <TextBlock Grid.Row="4" Text="Copyright © 2024–2026 XcaNet contributors" Classes="secondary-text" HorizontalAlignment="Center" TextWrapping="Wrap" TextAlignment="Center" />
+          <TextBlock Grid.Row="5" Text="Licensed under the MIT License" Classes="secondary-text" HorizontalAlignment="Center" />
+          <Button Grid.Row="6" Content="Close" Command="{Binding CloseAboutCommand}" HorizontalAlignment="Center" MinWidth="80" Margin="0,8,0,0" />
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- OID Resolver dialog overlay                                        -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="4"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsOidResolverDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="440"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="12">
+
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="OID Resolver" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Close" Command="{Binding CloseOidResolverCommand}" />
+          </Grid>
+
+          <TextBox Grid.Row="1"
+                   Text="{Binding OidResolverInput}"
+                   Watermark="Enter OID (e.g. 2.5.4.3) or name (e.g. commonName)" />
+
+          <Button Grid.Row="2" Content="Resolve" Command="{Binding ResolveOidCommand}" HorizontalAlignment="Left" />
+
+          <Border Grid.Row="3" Classes="workspace-pane" Padding="8" MinHeight="60">
+            <TextBlock Text="{Binding OidResolverResult}"
+                       TextWrapping="Wrap"
+                       Classes="secondary-text" />
+          </Border>
+        </Grid>
+      </Border>
+    </Grid>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- Change Password dialog overlay                                     -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="4"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsPasswordChangeDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="400"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="Change Database Password" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Close" Command="{Binding ClosePasswordChangeCommand}" />
+          </Grid>
+
+          <Grid Grid.Row="1" ColumnDefinitions="140,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="10">
+            <TextBlock Text="New password" VerticalAlignment="Center" />
+            <TextBox Grid.Column="1"
+                     Text="{Binding PasswordChangeNew}"
+                     PasswordChar="*"
+                     Watermark="New password" />
+            <TextBlock Grid.Row="1" Text="Confirm password" VerticalAlignment="Center" />
+            <TextBox Grid.Row="1" Grid.Column="1"
+                     Text="{Binding PasswordChangeConfirm}"
+                     PasswordChar="*"
+                     Watermark="Confirm new password" />
+          </Grid>
+
+          <Grid Grid.Row="2" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+            <TextBlock Classes="secondary-text" Text="Re-encrypts all stored private keys." VerticalAlignment="Center" TextWrapping="Wrap" />
+            <Button Grid.Column="1" Content="Change" Command="{Binding ConfirmPasswordChangeCommand}" />
+            <Button Grid.Column="2" Content="Cancel" Command="{Binding ClosePasswordChangeCommand}" />
+          </Grid>
+        </Grid>
+      </Border>
+    </Grid>
+
   </Grid>
 </Window>

--- a/src/XcaNet.App/Views/MainWindow.axaml
+++ b/src/XcaNet.App/Views/MainWindow.axaml
@@ -234,5 +234,36 @@
       </Border>
     </Grid>
 
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- Rename dialog overlay                                              -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <Grid Grid.RowSpan="4"
+          Background="{DynamicResource DialogOverlayBrush}"
+          IsVisible="{Binding IsRenameDialogOpen}">
+      <Border Classes="authoring-dialog-shell"
+              Width="380"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Padding="16">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="12">
+
+          <Grid ColumnDefinitions="*,Auto">
+            <TextBlock Text="Rename" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Close" Command="{Binding CloseRenameDialogCommand}" />
+          </Grid>
+
+          <TextBox Grid.Row="1"
+                   Text="{Binding RenamePendingName}"
+                   Watermark="New name" />
+
+          <Grid Grid.Row="2" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+            <TextBlock Classes="secondary-text" Text="Enter a new display name." VerticalAlignment="Center" />
+            <Button Grid.Column="1" Content="Rename" Command="{Binding ConfirmRenameCommand}" />
+            <Button Grid.Column="2" Content="Cancel" Command="{Binding CloseRenameDialogCommand}" />
+          </Grid>
+        </Grid>
+      </Border>
+    </Grid>
+
   </Grid>
 </Window>

--- a/src/XcaNet.App/Views/MainWindow.axaml
+++ b/src/XcaNet.App/Views/MainWindow.axaml
@@ -21,6 +21,16 @@
           <Separator />
           <MenuItem Header="Options" Command="{Binding SettingsSecurityCommand}" />
           <Separator />
+          <MenuItem Header="Set as Default Database" Command="{Binding SetDefaultDatabaseCommand}" />
+          <MenuItem Header="Recent Databases" ItemsSource="{Binding RecentDatabases}">
+            <MenuItem.ItemContainerTheme>
+              <ControlTheme TargetType="MenuItem">
+                <Setter Property="Header" Value="{Binding Header}" />
+                <Setter Property="Command" Value="{Binding Command}" />
+              </ControlTheme>
+            </MenuItem.ItemContainerTheme>
+          </MenuItem>
+          <Separator />
           <MenuItem Header="Exit" Command="{Binding ExitCommand}" />
         </MenuItem>
         <MenuItem Header="_Import">

--- a/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificateRequestsPageView.axaml
@@ -20,6 +20,9 @@
             <TextBlock Text="{Binding EmptyStateMessage}" TextWrapping="Wrap" />
           </Border>
           <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+            <ListBox.KeyBindings>
+              <KeyBinding Gesture="F2" Command="{Binding OpenRenameDialogCommand}" />
+            </ListBox.KeyBindings>
             <ListBox.ContextMenu>
               <ContextMenu>
                 <MenuItem Header="Show Details" Command="{Binding ShowDetailsCommand}" />

--- a/src/XcaNet.App/Views/Pages/CertificateRevocationListsPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificateRevocationListsPageView.axaml
@@ -19,6 +19,9 @@
             <TextBlock Text="{Binding EmptyStateMessage}" TextWrapping="Wrap" />
           </Border>
           <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+            <ListBox.KeyBindings>
+              <KeyBinding Gesture="F2" Command="{Binding OpenRenameDialogCommand}" />
+            </ListBox.KeyBindings>
             <ListBox.ItemTemplate>
               <DataTemplate>
                 <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">

--- a/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/CertificatesPageView.axaml
@@ -43,6 +43,9 @@
           <TreeView ItemsSource="{Binding CertificateTreeRoots}"
                     SelectedItem="{Binding SelectedTreeNode}"
                     IsVisible="{Binding !IsPlainView}">
+            <TreeView.KeyBindings>
+              <KeyBinding Gesture="F2" Command="{Binding OpenRenameDialogCommand}" />
+            </TreeView.KeyBindings>
             <TreeView.ContextMenu>
               <ContextMenu>
                 <MenuItem Header="Show Details" Command="{Binding ShowDetailsCommand}" />
@@ -80,6 +83,9 @@
           <ListBox ItemsSource="{Binding Items}"
                    SelectedItem="{Binding SelectedItem}"
                    IsVisible="{Binding IsPlainView}">
+            <ListBox.KeyBindings>
+              <KeyBinding Gesture="F2" Command="{Binding OpenRenameDialogCommand}" />
+            </ListBox.KeyBindings>
             <ListBox.ContextMenu>
               <ContextMenu>
                 <MenuItem Header="Show Details" Command="{Binding ShowDetailsCommand}" />

--- a/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/PrivateKeysPageView.axaml
@@ -20,6 +20,9 @@
             <TextBlock Text="{Binding EmptyStateMessage}" TextWrapping="Wrap" />
           </Border>
           <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+            <ListBox.KeyBindings>
+              <KeyBinding Gesture="F2" Command="{Binding OpenRenameDialogCommand}" />
+            </ListBox.KeyBindings>
             <ListBox.ContextMenu>
               <ContextMenu>
                 <MenuItem Header="Show Details" Command="{Binding ShowDetailsCommand}" />

--- a/src/XcaNet.App/Views/Pages/TemplatesPageView.axaml
+++ b/src/XcaNet.App/Views/Pages/TemplatesPageView.axaml
@@ -24,6 +24,9 @@
             <TextBlock Text="{Binding EmptyStateMessage}" TextWrapping="Wrap" />
           </Border>
           <ListBox ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem}">
+            <ListBox.KeyBindings>
+              <KeyBinding Gesture="F2" Command="{Binding OpenRenameDialogCommand}" />
+            </ListBox.KeyBindings>
             <ListBox.ItemTemplate>
               <DataTemplate>
                 <Border Padding="8,6" BorderBrush="{DynamicResource BorderSubtleBrush}" BorderThickness="0,0,0,1">

--- a/src/XcaNet.Application/Services/DatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/DatabaseSessionService.cs
@@ -1460,6 +1460,45 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
         return Task.FromResult(OperationResult.Failure(OperationErrorCode.StorageFailure, "Password change is not yet implemented."));
     }
 
+    public async Task<OperationResult> RenameStoredItemAsync(RenameStoredItemRequest request, CancellationToken cancellationToken)
+    {
+        if (_currentDatabasePath is null)
+            return OperationResult.Failure(OperationErrorCode.StorageFailure, "No database is open.");
+
+        if (string.IsNullOrWhiteSpace(request.NewName))
+            return OperationResult.Failure(OperationErrorCode.ValidationFailed, "Name cannot be empty.");
+
+        try
+        {
+            switch (request.Kind)
+            {
+                case BrowserEntityType.Certificate:
+                    await _certificateRepository.UpdateDisplayNameAsync(_currentDatabasePath, request.Id, request.NewName.Trim(), cancellationToken);
+                    break;
+                case BrowserEntityType.PrivateKey:
+                    await _privateKeyRepository.UpdateDisplayNameAsync(_currentDatabasePath, request.Id, request.NewName.Trim(), cancellationToken);
+                    break;
+                case BrowserEntityType.CertificateSigningRequest:
+                    await _certificateRequestRepository.UpdateDisplayNameAsync(_currentDatabasePath, request.Id, request.NewName.Trim(), cancellationToken);
+                    break;
+                case BrowserEntityType.CertificateRevocationList:
+                    await _certificateRevocationListRepository.UpdateDisplayNameAsync(_currentDatabasePath, request.Id, request.NewName.Trim(), cancellationToken);
+                    break;
+                case BrowserEntityType.Template:
+                    await _templateRepository.UpdateDisplayNameAsync(_currentDatabasePath, request.Id, request.NewName.Trim(), cancellationToken);
+                    break;
+                default:
+                    return OperationResult.Failure(OperationErrorCode.ValidationFailed, $"Unknown entity type: {request.Kind}.");
+            }
+
+            return OperationResult.Success("Item renamed.");
+        }
+        catch (Exception ex)
+        {
+            return OperationResult.Failure(OperationErrorCode.StorageFailure, $"Could not rename item: {ex.Message}");
+        }
+    }
+
     public DatabaseSessionSnapshot GetSnapshot()
     {
         var message = _state switch

--- a/src/XcaNet.Application/Services/DatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/DatabaseSessionService.cs
@@ -1455,6 +1455,11 @@ public sealed class DatabaseSessionService : IDatabaseSessionService, IDisposabl
         }
     }
 
+    public Task<OperationResult> ChangePasswordAsync(string newPassword, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(OperationResult.Failure(OperationErrorCode.StorageFailure, "Password change is not yet implemented."));
+    }
+
     public DatabaseSessionSnapshot GetSnapshot()
     {
         var message = _state switch

--- a/src/XcaNet.Application/Services/IDatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/IDatabaseSessionService.cs
@@ -74,5 +74,7 @@ public interface IDatabaseSessionService
 
     Task<OperationResult<AppliedTemplateDefaults>> ApplyTemplateAsync(ApplyTemplateRequest request, CancellationToken cancellationToken);
 
+    Task<OperationResult> ChangePasswordAsync(string newPassword, CancellationToken cancellationToken);
+
     DatabaseSessionSnapshot GetSnapshot();
 }

--- a/src/XcaNet.Application/Services/IDatabaseSessionService.cs
+++ b/src/XcaNet.Application/Services/IDatabaseSessionService.cs
@@ -76,5 +76,7 @@ public interface IDatabaseSessionService
 
     Task<OperationResult> ChangePasswordAsync(string newPassword, CancellationToken cancellationToken);
 
+    Task<OperationResult> RenameStoredItemAsync(RenameStoredItemRequest request, CancellationToken cancellationToken);
+
     DatabaseSessionSnapshot GetSnapshot();
 }

--- a/src/XcaNet.Contracts/Database/RenameStoredItemRequest.cs
+++ b/src/XcaNet.Contracts/Database/RenameStoredItemRequest.cs
@@ -1,0 +1,5 @@
+using XcaNet.Contracts.Browser;
+
+namespace XcaNet.Contracts.Database;
+
+public sealed record RenameStoredItemRequest(BrowserEntityType Kind, Guid Id, string NewName);

--- a/src/XcaNet.Storage/Repositories/CertificateRepository.cs
+++ b/src/XcaNet.Storage/Repositories/CertificateRepository.cs
@@ -115,4 +115,12 @@ public sealed class CertificateRepository : ICertificateRepository
         certificate.RevokedAtUtc = revokedAtUtc;
         await dbContext.SaveChangesAsync(cancellationToken);
     }
+
+    public async Task UpdateDisplayNameAsync(string databasePath, Guid certificateId, string newName, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var certificate = await dbContext.Certificates.SingleAsync(x => x.Id == certificateId, cancellationToken);
+        certificate.DisplayName = newName;
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
 }

--- a/src/XcaNet.Storage/Repositories/CertificateRequestRepository.cs
+++ b/src/XcaNet.Storage/Repositories/CertificateRequestRepository.cs
@@ -34,4 +34,12 @@ public sealed class CertificateRequestRepository : ICertificateRequestRepository
             .OrderByDescending(x => x.CreatedUtc)
             .ToListAsync(cancellationToken);
     }
+
+    public async Task UpdateDisplayNameAsync(string databasePath, Guid certificateRequestId, string newName, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var request = await dbContext.CertificateRequests.SingleAsync(x => x.Id == certificateRequestId, cancellationToken);
+        request.DisplayName = newName;
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
 }

--- a/src/XcaNet.Storage/Repositories/CertificateRevocationListRepository.cs
+++ b/src/XcaNet.Storage/Repositories/CertificateRevocationListRepository.cs
@@ -38,4 +38,12 @@ public sealed class CertificateRevocationListRepository : ICertificateRevocation
             .OrderByDescending(x => x.ThisUpdateUtc)
             .ToListAsync(cancellationToken);
     }
+
+    public async Task UpdateDisplayNameAsync(string databasePath, Guid certificateRevocationListId, string newName, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var crl = await dbContext.CertificateRevocationLists.SingleAsync(x => x.Id == certificateRevocationListId, cancellationToken);
+        crl.DisplayName = newName;
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
 }

--- a/src/XcaNet.Storage/Repositories/ICertificateRepository.cs
+++ b/src/XcaNet.Storage/Repositories/ICertificateRepository.cs
@@ -20,4 +20,6 @@ public interface ICertificateRepository
         int? revocationReason,
         DateTime? revokedAtUtc,
         CancellationToken cancellationToken);
+
+    Task UpdateDisplayNameAsync(string databasePath, Guid certificateId, string newName, CancellationToken cancellationToken);
 }

--- a/src/XcaNet.Storage/Repositories/ICertificateRequestRepository.cs
+++ b/src/XcaNet.Storage/Repositories/ICertificateRequestRepository.cs
@@ -9,4 +9,6 @@ public interface ICertificateRequestRepository
     Task<CertificateRequestEntity?> GetAsync(string databasePath, Guid certificateRequestId, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<CertificateRequestEntity>> ListAsync(string databasePath, CancellationToken cancellationToken);
+
+    Task UpdateDisplayNameAsync(string databasePath, Guid certificateRequestId, string newName, CancellationToken cancellationToken);
 }

--- a/src/XcaNet.Storage/Repositories/ICertificateRevocationListRepository.cs
+++ b/src/XcaNet.Storage/Repositories/ICertificateRevocationListRepository.cs
@@ -9,4 +9,6 @@ public interface ICertificateRevocationListRepository
     Task<CertificateRevocationListEntity?> GetAsync(string databasePath, Guid certificateRevocationListId, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<CertificateRevocationListEntity>> ListAsync(string databasePath, CancellationToken cancellationToken);
+
+    Task UpdateDisplayNameAsync(string databasePath, Guid certificateRevocationListId, string newName, CancellationToken cancellationToken);
 }

--- a/src/XcaNet.Storage/Repositories/IPrivateKeyRepository.cs
+++ b/src/XcaNet.Storage/Repositories/IPrivateKeyRepository.cs
@@ -9,4 +9,6 @@ public interface IPrivateKeyRepository
     Task<PrivateKeyEntity?> GetAsync(string databasePath, Guid privateKeyId, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<PrivateKeyEntity>> ListAsync(string databasePath, CancellationToken cancellationToken);
+
+    Task UpdateDisplayNameAsync(string databasePath, Guid privateKeyId, string newName, CancellationToken cancellationToken);
 }

--- a/src/XcaNet.Storage/Repositories/ITemplateRepository.cs
+++ b/src/XcaNet.Storage/Repositories/ITemplateRepository.cs
@@ -11,4 +11,6 @@ public interface ITemplateRepository
     Task<bool> SetFavoriteAsync(string databasePath, Guid templateId, bool isFavorite, CancellationToken cancellationToken);
     Task<bool> SetEnabledAsync(string databasePath, Guid templateId, bool isEnabled, CancellationToken cancellationToken);
     Task<bool> DeleteAsync(string databasePath, Guid templateId, CancellationToken cancellationToken);
+
+    Task UpdateDisplayNameAsync(string databasePath, Guid templateId, string newName, CancellationToken cancellationToken);
 }

--- a/src/XcaNet.Storage/Repositories/PrivateKeyRepository.cs
+++ b/src/XcaNet.Storage/Repositories/PrivateKeyRepository.cs
@@ -34,4 +34,12 @@ public sealed class PrivateKeyRepository : IPrivateKeyRepository
             .OrderByDescending(x => x.CreatedUtc)
             .ToListAsync(cancellationToken);
     }
+
+    public async Task UpdateDisplayNameAsync(string databasePath, Guid privateKeyId, string newName, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var key = await dbContext.PrivateKeys.SingleAsync(x => x.Id == privateKeyId, cancellationToken);
+        key.DisplayName = newName;
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
 }

--- a/src/XcaNet.Storage/Repositories/TemplateRepository.cs
+++ b/src/XcaNet.Storage/Repositories/TemplateRepository.cs
@@ -141,4 +141,12 @@ public sealed class TemplateRepository : ITemplateRepository
         await dbContext.SaveChangesAsync(cancellationToken);
         return true;
     }
+
+    public async Task UpdateDisplayNameAsync(string databasePath, Guid templateId, string newName, CancellationToken cancellationToken)
+    {
+        await using var dbContext = _dbContextFactory.CreateDbContext(databasePath);
+        var template = await dbContext.Templates.SingleAsync(x => x.Id == templateId, cancellationToken);
+        template.Name = newName;
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
 }

--- a/tests/XcaNet.Integration.Tests/CertificatesTabTests.cs
+++ b/tests/XcaNet.Integration.Tests/CertificatesTabTests.cs
@@ -335,4 +335,6 @@ file sealed class TestFileDialogService : IDesktopFileDialogService
         => Task.FromResult<IReadOnlyList<string>>([]);
     public Task<string?> PickSavePathAsync(string suggestedFileName, CancellationToken cancellationToken)
         => Task.FromResult<string?>(null);
+    public Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
+        => Task.FromResult<string?>(null);
 }

--- a/tests/XcaNet.Integration.Tests/CertificatesTabTests.cs
+++ b/tests/XcaNet.Integration.Tests/CertificatesTabTests.cs
@@ -207,7 +207,7 @@ public sealed class CertificatesTabTests
             new SignStoredCertificateSigningRequestRequest(csr.Value!.CertificateSigningRequestId, issuerCert.Value!.CertificateId, issuerKey.Value.PrivateKeyId, "Leaf", 90),
             CancellationToken.None);
 
-        var shell = new ShellViewModel(service, new TestFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new TestFileDialogService(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
         await ((AsyncCommand)shell.CertificatesPage.RefreshCommand!).ExecuteAsync();
         shell.CertificatesPage.SelectedItem = shell.CertificatesPage.Items.Single(x => x.CertificateId == leafCert.Value!.CertificateId);
         await Task.Delay(50);
@@ -231,7 +231,7 @@ public sealed class CertificatesTabTests
     {
         using var provider = BuildServiceProvider();
         var service = provider.GetRequiredService<IDatabaseSessionService>();
-        var shell = new ShellViewModel(service, new TestFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new TestFileDialogService(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
 
         Assert.False(shell.CertificatesPage.IsPlainView);
         shell.CertificatesPage.TogglePlainViewCommand!.Execute(null);
@@ -261,7 +261,7 @@ public sealed class CertificatesTabTests
             new SignStoredCertificateSigningRequestRequest(csr.Value!.CertificateSigningRequestId, caCert.Value!.CertificateId, caKey.Value.PrivateKeyId, "Leaf", 90),
             CancellationToken.None);
 
-        var shell = new ShellViewModel(service, new TestFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new TestFileDialogService(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
         await ((AsyncCommand)shell.CertificatesPage.RefreshCommand!).ExecuteAsync();
 
         // In tree view: exactly 1 root (the CA) with 1 child (leaf)
@@ -337,4 +337,13 @@ file sealed class TestFileDialogService : IDesktopFileDialogService
         => Task.FromResult<string?>(null);
     public Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
         => Task.FromResult<string?>(null);
+}
+
+file sealed class NullUserPreferences : IUserPreferencesService
+{
+    public string? DefaultDatabasePath => null;
+    public IReadOnlyList<string> RecentDatabases => [];
+    public void SetDefaultDatabase(string path) { }
+    public void AddRecentDatabase(string path) { }
+    public void Save() { }
 }

--- a/tests/XcaNet.Integration.Tests/FileWorkflowIntegrationTests.cs
+++ b/tests/XcaNet.Integration.Tests/FileWorkflowIntegrationTests.cs
@@ -179,5 +179,8 @@ public sealed class FileWorkflowIntegrationTests
 
         public Task<string?> PickSavePathAsync(string suggestedFileName, CancellationToken cancellationToken)
             => Task.FromResult<string?>(null);
+
+        public Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
+            => Task.FromResult<string?>(null);
     }
 }

--- a/tests/XcaNet.Integration.Tests/FileWorkflowIntegrationTests.cs
+++ b/tests/XcaNet.Integration.Tests/FileWorkflowIntegrationTests.cs
@@ -73,7 +73,7 @@ public sealed class FileWorkflowIntegrationTests
             new ExportStoredMaterialToFileRequest(CryptoImportKind.Certificate, certificate.Value!.CertificateId, CryptoDataFormat.Pem, outputPath, null, "issuer-ca"),
             CancellationToken.None);
 
-        var shell = new ShellViewModel(service, new FileDialogServiceStub(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new FileDialogServiceStub(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
         await shell.ImportFilesFromDropAsync([outputPath]);
 
         Assert.Equal("Available", shell.SettingsSecurityPage.ManagedBackendStatus);
@@ -182,5 +182,14 @@ public sealed class FileWorkflowIntegrationTests
 
         public Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
             => Task.FromResult<string?>(null);
+    }
+
+    private sealed class NullUserPreferences : IUserPreferencesService
+    {
+        public string? DefaultDatabasePath => null;
+        public IReadOnlyList<string> RecentDatabases => [];
+        public void SetDefaultDatabase(string path) { }
+        public void AddRecentDatabase(string path) { }
+        public void Save() { }
     }
 }

--- a/tests/XcaNet.Integration.Tests/RenameIntegrationTests.cs
+++ b/tests/XcaNet.Integration.Tests/RenameIntegrationTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using XcaNet.Application.DependencyInjection;
+using XcaNet.Application.Services;
+using XcaNet.Contracts.Browser;
+using XcaNet.Contracts.Crypto;
+using XcaNet.Contracts.Crypto.Workflow;
+using XcaNet.Contracts.Database;
+using XcaNet.Crypto.DotNet.DependencyInjection;
+
+namespace XcaNet.Integration.Tests;
+
+public sealed class RenameIntegrationTests
+{
+    [Fact]
+    public async Task RenameStoredItemAsync_ShouldRenamePrivateKey()
+    {
+        using var provider = BuildServiceProvider();
+        var service = provider.GetRequiredService<IDatabaseSessionService>();
+        var databasePath = GetDatabasePath();
+
+        await service.CreateDatabaseAsync(new CreateDatabaseRequest(databasePath, "correct horse battery staple", "Rename Test"), CancellationToken.None);
+        var key = await service.GenerateStoredKeyAsync(new GenerateStoredKeyRequest("Original Key", KeyAlgorithmKind.Rsa, 3072, null), CancellationToken.None);
+        Assert.True(key.IsSuccess, key.Message);
+
+        var result = await service.RenameStoredItemAsync(
+            new RenameStoredItemRequest(BrowserEntityType.PrivateKey, key.Value!.PrivateKeyId, "Renamed Key"),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Message);
+
+        var keys = await service.ListPrivateKeysAsync(CancellationToken.None);
+        Assert.Contains(keys.Value!, x => x.DisplayName == "Renamed Key");
+        Assert.DoesNotContain(keys.Value!, x => x.DisplayName == "Original Key");
+    }
+
+    [Fact]
+    public async Task RenameStoredItemAsync_ShouldRenameCertificate()
+    {
+        using var provider = BuildServiceProvider();
+        var service = provider.GetRequiredService<IDatabaseSessionService>();
+        var databasePath = GetDatabasePath();
+
+        await service.CreateDatabaseAsync(new CreateDatabaseRequest(databasePath, "correct horse battery staple", "Rename Cert"), CancellationToken.None);
+        var key = await service.GenerateStoredKeyAsync(new GenerateStoredKeyRequest("CA Key", KeyAlgorithmKind.Rsa, 3072, null), CancellationToken.None);
+        var cert = await service.CreateSelfSignedCaAsync(new CreateSelfSignedCaWorkflowRequest(key.Value!.PrivateKeyId, "Root CA", "CN=Root CA", 365), CancellationToken.None);
+
+        var result = await service.RenameStoredItemAsync(
+            new RenameStoredItemRequest(BrowserEntityType.Certificate, cert.Value!.CertificateId, "Renamed Root CA"),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Message);
+
+        var certs = await service.ListCertificatesAsync(new XcaNet.Contracts.Browser.CertificateFilterState(null, null, null, null, null, XcaNet.Contracts.Browser.CertificateValidityFilter.All, XcaNet.Contracts.Browser.CertificateAuthorityFilter.All, 30), CancellationToken.None);
+        Assert.Contains(certs.Value!, x => x.DisplayName == "Renamed Root CA");
+    }
+
+    [Fact]
+    public async Task RenameStoredItemAsync_ShouldRejectEmptyName()
+    {
+        using var provider = BuildServiceProvider();
+        var service = provider.GetRequiredService<IDatabaseSessionService>();
+        var databasePath = GetDatabasePath();
+
+        await service.CreateDatabaseAsync(new CreateDatabaseRequest(databasePath, "correct horse battery staple", "Rename Empty"), CancellationToken.None);
+        var key = await service.GenerateStoredKeyAsync(new GenerateStoredKeyRequest("Key", KeyAlgorithmKind.Rsa, 3072, null), CancellationToken.None);
+
+        var result = await service.RenameStoredItemAsync(
+            new RenameStoredItemRequest(BrowserEntityType.PrivateKey, key.Value!.PrivateKeyId, "   "),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(XcaNet.Contracts.Results.OperationErrorCode.ValidationFailed, result.ErrorCode);
+    }
+
+    private static ServiceProvider BuildServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddManagedCryptoServices();
+        services.AddApplication(new ConfigurationBuilder().Build());
+        return services.BuildServiceProvider();
+    }
+
+    private static string GetDatabasePath()
+        => System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"xcanet-rename-{Guid.NewGuid():N}.db");
+}

--- a/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
+++ b/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
@@ -38,7 +38,7 @@ public sealed class ShellWorkflowTests
             new SignStoredCertificateSigningRequestRequest(csr.Value!.CertificateSigningRequestId, issuerCertificate.Value!.CertificateId, issuerKey.Value.PrivateKeyId, "Leaf Certificate", 180),
             CancellationToken.None);
 
-        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
         await ((AsyncCommand)shell.CertificatesPage.RefreshCommand!).ExecuteAsync();
         shell.CertificatesPage.SelectedItem = shell.CertificatesPage.Items.Single(x => x.CertificateId == leafCertificate.Value!.CertificateId);
         await Task.Delay(50);
@@ -76,7 +76,7 @@ public sealed class ShellWorkflowTests
         await service.OpenDatabaseAsync(new OpenDatabaseRequest(databasePath), CancellationToken.None);
         await service.UnlockDatabaseAsync(new UnlockDatabaseRequest("correct horse battery staple"), CancellationToken.None);
 
-        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
         while (shell.IsBusy)
         {
             await Task.Delay(20);
@@ -159,7 +159,7 @@ public sealed class ShellWorkflowTests
     {
         using var provider = BuildServiceProvider();
         var service = provider.GetRequiredService<IDatabaseSessionService>();
-        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), NullLogger<ShellViewModel>.Instance);
+        var shell = new ShellViewModel(service, new TestDesktopFileDialogService(), new NullUserPreferences(), NullLogger<ShellViewModel>.Instance);
 
         Assert.Equal("Certificates", shell.CurrentPage.Title);
         Assert.Equal(5, shell.WorkspaceNavigationItems.Count);
@@ -203,4 +203,13 @@ file sealed class TestDesktopFileDialogService : IDesktopFileDialogService
 
     public Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
         => Task.FromResult<string?>(null);
+}
+
+file sealed class NullUserPreferences : IUserPreferencesService
+{
+    public string? DefaultDatabasePath => null;
+    public IReadOnlyList<string> RecentDatabases => [];
+    public void SetDefaultDatabase(string path) { }
+    public void AddRecentDatabase(string path) { }
+    public void Save() { }
 }

--- a/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
+++ b/tests/XcaNet.Integration.Tests/ShellWorkflowTests.cs
@@ -200,4 +200,7 @@ file sealed class TestDesktopFileDialogService : IDesktopFileDialogService
 
     public Task<string?> PickSavePathAsync(string suggestedFileName, CancellationToken cancellationToken)
         => Task.FromResult<string?>(null);
+
+    public Task<string?> GetClipboardTextAsync(CancellationToken cancellationToken)
+        => Task.FromResult<string?>(null);
 }


### PR DESCRIPTION
## Summary

- Adds `UpdateDisplayNameAsync` to all 5 storage repository interfaces and implementations
- New `RenameStoredItemRequest` contract + `RenameStoredItemAsync` service method dispatching by `BrowserEntityType`
- `ShellViewModel` exposes `OpenRenameDialogCommand` (enabled when unlocked + item selected), wired to `OpenRenameDialogCommand` on all 5 page VMs
- Rename dialog overlay in `MainWindow.axaml` pre-fills with current item name
- F2 `KeyBinding` on every `ListBox` and `TreeView` across all 5 tab views
- 3 integration tests: rename private key, rename certificate, reject empty name

## Test plan

- [x] All 55 integration tests pass
- [ ] Select a key → F2 → enter new name → confirm → list updates
- [ ] F2 with no selection → command disabled (button greyed)
- [ ] F2 → submit empty name → rejected
- [ ] Works on all 5 tabs (Keys, CSRs, Certs, CRLs, Templates)

Closes #73